### PR TITLE
Downgrade to Go 1.22

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -1,6 +1,8 @@
 module github.com/splunk/stef/benchmarks
 
-go 1.23.2
+go 1.22.7
+
+toolchain go1.23.2
 
 require (
 	github.com/klauspost/compress v1.17.9

--- a/go/grpc/go.mod
+++ b/go/grpc/go.mod
@@ -1,6 +1,8 @@
 module github.com/splunk/stef/go/grpc
 
-go 1.23.2
+go 1.22.7
+
+toolchain go1.23.2
 
 require (
 	github.com/splunk/stef/go/pkg v0.0.1

--- a/go/otel/go.mod
+++ b/go/otel/go.mod
@@ -1,6 +1,8 @@
 module github.com/splunk/stef/go/otel
 
-go 1.23.2
+go 1.22.7
+
+toolchain go1.23.2
 
 require (
 	github.com/splunk/stef/go/grpc v0.0.1

--- a/go/pdata/go.mod
+++ b/go/pdata/go.mod
@@ -1,6 +1,8 @@
 module github.com/splunk/stef/go/pdata
 
-go 1.23.2
+go 1.22.7
+
+toolchain go1.23.2
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/go/pkg/go.mod
+++ b/go/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/stef/go/pkg
 
-go 1.23.2
+go 1.22.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -1,6 +1,8 @@
 module github.com/splunk/stef/otelcol
 
-go 1.23.2
+go 1.22.7
+
+toolchain go1.23.2
 
 require (
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/stefgen/go.mod
+++ b/stefgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/splunk/stef/stefgen
 
-go 1.23.2
+go 1.22.7
 
 require github.com/splunk/stef/go/pkg v0.0.0
 

--- a/stefgen/go.sum
+++ b/stefgen/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
+github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This is to match Go version for Otelcol.