### PR TITLE
Fix mock server to always send ACK

### DIFF
--- a/go/grpc/client.go
+++ b/go/grpc/client.go
@@ -113,6 +113,8 @@ func NewClient(settings ClientSettings) *Client {
 }
 
 func (c *Client) Connect(ctx context.Context) (pkg.ChunkWriter, pkg.WriterOptions, error) {
+	c.logger.Debugf(context.Background(), "Begin connecting (client=%p)", c)
+
 	opts := pkg.WriterOptions{
 		FrameRestartFlags: pkg.RestartDictionaries,
 	}
@@ -215,6 +217,8 @@ func (c *Client) Disconnect(ctx context.Context) error {
 func (c *Client) receive() {
 	defer close(c.waitCh)
 
+	c.logger.Debugf(context.Background(), "Begin receiving acks (client=%p)", c)
+
 	for {
 		resp, err := c.stream.Recv()
 		if err != nil {
@@ -222,7 +226,7 @@ func (c *Client) receive() {
 				c.callbacks.OnDisconnect(nil)
 				return
 			}
-			c.logger.Errorf(context.Background(), "Error receiving acks: %v", err)
+			c.logger.Errorf(context.Background(), "Error receiving acks: %v (client=%p)", err, c)
 			c.callbacks.OnDisconnect(err)
 			return
 		}


### PR DESCRIPTION
Mock server previously could forget to send ACK on the last record received if not enough time passed since the last ACK.

Refactored the code make sure ACK is always sent, at approximately 100ms intervals, so ACK is sent at most 100 ms since the record is received.

Mock server can be used for testing the STEF exporter in Otel Collector.