### PR TITLE
Prepare version v0.0.1

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/klauspost/compress v1.17.9
 	github.com/open-telemetry/otel-arrow v0.31.0
 	github.com/parquet-go/parquet-go v0.23.0
-	github.com/splunk/stef/go/otel v0.0.0
+	github.com/splunk/stef/go/otel v0.0.1
 	github.com/splunk/stef/go/pdata v0.0.0
-	github.com/splunk/stef/go/pkg v0.0.0
+	github.com/splunk/stef/go/pkg v0.0.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.19.0
 	golang.org/x/text v0.18.0

--- a/go/grpc/go.mod
+++ b/go/grpc/go.mod
@@ -3,7 +3,7 @@ module github.com/splunk/stef/go/grpc
 go 1.23.2
 
 require (
-	github.com/splunk/stef/go/pkg v0.0.0
+	github.com/splunk/stef/go/pkg v0.0.1
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.68.0
 	google.golang.org/protobuf v1.35.2

--- a/go/otel/go.mod
+++ b/go/otel/go.mod
@@ -3,8 +3,8 @@ module github.com/splunk/stef/go/otel
 go 1.23.2
 
 require (
-	github.com/splunk/stef/go/grpc v0.0.0
-	github.com/splunk/stef/go/pkg v0.0.0
+	github.com/splunk/stef/go/grpc v0.0.1
+	github.com/splunk/stef/go/pkg v0.0.1
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.68.0
 )

--- a/go/pdata/go.mod
+++ b/go/pdata/go.mod
@@ -4,8 +4,8 @@ go 1.23.2
 
 require (
 	github.com/google/go-cmp v0.6.0
-	github.com/splunk/stef/go/otel v0.0.0
-	github.com/splunk/stef/go/pkg v0.0.0
+	github.com/splunk/stef/go/otel v0.0.1
+	github.com/splunk/stef/go/pkg v0.0.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.16.0
 	modernc.org/b/v2 v2.1.0

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -4,7 +4,7 @@ go 1.23.2
 
 require (
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/splunk/stef/go/grpc v0.0.0
+	github.com/splunk/stef/go/grpc v0.0.1
 	github.com/splunk/stef/go/pdata v0.0.0
 	go.opentelemetry.io/collector v0.103.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.103.0
@@ -25,8 +25,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.103.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.103.0
 	github.com/open-telemetry/otel-arrow v0.24.0
-	github.com/splunk/stef/go/otel v0.0.0
-	github.com/splunk/stef/go/pkg v0.0.0
+	github.com/splunk/stef/go/otel v0.0.1
+	github.com/splunk/stef/go/pkg v0.0.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.103.0
 	go.opentelemetry.io/collector/connector v0.103.0


### PR DESCRIPTION
I have run the command make prepver VERSION=v0.0.1 from https://github.com/splunk/stef/pull/14