### PR TITLE
Remove TimestampMultiplier from Header

### DIFF
--- a/benchmarks/cmd/stefbench/main.go
+++ b/benchmarks/cmd/stefbench/main.go
@@ -93,8 +93,7 @@ func writeBench(inputFilePath string) {
 	outputBuf := &pkg.MemChunkWriter{}
 	writer, err := oteltef.NewMetricsWriter(
 		outputBuf, pkg.WriterOptions{
-			Compression:         reader.Header().Compression,
-			TimestampMultiplier: reader.Header().TimestampMultiplier,
+			Compression: reader.Header().Compression,
 		},
 	)
 	if err != nil {

--- a/go/otel/oteltef/metricswriter.go
+++ b/go/otel/oteltef/metricswriter.go
@@ -79,8 +79,6 @@ func (f *MetricsWriter) writeFixedHeader() error {
 	flags := byte(f.opts.Compression) & pkg.HdrFlagsCompressionMethod
 
 	hdrTail = append(hdrTail, flags)
-
-	hdrTail = binary.AppendUvarint(hdrTail, f.opts.TimestampMultiplier)
 	hdrTailSize := uint64(len(hdrTail))
 
 	var hdrFull []byte

--- a/go/otel/oteltef/spanswriter.go
+++ b/go/otel/oteltef/spanswriter.go
@@ -79,8 +79,6 @@ func (f *SpansWriter) writeFixedHeader() error {
 	flags := byte(f.opts.Compression) & pkg.HdrFlagsCompressionMethod
 
 	hdrTail = append(hdrTail, flags)
-
-	hdrTail = binary.AppendUvarint(hdrTail, f.opts.TimestampMultiplier)
 	hdrTailSize := uint64(len(hdrTail))
 
 	var hdrFull []byte

--- a/go/pkg/basereader.go
+++ b/go/pkg/basereader.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 
 	"github.com/splunk/stef/go/pkg/schema"
@@ -78,11 +77,6 @@ func (r *BaseReader) ReadFixedHeader() error {
 		return ErrInvalidCompression
 	}
 
-	var n int
-	r.FixedHeader.TimestampMultiplier, n = binary.Uvarint(hdrContent[2:])
-	if n <= 0 {
-		return errors.New("invalid TimestampMultiplier in FixedHeader")
-	}
 	return nil
 }
 

--- a/go/pkg/header.go
+++ b/go/pkg/header.go
@@ -9,8 +9,7 @@ import (
 )
 
 type FixedHeader struct {
-	Compression         Compression
-	TimestampMultiplier uint64
+	Compression Compression
 }
 
 type VarHeader struct {

--- a/go/pkg/writeropts.go
+++ b/go/pkg/writeropts.go
@@ -10,15 +10,6 @@ type WriterOptions struct {
 	// IncludeDescriptor indicates that the schema descriptor must be written to the file.
 	IncludeDescriptor bool
 
-	// TimestampMultiplier is the multiplier to be used by readers to convert
-	// stored timestamps to nanosecond timestamps. For example a value of 1000
-	// means timestamps are stored in microsecond precision.
-	//
-	// The Writer will NOT perform any timestamp scaling operations. The timestamp
-	// values provided via WritePoint() calls will be written as is.
-	// TODO: remove from fixed header and allow adding custom fields like this.
-	TimestampMultiplier uint64
-
 	// Compression to use for frame content.
 	// CompressionNone disables the compression.
 	// CompressionZstd uses zstd compression for frame content.

--- a/stefgen/templates/writer.go.tmpl
+++ b/stefgen/templates/writer.go.tmpl
@@ -78,8 +78,6 @@ func (f *{{.StructName}}Writer) writeFixedHeader() error {
 	flags := byte(f.opts.Compression) & pkg.HdrFlagsCompressionMethod
 
 	hdrTail = append(hdrTail, flags)
-
-	hdrTail = binary.AppendUvarint(hdrTail, f.opts.TimestampMultiplier)
 	hdrTailSize := uint64(len(hdrTail))
 
 	var hdrFull []byte


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/12

We may want to later add it to the UserData var header, but it definitely does not belong to the fixed Header.