### PR TITLE
Add SendError to stefgrpc package

### DIFF
--- a/go/otel/grpc_test.go
+++ b/go/otel/grpc_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -133,6 +134,17 @@ func TestGrpcWriteRead(t *testing.T) {
 		t.Error("Timed out waiting for records")
 	}
 
+	// Close connection so that client's next sending fails.
 	conn.Close()
 	grpcServer.Stop()
+
+	// Write a record.
+	err = writer.Write()
+	require.NoError(t, err)
+
+	// Try to send the data.
+	err = writer.Flush()
+
+	// Make sure we see the expected error.
+	require.True(t, errors.Is(err, stefgrpc.SendError{}))
 }


### PR DESCRIPTION
The error is needed to be able to differentiate permanent (encoding) errors from transient (connection) errors in implementations that use STEF Writer over STEF gRPC Client.