### PR TITLE
Correctly handle Multimap with more than 62 kv pairs

### DIFF
--- a/go/otel/oteltef/attributes.go
+++ b/go/otel/oteltef/attributes.go
@@ -228,7 +228,7 @@ func (e *AttributesEncoder) Encode(list *Attributes) (changed bool) {
 		return changed
 	}
 
-	if list.isSameKeys(&e.lastVal) {
+	if list.isSameKeys(&e.lastVal) && len(e.lastVal.elems) < 63 {
 		changed = e.encodeValuesOnly(list)
 	} else {
 		e.encodeFull(list)

--- a/go/otel/oteltef/envelopeattributes.go
+++ b/go/otel/oteltef/envelopeattributes.go
@@ -232,7 +232,7 @@ func (e *EnvelopeAttributesEncoder) Encode(list *EnvelopeAttributes) (changed bo
 		return changed
 	}
 
-	if list.isSameKeys(&e.lastVal) {
+	if list.isSameKeys(&e.lastVal) && len(e.lastVal.elems) < 63 {
 		changed = e.encodeValuesOnly(list)
 	} else {
 		e.encodeFull(list)

--- a/go/otel/oteltef/keyvaluelist.go
+++ b/go/otel/oteltef/keyvaluelist.go
@@ -227,7 +227,7 @@ func (e *KeyValueListEncoder) Encode(list *KeyValueList) (changed bool) {
 		return changed
 	}
 
-	if list.isSameKeys(&e.lastVal) {
+	if list.isSameKeys(&e.lastVal) && len(e.lastVal.elems) < 63 {
 		changed = e.encodeValuesOnly(list)
 	} else {
 		e.encodeFull(list)

--- a/stef-spec/specification.md
+++ b/stef-spec/specification.md
@@ -705,9 +705,6 @@ This encoding is used when the current instance of the MultiMap has exactly the 
 as the previous instance of the MultiMap. In that case the keys are not encoded at all 
 and only values that differ from the previous instance's corresponding value are encoded.
 
-The encoding can be used if the number of key-value pairs in the MultiMap is less than 
-or equal to 63.
-
 The encoder compares the values of this instance of the MultiMap with the values of 
 the previous instance, key-by-key. For all values at index i bit number i is set in a 
 value `ChangedKeys`. After all values are iterated `ChangedKeysShifted` is computed 
@@ -723,6 +720,11 @@ MultiMap {
 
 All values that are different in this instance are then written to the value child 
 column. Nothing is written to the key child column.
+
+Value-only encoding can be used if the number of key-value pairs in the MultiMap is 
+less than or equal to 62. If the MultiMap has more than 62 key-value pairs then
+[Full MultiMap Encoding](#full-multimap-encoding) is always used even if the MultiMap
+has the same keys as the previous instance.
 
 ### String Codec
 

--- a/stefgen/templates/multimap.go.tmpl
+++ b/stefgen/templates/multimap.go.tmpl
@@ -331,7 +331,7 @@ func (e *{{ .MultimapName }}Encoder) Encode(list *{{ .MultimapName }}) (changed 
 		return changed
 	}
 
-	if list.isSameKeys(&e.lastVal) {
+	if list.isSameKeys(&e.lastVal) && len(e.lastVal.elems) < 63 {
 		changed = e.encodeValuesOnly(list)
 	} else {
 		e.encodeFull(list)


### PR DESCRIPTION
We always use full encoding for Multimaps with more than 62 kv pairs.

Resolves https://github.com/splunk/stef/issues/6