### PR TITLE
Auto-generate randomized Write/Read tests

### DIFF
--- a/go/otel/manual_test.go
+++ b/go/otel/manual_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"testing"
@@ -249,20 +249,20 @@ type attrGenerator struct {
 
 func (g *attrGenerator) randKey() string {
 	keys := []string{"", "abc", "def"}
-	return keys[g.r.Intn(len(keys))]
+	return keys[g.r.IntN(len(keys))]
 }
 
 func (g *attrGenerator) genAttr() map[string]any {
 	m := map[string]any{}
 
-	ln := g.r.Intn(2)
+	ln := g.r.IntN(2)
 	for i := 0; i < ln; i++ {
 		vals := []string{"", "foo", "bar"}
 		var val any
-		switch g.r.Intn(3) {
+		switch g.r.IntN(3) {
 		case 0:
 		case 1:
-			val = vals[g.r.Intn(len(vals))]
+			val = vals[g.r.IntN(len(vals))]
 		case 2:
 			val = g.genAttr()
 		}
@@ -276,7 +276,7 @@ func TestAnyValue(t *testing.T) {
 	w, err := oteltef.NewMetricsWriter(buf, pkg.WriterOptions{})
 	require.NoError(t, err)
 
-	g := attrGenerator{r: rand.New(rand.NewSource(0))}
+	g := attrGenerator{r: rand.New(rand.NewPCG(0, 0))}
 	var writeAttrs []map[string]any
 	for i := 0; i < 10000; i++ {
 		writeAttrs = append(writeAttrs, g.genAttr())

--- a/go/otel/oteltef/anyvalue.go
+++ b/go/otel/oteltef/anyvalue.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -318,6 +319,48 @@ func CmpAnyValue(left, right *AnyValue) int {
 	}
 
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *AnyValue) mutateRandom(random *rand.Rand) {
+	const fieldCount = 7
+	typeChanged := false
+	if random.IntN(10) == 0 {
+		s.SetType(AnyValueType(random.IntN(fieldCount + 1)))
+		typeChanged = true
+	}
+
+	switch s.typ {
+	case AnyValueTypeString:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetString(pkg.StringRandom(random))
+		}
+	case AnyValueTypeBool:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetBool(pkg.BoolRandom(random))
+		}
+	case AnyValueTypeInt64:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetInt64(pkg.Int64Random(random))
+		}
+	case AnyValueTypeFloat64:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetFloat64(pkg.Float64Random(random))
+		}
+	case AnyValueTypeArray:
+		if typeChanged || random.IntN(2) == 0 {
+			s.array.mutateRandom(random)
+		}
+	case AnyValueTypeKVList:
+		if typeChanged || random.IntN(2) == 0 {
+			s.kVList.mutateRandom(random)
+		}
+	case AnyValueTypeBytes:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetBytes(pkg.BytesRandom(random))
+		}
+	}
 }
 
 // AnyValueEncoder implements encoding of AnyValue

--- a/go/otel/oteltef/anyvaluearray.go
+++ b/go/otel/oteltef/anyvaluearray.go
@@ -2,6 +2,8 @@
 package oteltef
 
 import (
+	"math/rand/v2"
+
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
@@ -145,6 +147,24 @@ func CmpAnyValueArray(left, right *AnyValueArray) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *AnyValueArray) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		a.EnsureLen(a.Len() + 1)
+	}
+	if random.IntN(20) == 0 && a.Len() > 0 {
+		a.EnsureLen(a.Len() - 1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems)) == 0 {
+			a.elems[i].mutateRandom(random)
+		}
+	}
 }
 
 type AnyValueArrayEncoder struct {

--- a/go/otel/oteltef/attributes.go
+++ b/go/otel/oteltef/attributes.go
@@ -2,6 +2,7 @@
 package oteltef
 
 import (
+	"math/rand/v2"
 	"slices"
 	"strings"
 	"unsafe"
@@ -178,6 +179,27 @@ func CmpAttributes(left, right *Attributes) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (m *Attributes) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		m.EnsureLen(m.Len() + 1)
+	}
+	if random.IntN(20) == 0 && m.Len() > 0 {
+		m.EnsureLen(m.Len() - 1)
+	}
+
+	for i := range m.elems {
+		_ = i
+		if random.IntN(4*len(m.elems)) == 0 {
+			m.SetKey(i, pkg.StringRandom(random))
+		}
+		if random.IntN(4*len(m.elems)) == 0 {
+			m.elems[i].value.mutateRandom(random)
+		}
+	}
 }
 
 type AttributesEncoder struct {

--- a/go/otel/oteltef/envelope.go
+++ b/go/otel/oteltef/envelope.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -93,6 +94,15 @@ func (s *Envelope) markParentModified() {
 func (s *Envelope) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.attributes.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Envelope) mutateRandom(random *rand.Rand) {
+	const fieldCount = 1
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/envelopeattributes.go
+++ b/go/otel/oteltef/envelopeattributes.go
@@ -2,6 +2,7 @@
 package oteltef
 
 import (
+	"math/rand/v2"
 	"slices"
 	"strings"
 	"unsafe"
@@ -182,6 +183,27 @@ func CmpEnvelopeAttributes(left, right *EnvelopeAttributes) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (m *EnvelopeAttributes) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		m.EnsureLen(m.Len() + 1)
+	}
+	if random.IntN(20) == 0 && m.Len() > 0 {
+		m.EnsureLen(m.Len() - 1)
+	}
+
+	for i := range m.elems {
+		_ = i
+		if random.IntN(4*len(m.elems)) == 0 {
+			m.SetKey(i, pkg.StringRandom(random))
+		}
+		if random.IntN(4*len(m.elems)) == 0 {
+			m.SetValue(i, pkg.BytesRandom(random))
+		}
+	}
 }
 
 type EnvelopeAttributesEncoder struct {

--- a/go/otel/oteltef/event.go
+++ b/go/otel/oteltef/event.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -186,6 +187,24 @@ func (s *Event) markParentModified() {
 func (s *Event) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.attributes.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Event) mutateRandom(random *rand.Rand) {
+	const fieldCount = 4
+	if random.IntN(fieldCount) == 0 {
+		s.SetName(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetTimeUnixNano(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetDroppedAttributesCount(pkg.Uint64Random(random))
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/eventarray.go
+++ b/go/otel/oteltef/eventarray.go
@@ -2,6 +2,8 @@
 package oteltef
 
 import (
+	"math/rand/v2"
+
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
@@ -145,6 +147,24 @@ func CmpEventArray(left, right *EventArray) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *EventArray) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		a.EnsureLen(a.Len() + 1)
+	}
+	if random.IntN(20) == 0 && a.Len() > 0 {
+		a.EnsureLen(a.Len() - 1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems)) == 0 {
+			a.elems[i].mutateRandom(random)
+		}
+	}
 }
 
 type EventArrayEncoder struct {

--- a/go/otel/oteltef/exemplar.go
+++ b/go/otel/oteltef/exemplar.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -208,6 +209,27 @@ func (s *Exemplar) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.value.markUnmodified()
 	s.filteredAttributes.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Exemplar) mutateRandom(random *rand.Rand) {
+	const fieldCount = 5
+	if random.IntN(fieldCount) == 0 {
+		s.SetTimestamp(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.value.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetSpanID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetTraceID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.filteredAttributes.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/exemplararray.go
+++ b/go/otel/oteltef/exemplararray.go
@@ -2,6 +2,8 @@
 package oteltef
 
 import (
+	"math/rand/v2"
+
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
@@ -145,6 +147,24 @@ func CmpExemplarArray(left, right *ExemplarArray) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *ExemplarArray) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		a.EnsureLen(a.Len() + 1)
+	}
+	if random.IntN(20) == 0 && a.Len() > 0 {
+		a.EnsureLen(a.Len() - 1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems)) == 0 {
+			a.elems[i].mutateRandom(random)
+		}
+	}
 }
 
 type ExemplarArrayEncoder struct {

--- a/go/otel/oteltef/exemplarvalue.go
+++ b/go/otel/oteltef/exemplarvalue.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -185,6 +186,28 @@ func CmpExemplarValue(left, right *ExemplarValue) int {
 	}
 
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *ExemplarValue) mutateRandom(random *rand.Rand) {
+	const fieldCount = 2
+	typeChanged := false
+	if random.IntN(10) == 0 {
+		s.SetType(ExemplarValueType(random.IntN(fieldCount + 1)))
+		typeChanged = true
+	}
+
+	switch s.typ {
+	case ExemplarValueTypeInt64:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetInt64(pkg.Int64Random(random))
+		}
+	case ExemplarValueTypeFloat64:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetFloat64(pkg.Float64Random(random))
+		}
+	}
 }
 
 // ExemplarValueEncoder implements encoding of ExemplarValue

--- a/go/otel/oteltef/float64array.go
+++ b/go/otel/oteltef/float64array.go
@@ -2,6 +2,8 @@
 package oteltef
 
 import (
+	"math/rand/v2"
+
 	"slices"
 
 	"unsafe"
@@ -157,6 +159,28 @@ func CmpFloat64Array(left, right *Float64Array) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *Float64Array) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		a.EnsureLen(a.Len() + 1)
+	}
+	if random.IntN(20) == 0 && a.Len() > 0 {
+		a.EnsureLen(a.Len() - 1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems)) == 0 {
+			v := pkg.Float64Random(random)
+			if a.elems[i] != v {
+				a.elems[i] = v
+				a.markModified()
+			}
+		}
+	}
 }
 
 type Float64ArrayEncoder struct {

--- a/go/otel/oteltef/histogramvalue.go
+++ b/go/otel/oteltef/histogramvalue.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -285,6 +286,27 @@ func (s *HistogramValue) markParentModified() {
 func (s *HistogramValue) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.bucketCounts.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *HistogramValue) mutateRandom(random *rand.Rand) {
+	const fieldCount = 5
+	if random.IntN(fieldCount) == 0 {
+		s.SetCount(pkg.Int64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetSum(pkg.Float64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetMin(pkg.Float64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetMax(pkg.Float64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.bucketCounts.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/int64array.go
+++ b/go/otel/oteltef/int64array.go
@@ -2,6 +2,8 @@
 package oteltef
 
 import (
+	"math/rand/v2"
+
 	"slices"
 
 	"unsafe"
@@ -157,6 +159,28 @@ func CmpInt64Array(left, right *Int64Array) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *Int64Array) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		a.EnsureLen(a.Len() + 1)
+	}
+	if random.IntN(20) == 0 && a.Len() > 0 {
+		a.EnsureLen(a.Len() - 1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems)) == 0 {
+			v := pkg.Int64Random(random)
+			if a.elems[i] != v {
+				a.elems[i] = v
+				a.markModified()
+			}
+		}
+	}
 }
 
 type Int64ArrayEncoder struct {

--- a/go/otel/oteltef/keyvaluelist.go
+++ b/go/otel/oteltef/keyvaluelist.go
@@ -2,6 +2,7 @@
 package oteltef
 
 import (
+	"math/rand/v2"
 	"slices"
 	"strings"
 	"unsafe"
@@ -178,6 +179,27 @@ func CmpKeyValueList(left, right *KeyValueList) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (m *KeyValueList) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		m.EnsureLen(m.Len() + 1)
+	}
+	if random.IntN(20) == 0 && m.Len() > 0 {
+		m.EnsureLen(m.Len() - 1)
+	}
+
+	for i := range m.elems {
+		_ = i
+		if random.IntN(4*len(m.elems)) == 0 {
+			m.SetKey(i, pkg.StringRandom(random))
+		}
+		if random.IntN(4*len(m.elems)) == 0 {
+			m.elems[i].value.mutateRandom(random)
+		}
+	}
 }
 
 type KeyValueListEncoder struct {

--- a/go/otel/oteltef/link.go
+++ b/go/otel/oteltef/link.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -248,6 +249,30 @@ func (s *Link) markParentModified() {
 func (s *Link) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.attributes.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Link) mutateRandom(random *rand.Rand) {
+	const fieldCount = 6
+	if random.IntN(fieldCount) == 0 {
+		s.SetTraceID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetSpanID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetTraceState(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetFlags(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetDroppedAttributesCount(pkg.Uint64Random(random))
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/linkarray.go
+++ b/go/otel/oteltef/linkarray.go
@@ -2,6 +2,8 @@
 package oteltef
 
 import (
+	"math/rand/v2"
+
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
@@ -145,6 +147,24 @@ func CmpLinkArray(left, right *LinkArray) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *LinkArray) mutateRandom(random *rand.Rand) {
+	if random.IntN(20) == 0 {
+		a.EnsureLen(a.Len() + 1)
+	}
+	if random.IntN(20) == 0 && a.Len() > 0 {
+		a.EnsureLen(a.Len() - 1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems)) == 0 {
+			a.elems[i].mutateRandom(random)
+		}
+	}
 }
 
 type LinkArrayEncoder struct {

--- a/go/otel/oteltef/metric.go
+++ b/go/otel/oteltef/metric.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -303,6 +304,36 @@ func (s *Metric) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.metadata.markUnmodified()
 	s.histogramBounds.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Metric) mutateRandom(random *rand.Rand) {
+	const fieldCount = 8
+	if random.IntN(fieldCount) == 0 {
+		s.SetName(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetDescription(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetUnit(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetType(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.metadata.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.histogramBounds.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetAggregationTemporality(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetMonotonic(pkg.BoolRandom(random))
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/metrics.go
+++ b/go/otel/oteltef/metrics.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -206,6 +207,30 @@ func (s *Metrics) markUnmodified() {
 	s.scope.markUnmodified()
 	s.attributes.markUnmodified()
 	s.point.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Metrics) mutateRandom(random *rand.Rand) {
+	const fieldCount = 6
+	if random.IntN(fieldCount) == 0 {
+		s.envelope.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.metric.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.resource.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.scope.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.point.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/point.go
+++ b/go/otel/oteltef/point.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -177,6 +178,24 @@ func (s *Point) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.value.markUnmodified()
 	s.exemplars.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Point) mutateRandom(random *rand.Rand) {
+	const fieldCount = 4
+	if random.IntN(fieldCount) == 0 {
+		s.SetStartTimestamp(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetTimestamp(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.value.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.exemplars.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/pointvalue.go
+++ b/go/otel/oteltef/pointvalue.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -208,6 +209,32 @@ func CmpPointValue(left, right *PointValue) int {
 	}
 
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *PointValue) mutateRandom(random *rand.Rand) {
+	const fieldCount = 3
+	typeChanged := false
+	if random.IntN(10) == 0 {
+		s.SetType(PointValueType(random.IntN(fieldCount + 1)))
+		typeChanged = true
+	}
+
+	switch s.typ {
+	case PointValueTypeInt64:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetInt64(pkg.Int64Random(random))
+		}
+	case PointValueTypeFloat64:
+		if typeChanged || random.IntN(2) == 0 {
+			s.SetFloat64(pkg.Float64Random(random))
+		}
+	case PointValueTypeHistogram:
+		if typeChanged || random.IntN(2) == 0 {
+			s.histogram.mutateRandom(random)
+		}
+	}
 }
 
 // PointValueEncoder implements encoding of PointValue

--- a/go/otel/oteltef/resource.go
+++ b/go/otel/oteltef/resource.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -157,6 +158,21 @@ func (s *Resource) markParentModified() {
 func (s *Resource) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.attributes.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Resource) mutateRandom(random *rand.Rand) {
+	const fieldCount = 3
+	if random.IntN(fieldCount) == 0 {
+		s.SetSchemaURL(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetDroppedAttributesCount(pkg.Uint64Random(random))
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/scope.go
+++ b/go/otel/oteltef/scope.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -219,6 +220,27 @@ func (s *Scope) markParentModified() {
 func (s *Scope) markUnmodified() {
 	s.modifiedFields.markUnmodified()
 	s.attributes.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Scope) mutateRandom(random *rand.Rand) {
+	const fieldCount = 5
+	if random.IntN(fieldCount) == 0 {
+		s.SetName(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetVersion(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetSchemaURL(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetDroppedAttributesCount(pkg.Uint64Random(random))
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/span.go
+++ b/go/otel/oteltef/span.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -469,6 +470,54 @@ func (s *Span) markUnmodified() {
 	s.events.markUnmodified()
 	s.links.markUnmodified()
 	s.status.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Span) mutateRandom(random *rand.Rand) {
+	const fieldCount = 14
+	if random.IntN(fieldCount) == 0 {
+		s.SetTraceID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetSpanID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetTraceState(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetParentSpanID(pkg.BytesRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetFlags(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetName(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetKind(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetStartTimeUnixNano(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetEndTimeUnixNano(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.attributes.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetDroppedAttributesCount(pkg.Uint64Random(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.events.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.links.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.status.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/spans.go
+++ b/go/otel/oteltef/spans.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -161,6 +162,24 @@ func (s *Spans) markUnmodified() {
 	s.resource.markUnmodified()
 	s.scope.markUnmodified()
 	s.span.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *Spans) mutateRandom(random *rand.Rand) {
+	const fieldCount = 4
+	if random.IntN(fieldCount) == 0 {
+		s.envelope.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.resource.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.scope.mutateRandom(random)
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.span.mutateRandom(random)
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/spanstatus.go
+++ b/go/otel/oteltef/spanstatus.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"unsafe"
 
@@ -133,6 +134,18 @@ func (s *SpanStatus) markParentModified() {
 
 func (s *SpanStatus) markUnmodified() {
 	s.modifiedFields.markUnmodified()
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *SpanStatus) mutateRandom(random *rand.Rand) {
+	const fieldCount = 2
+	if random.IntN(fieldCount) == 0 {
+		s.SetMessage(pkg.StringRandom(random))
+	}
+	if random.IntN(fieldCount) == 0 {
+		s.SetCode(pkg.Uint64Random(random))
+	}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/go/otel/oteltef/spanswriter_test.go
+++ b/go/otel/oteltef/spanswriter_test.go
@@ -2,18 +2,92 @@
 package oteltef
 
 import (
+	"bytes"
+	"io"
+	"math/rand/v2"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/splunk/stef/go/pkg"
 )
 
-func TestSpansWriterWrite(t *testing.T) {
-	cw := &pkg.MemChunkWriter{}
-	stef, err := NewSpansWriter(cw, pkg.WriterOptions{MaxTotalDictSize: 100})
-	require.NoError(t, err)
+// genSpansRecords generates a number of records pseudo-randomly
+// using the supplied Rand generator. Generated records will be always
+// the same for the same input state of Rand generator.
+func genSpansRecords(random *rand.Rand) (records []Spans) {
+	const recCount = 1000
+	var record Spans
+	record.Init()
 
-	err = stef.Write()
-	require.NoError(t, err)
+	records = make([]Spans, recCount)
+	for i := 0; i < recCount; i++ {
+		record.mutateRandom(random)
+		records[i].Init()
+		records[i].CopyFrom(&record)
+	}
+
+	return records
+}
+
+func TestSpansWriteRead(t *testing.T) {
+	opts := []pkg.WriterOptions{
+		{},
+		{
+			Compression: pkg.CompressionZstd,
+		},
+		{
+			MaxUncompressedFrameByteSize: 500,
+		},
+		{
+			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
+			// MaxTotalDictSize: 500,
+		},
+		{
+			Compression:                  pkg.CompressionZstd,
+			MaxUncompressedFrameByteSize: 500,
+			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
+			// MaxTotalDictSize: 500,
+		},
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed1 := uint64(time.Now().UnixNano())
+	random := rand.New(rand.NewPCG(seed1, 0))
+
+	for _, opt := range opts {
+		t.Run(
+			"", func(t *testing.T) {
+				buf := &pkg.MemChunkWriter{}
+				writer, err := NewSpansWriter(buf, opt)
+				require.NoError(t, err, "seed %v", seed1)
+
+				// Generate records pseudo-randomly
+				records := genSpansRecords(random)
+				// Write the records
+				for i := 0; i < len(records); i++ {
+					writer.Record.CopyFrom(&records[i])
+					err = writer.Write()
+					require.NoError(t, err, "record %d seed %v", i, seed1)
+				}
+				err = writer.Flush()
+				require.NoError(t, err, "seed %v", seed1)
+
+				// Read the records and compare to written.
+				reader, err := NewSpansReader(bytes.NewBuffer(buf.Bytes()))
+				require.NoError(t, err, "seed %v", seed1)
+
+				for i := 0; i < len(records); i++ {
+					readRecord, err := reader.Read()
+					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NotNil(t, readRecord, "record %d seed %v", i, seed1)
+					require.True(t, readRecord.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+				}
+				_, err = reader.Read()
+				require.Error(t, io.EOF, seed1)
+			},
+		)
+	}
 }

--- a/go/pkg/types.go
+++ b/go/pkg/types.go
@@ -1,6 +1,10 @@
 package pkg
 
-import "strings"
+import (
+	"math/rand/v2"
+	"strconv"
+	"strings"
+)
 
 // Bytes is a sequence of immutable bytes.
 type Bytes string
@@ -71,4 +75,28 @@ func StringEqual(left, right string) bool {
 
 func BytesEqual(left, right Bytes) bool {
 	return left == right
+}
+
+func Uint64Random(random *rand.Rand) uint64 {
+	return random.Uint64()
+}
+
+func Int64Random(random *rand.Rand) int64 {
+	return random.Int64()
+}
+
+func BoolRandom(random *rand.Rand) bool {
+	return random.IntN(2) == 0
+}
+
+func Float64Random(random *rand.Rand) float64 {
+	return random.Float64()
+}
+
+func StringRandom(random *rand.Rand) string {
+	return strconv.Itoa(random.IntN(10))
+}
+
+func BytesRandom(random *rand.Rand) Bytes {
+	return Bytes(StringRandom(random))
 }

--- a/stefgen/generator/genschema.go
+++ b/stefgen/generator/genschema.go
@@ -205,6 +205,25 @@ func (r *genPrimitiveTypeRef) EqualFunc() string {
 	}
 }
 
+func (r *genPrimitiveTypeRef) RandomFunc() string {
+	switch r.Type {
+	case schema.PrimitiveTypeUint64:
+		return "pkg.Uint64Random"
+	case schema.PrimitiveTypeInt64:
+		return "pkg.Int64Random"
+	case schema.PrimitiveTypeFloat64:
+		return "pkg.Float64Random"
+	case schema.PrimitiveTypeBool:
+		return "pkg.BoolRandom"
+	case schema.PrimitiveTypeString:
+		return "pkg.StringRandom"
+	case schema.PrimitiveTypeBytes:
+		return "pkg.BytesRandom"
+	default:
+		panic(fmt.Sprintf("unknown type %v", r.Type))
+	}
+}
+
 func (r *genPrimitiveTypeRef) CompareFunc() string {
 	switch r.Type {
 	case schema.PrimitiveTypeUint64:

--- a/stefgen/templates/array.go.tmpl
+++ b/stefgen/templates/array.go.tmpl
@@ -1,6 +1,7 @@
 package {{ .PackageName }}
 
 import (
+	"math/rand/v2"
 	{{if not .ElemType.MustClone}}
 	"slices"
 	{{end}}
@@ -201,6 +202,32 @@ func Cmp{{.ArrayName}}(left, right *{{ .ArrayName }}) int {
 		}
 	}
 	return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (a *{{ .ArrayName }}) mutateRandom(random *rand.Rand) {
+	if random.IntN(20)==0 {
+		a.EnsureLen(a.Len()+1)
+	}
+	if random.IntN(20)==0 && a.Len()>0 {
+		a.EnsureLen(a.Len()-1)
+	}
+
+	for i := range a.elems {
+		_ = i
+		if random.IntN(2*len(a.elems))==0 {
+		{{- if not .ElemType.IsPrimitive }}
+			a.elems[i].mutateRandom(random)
+		{{- else}}
+			v := {{ .ElemType.RandomFunc }}(random)
+			if a.elems[i] != v {
+				a.elems[i] = v
+				a.markModified()
+			}
+		{{- end}}
+		}
+	}
 }
 
 type {{ .ArrayName }}Encoder struct {

--- a/stefgen/templates/multimap.go.tmpl
+++ b/stefgen/templates/multimap.go.tmpl
@@ -3,6 +3,7 @@ package {{ .PackageName }}
 
 import (
     "strings"
+    "math/rand/v2"
     "unsafe"
 	"slices"
 
@@ -265,6 +266,35 @@ func Cmp{{.MultimapName}}(left, right *{{.MultimapName}}) int {
         }
     }
     return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (m *{{ .MultimapName }}) mutateRandom(random *rand.Rand) {
+	if random.IntN(20)==0 {
+		m.EnsureLen(m.Len()+1)
+	}
+	if random.IntN(20)==0 && m.Len()>0 {
+		m.EnsureLen(m.Len()-1)
+	}
+
+	for i := range m.elems {
+		_ = i
+		if random.IntN(4*len(m.elems))==0 {
+		{{- if not .Key.Type.IsPrimitive }}
+			m.elems[i].key.mutateRandom(random)
+		{{- else }}
+			m.SetKey(i, {{ .Key.Type.RandomFunc }}(random))
+		{{- end}}
+		}
+		if random.IntN(4*len(m.elems))==0 {
+		{{- if not .Value.Type.IsPrimitive }}
+			m.elems[i].value.mutateRandom(random)
+		{{- else }}
+			m.SetValue(i, {{ .Value.Type.RandomFunc }}(random))
+		{{- end}}
+		}
+	}
 }
 
 type {{ .MultimapName }}Encoder struct {

--- a/stefgen/templates/oneof.go.tmpl
+++ b/stefgen/templates/oneof.go.tmpl
@@ -2,6 +2,7 @@ package {{ .PackageName }}
 
 import (
     "fmt"
+    "math/rand/v2"
     "strings"
 	"unsafe"
 
@@ -205,6 +206,30 @@ func Cmp{{.StructName}}(left, right *{{.StructName}}) int {
     }
 
     return 0
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *{{ .StructName }}) mutateRandom(random *rand.Rand) {
+    const fieldCount = {{len .Fields}}
+    typeChanged := false
+    if random.IntN(10)==0 {
+        s.SetType({{$.StructName }}Type(random.IntN(fieldCount+1)))
+        typeChanged = true
+    }
+
+    switch s.typ {
+    {{- range .Fields }}
+    case {{ $.StructName }}Type{{.Name}}:
+        if typeChanged || random.IntN(2)==0 {
+        {{- if not .Type.IsPrimitive }}
+            s.{{.name}}.mutateRandom(random)
+        {{- else }}
+            s.Set{{.Name}}({{ .Type.RandomFunc }}(random))
+        {{- end}}
+        }
+    {{- end }}
+    }
 }
 
 // {{ .StructName }}Encoder implements encoding of {{ .StructName }}

--- a/stefgen/templates/struct.go.tmpl
+++ b/stefgen/templates/struct.go.tmpl
@@ -1,7 +1,8 @@
 package {{ .PackageName }}
 
 import (
-"fmt"
+    "fmt"
+    "math/rand/v2"
     "strings"
 	"unsafe"
 
@@ -184,6 +185,21 @@ func (s* {{.StructName}}) markUnmodified() {
 	s.{{.name}}.markUnmodified()
 	{{- end}}
 	{{- end }}
+}
+
+// mutateRandom mutates fields in a random, deterministic manner using
+// random parameter as a deterministic generator.
+func (s *{{ .StructName }}) mutateRandom(random *rand.Rand) {
+    const fieldCount = {{len .Fields}}
+{{- range .Fields }}
+    if random.IntN(fieldCount)==0 {
+    {{- if not .Type.IsPrimitive }}
+        s.{{.name}}.mutateRandom(random)
+    {{- else }}
+        s.Set{{.Name}}({{ .Type.RandomFunc }}(random))
+    {{- end}}
+    }
+{{- end }}
 }
 
 // IsEqual performs deep comparison and returns true if struct is equal to val.

--- a/stefgen/templates/writer_test.go.tmpl
+++ b/stefgen/templates/writer_test.go.tmpl
@@ -1,18 +1,92 @@
 package {{ .PackageName }}
 
 import (
+	"bytes"
+	"io"
+	"math/rand/v2"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/splunk/stef/go/pkg"
 )
 
-func Test{{.StructName}}WriterWrite(t* testing.T) {
-	cw := &pkg.MemChunkWriter{}
-	stef, err := New{{.StructName}}Writer(cw, pkg.WriterOptions{MaxTotalDictSize: 100})
-	require.NoError(t, err)
+// gen{{.StructName}}Records generates a number of records pseudo-randomly
+// using the supplied Rand generator. Generated records will be always
+// the same for the same input state of Rand generator.
+func gen{{.StructName}}Records(random *rand.Rand) (records []{{.StructName}}) {
+	const recCount = 1000
+	var record {{.StructName}}
+	record.Init()
 
-	err = stef.Write()
-	require.NoError(t, err)
+	records = make([]{{.StructName}}, recCount)
+	for i := 0; i < recCount; i++ {
+		record.mutateRandom(random)
+		records[i].Init()
+		records[i].CopyFrom(&record)
+	}
+
+	return records
+}
+
+func Test{{.StructName}}WriteRead(t *testing.T) {
+	opts := []pkg.WriterOptions{
+		{},
+		{
+			Compression: pkg.CompressionZstd,
+		},
+		{
+			MaxUncompressedFrameByteSize: 500,
+		},
+		{
+			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
+			// MaxTotalDictSize: 500,
+		},
+		{
+			Compression:                  pkg.CompressionZstd,
+			MaxUncompressedFrameByteSize: 500,
+			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
+			// MaxTotalDictSize: 500,
+		},
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed1 := uint64(time.Now().UnixNano())
+	random := rand.New(rand.NewPCG(seed1, 0))
+
+	for _, opt := range opts {
+		t.Run(
+			"", func(t *testing.T) {
+				buf := &pkg.MemChunkWriter{}
+				writer, err := New{{.StructName}}Writer(buf, opt)
+				require.NoError(t, err, "seed %v", seed1)
+
+				// Generate records pseudo-randomly
+				records := gen{{.StructName}}Records(random)
+				// Write the records
+				for i := 0; i < len(records); i++ {
+					writer.Record.CopyFrom(&records[i])
+					err = writer.Write()
+					require.NoError(t, err, "record %d seed %v", i, seed1)
+				}
+				err = writer.Flush()
+				require.NoError(t, err, "seed %v", seed1)
+
+				// Read the records and compare to written.
+				reader, err := New{{.StructName}}Reader(bytes.NewBuffer(buf.Bytes()))
+				require.NoError(t, err, "seed %v", seed1)
+
+				for i := 0; i < len(records); i++ {
+					readRecord, err := reader.Read()
+					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NotNil(t, readRecord, "record %d seed %v", i, seed1)
+					require.True(t, readRecord.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+				}
+				_, err = reader.Read()
+				require.Error(t, io.EOF, seed1)
+			},
+		)
+	}
 }


### PR DESCRIPTION
This helps cover a wider variety of encoding/decoding paths. For example, it correctly hits an existing bug with dictionary resets. The expected failing cases are disabled until https://github.com/splunk/stef/pull/44 is merged.

The test is randomized with non-deterministic starting seed, but runs deterministically after the seed and prints the seed value on failures, allowing to reproduce the failing case locally.