### PR TITLE
Run only STEF benchmarks on github

### DIFF
--- a/benchmarks/benchmarks_test.go
+++ b/benchmarks/benchmarks_test.go
@@ -253,7 +253,7 @@ func BenchmarkReaderReadMany(b *testing.B) {
 }
 */
 
-func BenchmarkReaderRead(b *testing.B) {
+func BenchmarkSTEFReaderRead(b *testing.B) {
 	generator := &generators.File{
 		FilePath: "testdata/hipstershop.pb.zst",
 	}
@@ -297,7 +297,7 @@ func BenchmarkReaderRead(b *testing.B) {
 
 var multipartFiles = []string{"oteldemo-with-histogram.otlp", "astronomyshop.pb"}
 
-func BenchmarkSerializeMultipart(b *testing.B) {
+func BenchmarkSTEFSerializeMultipart(b *testing.B) {
 	for _, file := range multipartFiles {
 		parts, err := testutils.ReadMultipartOTLPFile("testdata/" + file + ".zst")
 		require.NoError(b, err)
@@ -337,7 +337,7 @@ func BenchmarkSerializeMultipart(b *testing.B) {
 	}
 }
 
-func BenchmarkDeserializeMultipart(b *testing.B) {
+func BenchmarkSTEFDeserializeMultipart(b *testing.B) {
 	for _, file := range multipartFiles {
 		parts, err := testutils.ReadMultipartOTLPFile("testdata/" + file + ".zst")
 		require.NoError(b, err)

--- a/benchmarks/makefile
+++ b/benchmarks/makefile
@@ -1,5 +1,8 @@
 GO=$(shell which go)
+
 BENCH_COUNT ?= 6
+CI_BENCHMARKS=STEF\|/STEF
+
 MASTER_BRANCH ?= main
 REF_NAME ?= $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
 SHELL := /bin/bash
@@ -34,7 +37,7 @@ bench-stat-cli:
 
 .PHONY: bench-run
 bench-run:
-	@set -o pipefail && $(GO) test -test.benchmem -bench=. -count=$(BENCH_COUNT) -run=^a  ./... | tee bench-$(REF_NAME).txt
+	@set -o pipefail && $(GO) test -test.benchmem -bench=$(CI_BENCHMARKS) -count=$(BENCH_COUNT) -run=^a  ./... | tee bench-$(REF_NAME).txt
 
 .PHONY: bench-stat-diff
 bench-stat-diff: bench-stat-cli

--- a/benchmarks/readwrite_test.go
+++ b/benchmarks/readwrite_test.go
@@ -77,7 +77,7 @@ func TestCopy(t *testing.T) {
 	}
 }
 
-func BenchmarkReadTEF(b *testing.B) {
+func BenchmarkReadSTEF(b *testing.B) {
 	tefBytes, err := os.ReadFile("testdata/hipstershop.tefz")
 	require.NoError(b, err)
 
@@ -135,7 +135,7 @@ func BenchmarkReadTEF(b *testing.B) {
 	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*recCount), "ns/point")
 }
 
-func BenchmarkReadTEFZ(b *testing.B) {
+func BenchmarkReadSTEFZ(b *testing.B) {
 	tefBytes, err := os.ReadFile("testdata/hipstershop.tefz")
 	require.NoError(b, err)
 
@@ -163,7 +163,7 @@ func BenchmarkReadTEFZ(b *testing.B) {
 	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*recCount), "ns/point")
 }
 
-func BenchmarkReadTEFZWriteTEF(b *testing.B) {
+func BenchmarkReadSTEFZWriteSTEF(b *testing.B) {
 	tefBytes, err := os.ReadFile("testdata/hipstershop.tefz")
 	require.NoError(b, err)
 


### PR DESCRIPTION
The benchmarks github action is needed to prevent regressions to STEF performance. It is sufficient to run only STEF benchmarks for this. This will significantly speedup the PR builds.