### PR TITLE
Publish some benchmark results as HTML page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # STEF (Sequential Tabular Encoding Format)
 
 STEF is a data format and network protocol optimized for small payload size
-and fast serialization. See some [benchmark results here](./benchmarks/results/benchmarks.html).
+and fast serialization. See some
+[benchmark results here](https://splunk.github.io/stef/benchmarks/results/benchmarks.html).
 
 ### Directories
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # STEF (Sequential Tabular Encoding Format)
 
-To run tests: `make`
+STEF is a data format and network protocol optimized for small payload size
+and fast serialization. See some [benchmark results here](./benchmarks/results/benchmarks.html).
 
 ### Directories
 

--- a/benchmarks/charts.go
+++ b/benchmarks/charts.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"fmt"
+	"html/template"
+	"math"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/go-echarts/go-echarts/v2/charts"
+	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/stretchr/testify/require"
+)
+
+type BarOutput struct {
+	t       testing.TB
+	title   string
+	file    *os.File
+	results map[string]float64
+}
+
+func (c *BarOutput) BeginChart(title string, t testing.TB) {
+	c.t = t
+	c.title = title
+	c.results = map[string]float64{}
+}
+
+func (c *BarOutput) EndChart(unit string, seriesName string, globalopts ...charts.GlobalOpts) {
+	var xAxis []string
+	for label := range c.results {
+		xAxis = append(xAxis, label)
+	}
+	slices.Sort(xAxis)
+
+	var items []opts.BarData
+	for _, label := range xAxis {
+		value := c.results[label]
+		items = append(items, opts.BarData{Value: value})
+	}
+
+	// create a new bar instance
+	bar := charts.NewBar()
+	// set some global options like Title/Legend/ToolTip or anything else
+	globalopts = append(
+		globalopts, charts.WithTitleOpts(
+			opts.Title{
+				Title: c.title,
+			},
+		),
+		charts.WithAnimation(false),
+		charts.WithYAxisOpts(
+			opts.YAxis{
+				Name: unit,
+			},
+		),
+	)
+
+	bar.SetGlobalOptions(globalopts...)
+
+	// Put data into instance
+
+	bar.SetXAxis(xAxis).AddSeries(seriesName, items)
+
+	chartSnippet := bar.RenderSnippet()
+
+	tmpl := "{{.Element}} {{.Script}}"
+	t := template.New("snippet")
+	t, err := t.Parse(tmpl)
+	if err != nil {
+		panic(err)
+	}
+
+	data := struct {
+		Element template.HTML
+		Script  template.HTML
+		Option  template.HTML
+	}{
+		Element: template.HTML(chartSnippet.Element),
+		Script:  template.HTML(chartSnippet.Script),
+		Option:  template.HTML(chartSnippet.Option),
+	}
+
+	err = t.Execute(c.file, data)
+	require.NoError(c.t, err)
+}
+
+func (c *BarOutput) Record(b *testing.B, encoding string, val float64) {
+	if b != nil {
+		b.ReportMetric(val, "ns/point")
+	}
+	c.results[encoding] = math.Round(val)
+}
+
+func (c *BarOutput) Begin() {
+	output, err := os.Create("results/benchmarks.html")
+	if err != nil {
+		panic(err)
+	}
+	c.file = output
+
+	_, err = c.file.WriteString(
+		`<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Awesome go-echarts</title>
+    <script src="https://go-echarts.github.io/go-echarts-assets/assets/echarts.min.js"></script>
+</head>
+
+<body>
+`,
+	)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (c *BarOutput) End() {
+	_, err := c.file.WriteString(`</body></html>`)
+	if err != nil {
+		panic(err)
+	}
+
+	err = c.file.Close()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (c *BarOutput) BeginSection(s string) {
+	_, err := c.file.WriteString(fmt.Sprintf("<div/><h2>%s</h2>\n", s))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/benchmarks/encodings/metric_encoding.go
+++ b/benchmarks/encodings/metric_encoding.go
@@ -6,6 +6,7 @@ import (
 
 type MetricEncoding interface {
 	Name() string
+	LongName() string
 	FromOTLP(batch pmetric.Metrics) (InMemoryData, error)
 	Encode(data InMemoryData) ([]byte, error)
 	Decode([]byte) (any, error)
@@ -17,6 +18,7 @@ type InMemoryData any
 type MetricMultipartEncoding interface {
 	Name() string
 	StartMultipart(compression string) (MetricMultipartStream, error)
+	LongName() string
 }
 
 type MetricMultipartStream interface {

--- a/benchmarks/encodings/otlp/otlp.go
+++ b/benchmarks/encodings/otlp/otlp.go
@@ -31,6 +31,9 @@ func (*OTLPEncoding) ToOTLP(data []byte) (pmetric.Metrics, error) {
 func (*OTLPEncoding) Name() string {
 	return "OTLP"
 }
+func (*OTLPEncoding) LongName() string {
+	return "Protobuf OTLP"
+}
 
 type otlpMultipart struct {
 	compression string

--- a/benchmarks/encodings/parquet/parquet.go
+++ b/benchmarks/encodings/parquet/parquet.go
@@ -153,10 +153,13 @@ func (d *Encoding) Decode(b []byte) (any, error) {
 	return nil, nil
 }
 
-func (*Encoding) ToOTLP(data []byte) (pmetric.Metrics, error) {
+func (d *Encoding) ToOTLP(data []byte) (pmetric.Metrics, error) {
 	return pmetric.NewMetrics(), nil
 }
 
-func (*Encoding) Name() string {
+func (d *Encoding) Name() string {
 	return "Parquet"
+}
+func (d *Encoding) LongName() string {
+	return d.Name()
 }

--- a/benchmarks/encodings/stef/stef.go
+++ b/benchmarks/encodings/stef/stef.go
@@ -92,6 +92,10 @@ func (e *STEFEncoding) Name() string {
 	return str
 }
 
+func (e *STEFEncoding) LongName() string {
+	return e.Name()
+}
+
 func (e *STEFEncoding) StartMultipart(compression string) (encodings.MetricMultipartStream, error) {
 	outputBuf := &pkg.MemChunkWriter{}
 

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -5,6 +5,7 @@ go 1.22.7
 toolchain go1.23.2
 
 require (
+	github.com/go-echarts/go-echarts/v2 v2.5.0
 	github.com/klauspost/compress v1.17.9
 	github.com/open-telemetry/otel-arrow v0.31.0
 	github.com/parquet-go/parquet-go v0.23.0

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -20,6 +20,8 @@ github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fp
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/go-echarts/go-echarts/v2 v2.5.0 h1:P/JGanoIrpOOC4K9sRFeKSIUTIpPQwGHQJ/ELWre19Y=
+github.com/go-echarts/go-echarts/v2 v2.5.0/go.mod h1:56YlvzhW/a+du15f3S2qUGNDfKnFOeJSThBIrVFHDtI=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/benchmarks/makefile
+++ b/benchmarks/makefile
@@ -46,3 +46,7 @@ bench-stat-diff: bench-stat-cli
 .PHONY: bench-stat
 bench-stat: bench-stat-cli
 	benchstat bench-$(REF_NAME).txt
+
+.PHONY: update-charts
+update-charts:
+	go test -run TestMetricsSize\|TestMetricsMultipart -bench alizeNative

--- a/benchmarks/results/benchmarks.html
+++ b/benchmarks/results/benchmarks.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Awesome go-echarts</title>
+    <script src="https://go-echarts.github.io/go-echarts-assets/assets/echarts.min.js"></script>
+</head>
+
+<body>
+<div/><h2>Size Benchmarks - One Large Batch</h2>
+<div class="container">
+    <div class="item" id="BOtVWbZemKyI" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_BOtVWbZemKyI = echarts.init(document.getElementById('BOtVWbZemKyI'), "white", { renderer: "canvas" });
+    let option_BOtVWbZemKyI = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":86401},{"value":116224},{"value":65119}]}],"title":{"text":"Dataset: oteldemo-with-histogram.otlp.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_BOtVWbZemKyI.setOption(option_BOtVWbZemKyI);
+</script>
+<div class="container">
+    <div class="item" id="bSwUVMCBQlBL" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_bSwUVMCBQlBL = echarts.init(document.getElementById('bSwUVMCBQlBL'), "white", { renderer: "canvas" });
+    let option_bSwUVMCBQlBL = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":1605365},{"value":6304039},{"value":1650236}]}],"title":{"text":"Dataset: astronomyshop.pb.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_bSwUVMCBQlBL.setOption(option_bSwUVMCBQlBL);
+</script>
+<div class="container">
+    <div class="item" id="aYrKKkTuooKE" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_aYrKKkTuooKE = echarts.init(document.getElementById('aYrKKkTuooKE'), "white", { renderer: "canvas" });
+    let option_aYrKKkTuooKE = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":206885},{"value":549012},{"value":93636}]}],"title":{"text":"Dataset: hipstershop.pb.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_aYrKKkTuooKE.setOption(option_aYrKKkTuooKE);
+</script>
+<div class="container">
+    <div class="item" id="WwykAlCitDQM" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_WwykAlCitDQM = echarts.init(document.getElementById('WwykAlCitDQM'), "white", { renderer: "canvas" });
+    let option_WwykAlCitDQM = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":130650},{"value":846035},{"value":83007}]}],"title":{"text":"Dataset: hostandcollectormetrics.pb.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_WwykAlCitDQM.setOption(option_WwykAlCitDQM);
+</script>
+<div/><h2>Size Benchmarks - Many Batches, Multipart</h2>
+<div class="container">
+    <div class="item" id="ePLotxZwiYbw" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_ePLotxZwiYbw = echarts.init(document.getElementById('ePLotxZwiYbw'), "white", { renderer: "canvas" });
+    let option_ePLotxZwiYbw = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","data":[{"value":2107272},{"value":225443}]}],"title":{"text":"Dataset: oteldemo-with-histogram.otlp"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_ePLotxZwiYbw.setOption(option_ePLotxZwiYbw);
+</script>
+<div class="container">
+    <div class="item" id="NSaLgYnalAIQ" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_NSaLgYnalAIQ = echarts.init(document.getElementById('NSaLgYnalAIQ'), "white", { renderer: "canvas" });
+    let option_NSaLgYnalAIQ = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","data":[{"value":22219873},{"value":1352775}]}],"title":{"text":"Dataset: hostandcollectormetrics.pb"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_NSaLgYnalAIQ.setOption(option_NSaLgYnalAIQ);
+</script>
+<div class="container">
+    <div class="item" id="jAqGQDceOtAu" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_jAqGQDceOtAu = echarts.init(document.getElementById('jAqGQDceOtAu'), "white", { renderer: "canvas" });
+    let option_jAqGQDceOtAu = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","data":[{"value":145844039},{"value":9916633}]}],"title":{"text":"Dataset: astronomyshop.pb"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_jAqGQDceOtAu.setOption(option_jAqGQDceOtAu);
+</script>
+<div class="container">
+    <div class="item" id="LRCBOjkwTYZj" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_LRCBOjkwTYZj = echarts.init(document.getElementById('LRCBOjkwTYZj'), "white", { renderer: "canvas" });
+    let option_LRCBOjkwTYZj = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","data":[{"value":249074},{"value":85130}]}],"title":{"text":"Dataset: oteldemo-with-histogram.otlp"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_LRCBOjkwTYZj.setOption(option_LRCBOjkwTYZj);
+</script>
+<div class="container">
+    <div class="item" id="DFoZmlGBpNTa" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_DFoZmlGBpNTa = echarts.init(document.getElementById('DFoZmlGBpNTa'), "white", { renderer: "canvas" });
+    let option_DFoZmlGBpNTa = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","data":[{"value":2750908},{"value":245978}]}],"title":{"text":"Dataset: hostandcollectormetrics.pb"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_DFoZmlGBpNTa.setOption(option_DFoZmlGBpNTa);
+</script>
+<div class="container">
+    <div class="item" id="qEHJbGWrSwhH" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_qEHJbGWrSwhH = echarts.init(document.getElementById('qEHJbGWrSwhH'), "white", { renderer: "canvas" });
+    let option_qEHJbGWrSwhH = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","data":[{"value":19855253},{"value":3375131}]}],"title":{"text":"Dataset: astronomyshop.pb"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Protobuf OTLP","STEF"]}],"yAxis":[{"name":"Bytes"}]}
+
+    goecharts_qEHJbGWrSwhH.setOption(option_qEHJbGWrSwhH);
+</script>
+<div/><h2>Speed Benchmarks</h2>
+<div class="container">
+    <div class="item" id="FZyAjCkVHcSk" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_FZyAjCkVHcSk = echarts.init(document.getElementById('FZyAjCkVHcSk'), "white", { renderer: "canvas" });
+    let option_FZyAjCkVHcSk = {"animation":false,"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","data":[{"value":1098},{"value":300},{"value":59}]}],"title":{"text":"Serialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF"]}],"yAxis":[{"name":"ns/point"}]}
+
+    goecharts_FZyAjCkVHcSk.setOption(option_FZyAjCkVHcSk);
+</script>
+<div class="container">
+    <div class="item" id="CgORAWyZzMHL" style="width:900px;height:500px;"></div>
+</div>
+
+    
+ <script type="text/javascript">
+    "use strict";
+    let goecharts_CgORAWyZzMHL = echarts.init(document.getElementById('CgORAWyZzMHL'), "white", { renderer: "canvas" });
+    let option_CgORAWyZzMHL = {"animation":false,"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to deserialize one data point","type":"bar","data":[{"value":2300},{"value":731},{"value":25}]}],"title":{"text":"Deserialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF"]}],"yAxis":[{"name":"ns/point"}]}
+
+    goecharts_CgORAWyZzMHL.setOption(option_CgORAWyZzMHL);
+</script>
+</body></html>


### PR DESCRIPTION
Running `make update-charts` in the benchmarks directory will now update results/benchmarks.html.

The output is visualized as bar charts.