### PR TITLE
Implement dictionary reset on the Reader side

### DIFF
--- a/go/grpc/client.go
+++ b/go/grpc/client.go
@@ -115,9 +115,7 @@ func NewClient(settings ClientSettings) *Client {
 func (c *Client) Connect(ctx context.Context) (pkg.ChunkWriter, pkg.WriterOptions, error) {
 	c.logger.Debugf(context.Background(), "Begin connecting (client=%p)", c)
 
-	opts := pkg.WriterOptions{
-		FrameRestartFlags: pkg.RestartDictionaries,
-	}
+	opts := pkg.WriterOptions{}
 
 	ctx, cancelFunc := context.WithCancel(ctx)
 	c.cancelFunc = cancelFunc

--- a/go/otel/grpc_test.go
+++ b/go/otel/grpc_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -147,4 +149,127 @@ func TestGrpcWriteRead(t *testing.T) {
 
 	// Make sure we see the expected error.
 	require.True(t, errors.Is(err, stefgrpc.SendError{}))
+}
+
+func TestDictReset(t *testing.T) {
+	grpcServer, listener, serverPort := newGrpcServer()
+	defer grpcServer.Stop()
+
+	schema, err := oteltef.MetricsWireSchema()
+	require.NoError(t, err)
+
+	const nameLen = 1000
+
+	// This sequence is crafted to catch a bug when Reader fails to resets
+	// its dict in sync with Writer.
+	metricNames := []string{
+		strings.Repeat("a", nameLen), // elem 1 in dict
+		strings.Repeat("b", nameLen), // elem 2 in dict
+		strings.Repeat("c", nameLen), // elem 3 in dict, hit the dict limit, next record is a new frame
+		"d",                          // elem 1 in dict, This starts a new frame and resets dicts
+		strings.Repeat("c", nameLen), // elem 2 in dict, this adds a new element to dicts
+		"d",                          // elem 1 in dict, but if we have a bug in reader reset this will be elem 4
+	}
+
+	recordsReceivedAndVerified := make(chan struct{})
+	serverSettings := stefgrpc.ServerSettings{
+		MaxDictBytes: uint64(2*nameLen + 500), // Fit 2 elems, 3rd is over limit.
+		ServerSchema: &schema,
+		OnStream: func(source stefgrpc.GrpcReader, ackFunc func(sequenceId uint64) error) error {
+			reader, err := oteltef.NewMetricsReader(source)
+			require.NoError(t, err)
+
+			// Read and verify that received records match what was sent.
+			for i, metricName := range metricNames {
+				record, err := reader.Read()
+				require.NoError(t, err)
+				assert.EqualValues(t, metricName, record.Metric().Name(), i)
+			}
+
+			// Send acknowledgment to the client.
+			err = ackFunc(reader.RecordCount())
+			if err != nil {
+				log.Printf("Error sending ack record id to server: %v", err)
+			}
+
+			// Signal that verification is done.
+			close(recordsReceivedAndVerified)
+			return nil
+		},
+	}
+
+	server := stefgrpc.NewStreamServer(serverSettings)
+
+	// Start a server.
+	stef_proto.RegisterSTEFDestinationServer(grpcServer, server)
+	go func() {
+		grpcServer.Serve(listener)
+	}()
+
+	// Connect to the server.
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("localhost:%d", serverPort),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Open a stream to the server.
+	grpcClient := stef_proto.NewSTEFDestinationClient(conn)
+
+	// Last Id acked by the server.
+	var lastAckId atomic.Uint64
+
+	// Prepare client callbacks.
+	callbacks := stefgrpc.ClientCallbacks{
+		OnAck: func(ackId uint64) error {
+			lastAckId.Store(ackId)
+			return nil
+		},
+	}
+	require.NoError(t, err)
+
+	clientSettings := stefgrpc.ClientSettings{
+		GrpcClient:   grpcClient,
+		ClientSchema: &schema,
+		Callbacks:    callbacks,
+	}
+	client := stefgrpc.NewClient(clientSettings)
+
+	w, opts, err := client.Connect(context.Background())
+	require.NoError(t, err)
+
+	opts.Compression = pkg.CompressionZstd
+
+	// Create record writer.
+	writer, err := oteltef.NewMetricsWriter(w, opts)
+	require.NoError(t, err)
+
+	// Write the records.
+	for _, metricName := range metricNames {
+		writer.Record.Metric().SetName(metricName)
+		err = writer.Write()
+		require.NoError(t, err)
+	}
+
+	lastSentId := writer.RecordCount()
+
+	// Make sure data is sent.
+	err = writer.Flush()
+	require.NoError(t, err)
+
+	// Make sure all data is acknowledged by the server.
+	require.Eventually(
+		t, func() bool {
+			// Wait until the last piece of data tha was sent by the client is acked by the server.
+			return lastAckId.Load() == lastSentId
+		}, 5*time.Second, 10*time.Millisecond,
+	)
+
+	// Wait until all records are decoded by the server and verified.
+	select {
+	case <-recordsReceivedAndVerified:
+	case <-time.Tick(5 * time.Second):
+		t.Error("Timed out waiting for records")
+	}
 }

--- a/go/otel/oteltef/dicts.go
+++ b/go/otel/oteltef/dicts.go
@@ -159,3 +159,21 @@ func (d *ReaderState) Init(overrideSchema *schema.WireSchema) {
 	d.SpanEventName.Init()
 	d.SpanName.Init()
 }
+
+// ResetDicts resets all dictionaries to initial state. Used when a frame is
+// started with RestartDictionaries flag.
+func (d *ReaderState) ResetDicts() {
+	d.AnyValueString.Reset()
+	d.AttributeKey.Reset()
+	d.Metric.Reset()
+	d.MetricDescription.Reset()
+	d.MetricName.Reset()
+	d.MetricUnit.Reset()
+	d.Resource.Reset()
+	d.SchemaURL.Reset()
+	d.Scope.Reset()
+	d.ScopeName.Reset()
+	d.ScopeVersion.Reset()
+	d.SpanEventName.Reset()
+	d.SpanName.Reset()
+}

--- a/go/otel/oteltef/metric.go
+++ b/go/otel/oteltef/metric.go
@@ -924,3 +924,9 @@ func (d *MetricDecoderDict) Init() {
 	d.dict = d.dict[:0]
 	d.dict = append(d.dict, nil) // nil Metric is RefNum 0
 }
+
+// Reset the dictionary to initial state. Used when a frame is
+// started with RestartDictionaries flag.
+func (d *MetricDecoderDict) Reset() {
+	d.Init()
+}

--- a/go/otel/oteltef/metricsreader.go
+++ b/go/otel/oteltef/metricsreader.go
@@ -79,9 +79,17 @@ func (r *MetricsReader) RecordCount() uint64 {
 }
 
 func (r *MetricsReader) nextFrame() error {
-	if err := r.base.NextFrame(); err != nil {
+	frameFlags, err := r.base.NextFrame()
+	if err != nil {
 		return err
 	}
+
+	if frameFlags&pkg.RestartDictionaries != 0 {
+		// The frame that has just started indicates that the dictionaries
+		// must be restarted. Reset all dictionaries.
+		r.state.ResetDicts()
+	}
+
 	r.decoder.Continue()
 	return nil
 }

--- a/go/otel/oteltef/resource.go
+++ b/go/otel/oteltef/resource.go
@@ -553,3 +553,9 @@ func (d *ResourceDecoderDict) Init() {
 	d.dict = d.dict[:0]
 	d.dict = append(d.dict, nil) // nil Resource is RefNum 0
 }
+
+// Reset the dictionary to initial state. Used when a frame is
+// started with RestartDictionaries flag.
+func (d *ResourceDecoderDict) Reset() {
+	d.Init()
+}

--- a/go/otel/oteltef/scope.go
+++ b/go/otel/oteltef/scope.go
@@ -705,3 +705,9 @@ func (d *ScopeDecoderDict) Init() {
 	d.dict = d.dict[:0]
 	d.dict = append(d.dict, nil) // nil Scope is RefNum 0
 }
+
+// Reset the dictionary to initial state. Used when a frame is
+// started with RestartDictionaries flag.
+func (d *ScopeDecoderDict) Reset() {
+	d.Init()
+}

--- a/go/otel/oteltef/spansreader.go
+++ b/go/otel/oteltef/spansreader.go
@@ -79,9 +79,17 @@ func (r *SpansReader) RecordCount() uint64 {
 }
 
 func (r *SpansReader) nextFrame() error {
-	if err := r.base.NextFrame(); err != nil {
+	frameFlags, err := r.base.NextFrame()
+	if err != nil {
 		return err
 	}
+
+	if frameFlags&pkg.RestartDictionaries != 0 {
+		// The frame that has just started indicates that the dictionaries
+		// must be restarted. Reset all dictionaries.
+		r.state.ResetDicts()
+	}
+
 	r.decoder.Continue()
 	return nil
 }

--- a/go/pkg/basereader.go
+++ b/go/pkg/basereader.go
@@ -113,24 +113,20 @@ func (r *BaseReader) ReadVarHeader(ownSchema schema.WireSchema) error {
 	return nil
 }
 
-func (r *BaseReader) NextFrame() error {
-	frameFlag, err := r.FrameDecoder.Next()
-	_ = frameFlag
+func (r *BaseReader) NextFrame() (FrameFlags, error) {
+	frameFlags, err := r.FrameDecoder.Next()
 	if err != nil {
-		return err
+		return 0, err
 	}
-	//if frameFlag&pkg.RestartDictionaries != 0 {
-	//	r.restartDictionaries()
-	//}
 
 	r.FrameRecordCount, err = binary.ReadUvarint(&r.FrameDecoder)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if err := r.ReadBufs.ReadFrom(&r.FrameDecoder); err != nil {
-		return err
+		return 0, err
 	}
 
-	return nil
+	return frameFlags, nil
 }

--- a/go/pkg/encoders/string.go
+++ b/go/pkg/encoders/string.go
@@ -79,14 +79,17 @@ type StringDecoderDict struct {
 func (d *StringDecoderDict) Init() {
 }
 
+func (d *StringDecoderDict) Reset() {
+	d.dict = d.dict[:0]
+}
+
 var ErrInvalidRefNum = errors.New("invalid RefNum, out of dictionary range")
 
 func (d *StringDecoder) Continue() {
 	d.buf.Reset(d.column.Data())
 }
 
-func (d *StringDecoder) Reset() {
-}
+func (d *StringDecoder) Reset() {}
 
 func (d *StringDecoder) Decode(dst *string) error {
 	varint, err := d.buf.ReadVarint()

--- a/go/pkg/writeropts.go
+++ b/go/pkg/writeropts.go
@@ -29,11 +29,13 @@ type WriterOptions struct {
 
 	// When a frame is restarted these flags define additional behavior.
 	//
-	// RestartDictionaries - the dictionaries will be cleared. The frames will
+	// RestartDictionaries - the dictionaries will be cleared. All new frames will
 	//   start with new dictionaries. Can be used to limit the size of the
-	//   dictionaries that the recipients must keep in memory.
+	//   dictionaries that the recipients must keep in memory. Note that the
+	//   frames always restart dictionaries regardless of MaxTotalDictSize setting.
 	//
 	// RestartCompression - the compression stream is started anew.
+	//   All new frames will start with a new compressor state.
 	//   Can be used to make the frames within a file skipable. Each new
 	//   frame's compression streams starts with a new state of encoder.
 	//   If this flag is unspecified the state of the compression encoder
@@ -50,6 +52,8 @@ type WriterOptions struct {
 	// during encoding process. When this limit is reached the Writer will
 	// reset the dictionaries and will start a new Frame with RestartDictionaries
 	// frame flag set.
+	// Note that when the limit is reached the dictionaries will be reset regardless
+	// of the value in RestartDictionaries bit in FrameRestartFlags.
 	//
 	// The Writer's total byte size calculation is approximate.
 	// It is expected that the real memory usage by dictionaries may somewhat

--- a/stefgen/templates/dicts.go.tmpl
+++ b/stefgen/templates/dicts.go.tmpl
@@ -63,3 +63,11 @@ func (d* ReaderState) Init(overrideSchema *schema.WireSchema) {
  	d.{{.DictName}}.Init()
     {{end -}}
 }
+
+// ResetDicts resets all dictionaries to initial state. Used when a frame is
+// started with RestartDictionaries flag.
+func (d* ReaderState) ResetDicts() {
+    {{range .Dicts -}}
+    d.{{.DictName}}.Reset()
+    {{end -}}
+}

--- a/stefgen/templates/reader.go.tmpl
+++ b/stefgen/templates/reader.go.tmpl
@@ -78,9 +78,17 @@ func (r *{{.StructName}}Reader) RecordCount() uint64 {
 }
 
 func (r *{{.StructName}}Reader) nextFrame() error {
-	if err:=r.base.NextFrame(); err != nil {
+	frameFlags, err := r.base.NextFrame()
+	if err != nil {
 		return err
 	}
+
+	if frameFlags&pkg.RestartDictionaries != 0 {
+		// The frame that has just started indicates that the dictionaries
+		// must be restarted. Reset all dictionaries.
+		r.state.ResetDicts()
+	}
+
 	r.decoder.Continue()
 	return nil
 }

--- a/stefgen/templates/struct.go.tmpl
+++ b/stefgen/templates/struct.go.tmpl
@@ -580,4 +580,10 @@ func (d* {{ .StructName }}DecoderDict) Init() {
     d.dict = d.dict[:0]
     d.dict = append(d.dict, nil) // nil {{.StructName}} is RefNum 0
 }
+
+// Reset the dictionary to initial state. Used when a frame is
+// started with RestartDictionaries flag.
+func (d* {{ .StructName }}DecoderDict) Reset() {
+    d.Init()
+}
 {{end}}


### PR DESCRIPTION
We previously only had Writer setting the reset flag but Reader was ignoring it. Now the Reader also
correctly resets the dictionaries when it encounters the RestartDictionaries frame flag.