### PR TITLE
Separate RestartDictionaries and RestartCodecs frame flags

### DIFF
--- a/go/otel/oteltef/anyvalue.go
+++ b/go/otel/oteltef/anyvalue.go
@@ -451,8 +451,6 @@ func (e *AnyValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 }
 
 func (e *AnyValueEncoder) Reset() {
-	// Since we are resetting the state of encoder make sure the next Encode()
-	// call forcedly writes all fields and does not attempt to skip.
 	e.prevType = 0
 	e.stringEncoder.Reset()
 	e.boolEncoder.Reset()

--- a/go/otel/oteltef/anyvaluearray.go
+++ b/go/otel/oteltef/anyvaluearray.go
@@ -249,7 +249,7 @@ func (d *AnyValueArrayDecoder) Continue() {
 }
 
 func (d *AnyValueArrayDecoder) Reset() {
-	d.decoder.Reset()
+	d.prevLen = 0
 }
 
 func (d *AnyValueArrayDecoder) Decode(dst *AnyValueArray) error {

--- a/go/otel/oteltef/dicts.go
+++ b/go/otel/oteltef/dicts.go
@@ -78,7 +78,7 @@ func (d *WriterState) Init(opts *pkg.WriterOptions) {
 
 }
 
-func (d *WriterState) Reset() {
+func (d *WriterState) ResetDicts() {
 	d.limiter.ResetDict()
 	d.AnyValueString.Reset()
 	d.AttributeKey.Reset()

--- a/go/otel/oteltef/eventarray.go
+++ b/go/otel/oteltef/eventarray.go
@@ -260,6 +260,7 @@ func (d *EventArrayDecoder) Continue() {
 }
 
 func (d *EventArrayDecoder) Reset() {
+	d.prevLen = 0
 	d.decoder.Reset()
 }
 

--- a/go/otel/oteltef/exemplararray.go
+++ b/go/otel/oteltef/exemplararray.go
@@ -260,6 +260,7 @@ func (d *ExemplarArrayDecoder) Continue() {
 }
 
 func (d *ExemplarArrayDecoder) Reset() {
+	d.prevLen = 0
 	d.decoder.Reset()
 }
 

--- a/go/otel/oteltef/exemplarvalue.go
+++ b/go/otel/oteltef/exemplarvalue.go
@@ -258,8 +258,6 @@ func (e *ExemplarValueEncoder) Init(state *WriterState, columns *pkg.WriteColumn
 }
 
 func (e *ExemplarValueEncoder) Reset() {
-	// Since we are resetting the state of encoder make sure the next Encode()
-	// call forcedly writes all fields and does not attempt to skip.
 	e.prevType = 0
 	e.int64Encoder.Reset()
 	e.float64Encoder.Reset()

--- a/go/otel/oteltef/float64array.go
+++ b/go/otel/oteltef/float64array.go
@@ -260,6 +260,7 @@ func (d *Float64ArrayDecoder) Continue() {
 }
 
 func (d *Float64ArrayDecoder) Reset() {
+	d.prevLen = 0
 	d.decoder.Reset()
 }
 

--- a/go/otel/oteltef/int64array.go
+++ b/go/otel/oteltef/int64array.go
@@ -260,6 +260,7 @@ func (d *Int64ArrayDecoder) Continue() {
 }
 
 func (d *Int64ArrayDecoder) Reset() {
+	d.prevLen = 0
 	d.decoder.Reset()
 }
 

--- a/go/otel/oteltef/linkarray.go
+++ b/go/otel/oteltef/linkarray.go
@@ -260,6 +260,7 @@ func (d *LinkArrayDecoder) Continue() {
 }
 
 func (d *LinkArrayDecoder) Reset() {
+	d.prevLen = 0
 	d.decoder.Reset()
 }
 

--- a/go/otel/oteltef/metricsreader.go
+++ b/go/otel/oteltef/metricsreader.go
@@ -90,6 +90,12 @@ func (r *MetricsReader) nextFrame() error {
 		r.state.ResetDicts()
 	}
 
+	if frameFlags&pkg.RestartCodecs != 0 {
+		// The frame that has just started indicates that the decoders
+		// must be restarted.
+		r.decoder.Reset()
+	}
+
 	r.decoder.Continue()
 	return nil
 }

--- a/go/otel/oteltef/metricswriter.go
+++ b/go/otel/oteltef/metricswriter.go
@@ -137,16 +137,25 @@ func (w *MetricsWriter) Write() error {
 	w.encoder.Encode(&w.Record)
 	w.frameRecordCount++
 
-	if w.state.limiter.DictLimitReached() {
-		if err := w.resetDicts(); err != nil {
-			return err
-		}
-		nextFrameFlags := w.opts.FrameRestartFlags | pkg.RestartDictionaries
-		if err := w.restartFrame(nextFrameFlags); err != nil {
-			return err
-		}
-	} else if w.state.limiter.FrameLimitReached() {
-		nextFrameFlags := w.opts.FrameRestartFlags
+	nextFrameFlags := w.opts.FrameRestartFlags
+	restartFrame := false
+	if w.state.limiter.DictLimitReached() || (nextFrameFlags&pkg.RestartDictionaries != 0) {
+		w.state.ResetDicts()
+		nextFrameFlags = w.opts.FrameRestartFlags | pkg.RestartDictionaries
+		restartFrame = true
+	}
+
+	if nextFrameFlags&pkg.RestartCodecs != 0 {
+		w.encoder.Reset()
+		nextFrameFlags = w.opts.FrameRestartFlags | pkg.RestartCodecs
+		restartFrame = true
+	}
+
+	if w.state.limiter.FrameLimitReached() {
+		restartFrame = true
+	}
+
+	if restartFrame {
 		if err := w.restartFrame(nextFrameFlags); err != nil {
 			return err
 		}
@@ -159,14 +168,6 @@ func (w *MetricsWriter) Write() error {
 
 func (w *MetricsWriter) RecordCount() uint64 {
 	return w.recordCount
-}
-
-func (w *MetricsWriter) resetDicts() error {
-	// Reset all state so that the content that follows is not dependent on
-	// preceding content.
-	w.state.Reset()
-	w.encoder.Reset()
-	return nil
 }
 
 func (w *MetricsWriter) restartFrame(nextFrameFlags pkg.FrameFlags) error {

--- a/go/otel/oteltef/metricswriter_test.go
+++ b/go/otel/oteltef/metricswriter_test.go
@@ -34,21 +34,25 @@ func genMetricsRecords(random *rand.Rand) (records []Metrics) {
 func TestMetricsWriteRead(t *testing.T) {
 	opts := []pkg.WriterOptions{
 		{},
-		{
-			Compression: pkg.CompressionZstd,
-		},
-		{
-			MaxUncompressedFrameByteSize: 500,
-		},
-		{
-			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
-			// MaxTotalDictSize: 500,
-		},
+		{Compression: pkg.CompressionZstd},
+		{MaxUncompressedFrameByteSize: 500},
+		{MaxTotalDictSize: 500},
 		{
 			Compression:                  pkg.CompressionZstd,
 			MaxUncompressedFrameByteSize: 500,
-			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
-			// MaxTotalDictSize: 500,
+			MaxTotalDictSize:             500,
+		},
+		{FrameRestartFlags: pkg.RestartDictionaries},
+		{FrameRestartFlags: pkg.RestartCodecs},
+		{FrameRestartFlags: pkg.RestartDictionaries | pkg.RestartCodecs},
+		{FrameRestartFlags: pkg.RestartCompression, Compression: pkg.CompressionZstd},
+		{
+			FrameRestartFlags: pkg.RestartDictionaries | pkg.RestartCodecs | pkg.RestartCompression,
+			Compression:       pkg.CompressionZstd,
+		},
+		{
+			FrameRestartFlags:            pkg.RestartCodecs,
+			MaxUncompressedFrameByteSize: 500,
 		},
 	}
 

--- a/go/otel/oteltef/pointvalue.go
+++ b/go/otel/oteltef/pointvalue.go
@@ -293,8 +293,6 @@ func (e *PointValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet
 }
 
 func (e *PointValueEncoder) Reset() {
-	// Since we are resetting the state of encoder make sure the next Encode()
-	// call forcedly writes all fields and does not attempt to skip.
 	e.prevType = 0
 	e.int64Encoder.Reset()
 	e.float64Encoder.Reset()

--- a/go/otel/oteltef/spansreader.go
+++ b/go/otel/oteltef/spansreader.go
@@ -90,6 +90,12 @@ func (r *SpansReader) nextFrame() error {
 		r.state.ResetDicts()
 	}
 
+	if frameFlags&pkg.RestartCodecs != 0 {
+		// The frame that has just started indicates that the decoders
+		// must be restarted.
+		r.decoder.Reset()
+	}
+
 	r.decoder.Continue()
 	return nil
 }

--- a/go/otel/oteltef/spanswriter_test.go
+++ b/go/otel/oteltef/spanswriter_test.go
@@ -34,21 +34,25 @@ func genSpansRecords(random *rand.Rand) (records []Spans) {
 func TestSpansWriteRead(t *testing.T) {
 	opts := []pkg.WriterOptions{
 		{},
-		{
-			Compression: pkg.CompressionZstd,
-		},
-		{
-			MaxUncompressedFrameByteSize: 500,
-		},
-		{
-			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
-			// MaxTotalDictSize: 500,
-		},
+		{Compression: pkg.CompressionZstd},
+		{MaxUncompressedFrameByteSize: 500},
+		{MaxTotalDictSize: 500},
 		{
 			Compression:                  pkg.CompressionZstd,
 			MaxUncompressedFrameByteSize: 500,
-			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
-			// MaxTotalDictSize: 500,
+			MaxTotalDictSize:             500,
+		},
+		{FrameRestartFlags: pkg.RestartDictionaries},
+		{FrameRestartFlags: pkg.RestartCodecs},
+		{FrameRestartFlags: pkg.RestartDictionaries | pkg.RestartCodecs},
+		{FrameRestartFlags: pkg.RestartCompression, Compression: pkg.CompressionZstd},
+		{
+			FrameRestartFlags: pkg.RestartDictionaries | pkg.RestartCodecs | pkg.RestartCompression,
+			Compression:       pkg.CompressionZstd,
+		},
+		{
+			FrameRestartFlags:            pkg.RestartCodecs,
+			MaxUncompressedFrameByteSize: 500,
 		},
 	}
 

--- a/go/pkg/frameflags.go
+++ b/go/pkg/frameflags.go
@@ -7,6 +7,8 @@ const (
 	RestartDictionaries FrameFlags = 1 << iota
 	// RestartCompression resets and restarts the compression stream at frame beginning.
 	RestartCompression
+	// RestartCodecs resets the state of all encoders/decoders at frame beginning.
+	RestartCodecs
 
-	FrameFlagsMask = RestartDictionaries | RestartCompression
+	FrameFlagsMask = RestartDictionaries | RestartCompression | RestartCodecs
 )

--- a/go/pkg/writeropts.go
+++ b/go/pkg/writeropts.go
@@ -42,6 +42,13 @@ type WriterOptions struct {
 	//   carries over through the frames, which makes impossible to skip
 	//   frames and start decompressing from the next frame.
 	//   This flag has effect only if Compression!=CompressionNone.
+	//
+	// RestartEncoders - the encoder's state will be cleared. All new frames will
+	//   start with initial state of encoders.
+	//
+	// A combination of RestartDictionaries|RestartCompression|RestartEncoders flags
+	// ensures that a frame is readable and decodable on its own, without the need
+	// to read any preceding frames.
 	FrameRestartFlags FrameFlags
 
 	// MaxTotalDictSize is the maximum total byte size of all dictionaries.

--- a/stef-spec/specification.md
+++ b/stef-spec/specification.md
@@ -432,7 +432,8 @@ Frame structure is used to represent either a VarHeader or a Data Frame.
 Frame {
     RestartDictionaries: 1
     RestartCompression: 1
-    Random: 6
+    RestartCodecs: 1
+    Random: 5
     UncompressedSize: U64
     /CompressedSize: U64/
     Content: ..
@@ -449,6 +450,9 @@ anew from this frame's Content. Reader's state of compression decoder MUST be
 reset when this bit is set. If this bit is unset the state of the compression encoder
 carries over through the Content field of frames. This bit has effect only if Flags
 field in the Header specifies a compression.
+
+RestartCodecs indicates that the state of encoders/decoders is cleared and started
+anew from this frame's Content.
 
 The UncompressedSize size field specifies the total size in bytes of the frame Content
 in uncompressed form. If no compression is used the UncompressedSize field is

--- a/stefgen/templates/array.go.tmpl
+++ b/stefgen/templates/array.go.tmpl
@@ -357,7 +357,10 @@ func (d *{{ .ArrayName }}Decoder) Continue() {
 }
 
 func (d *{{ .ArrayName }}Decoder) Reset() {
+	d.prevLen = 0
+	{{- if not .Recursive}}
 	d.decoder.Reset()
+	{{- end}}
 }
 
 func (d *{{ .ArrayName }}Decoder) Decode(dst *{{.ArrayName}}) error {

--- a/stefgen/templates/dicts.go.tmpl
+++ b/stefgen/templates/dicts.go.tmpl
@@ -34,7 +34,7 @@ func (d *WriterState) Init(opts *pkg.WriterOptions) {
     {{end}}
 }
 
-func (d *WriterState) Reset() {
+func (d *WriterState) ResetDicts() {
     d.limiter.ResetDict()
     {{range .Dicts -}}
     d.{{.DictName}}.Reset()

--- a/stefgen/templates/oneof.go.tmpl
+++ b/stefgen/templates/oneof.go.tmpl
@@ -312,9 +312,7 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
 }
 
 func (e *{{ .StructName }}Encoder) Reset() {
-	// Since we are resetting the state of encoder make sure the next Encode()
-	// call forcedly writes all fields and does not attempt to skip.
-	e.prevType = 0
+    e.prevType = 0
     {{- range .Fields}}
     e.{{.name}}Encoder.Reset()
     {{- end}}

--- a/stefgen/templates/reader.go.tmpl
+++ b/stefgen/templates/reader.go.tmpl
@@ -89,6 +89,12 @@ func (r *{{.StructName}}Reader) nextFrame() error {
 		r.state.ResetDicts()
 	}
 
+	if frameFlags&pkg.RestartCodecs != 0 {
+		// The frame that has just started indicates that the decoders
+		// must be restarted.
+		r.decoder.Reset()
+	}
+
 	r.decoder.Continue()
 	return nil
 }

--- a/stefgen/templates/writer.go.tmpl
+++ b/stefgen/templates/writer.go.tmpl
@@ -136,16 +136,25 @@ func (w *{{.StructName}}Writer) Write() error {
 	w.encoder.Encode(&w.Record)
 	w.frameRecordCount++
 
-	if w.state.limiter.DictLimitReached() {
-		if err := w.resetDicts(); err != nil {
-			return err
-		}
-		nextFrameFlags := w.opts.FrameRestartFlags | pkg.RestartDictionaries
-		if err := w.restartFrame(nextFrameFlags); err != nil {
-			return err
-		}
-	} else if w.state.limiter.FrameLimitReached() {
-		nextFrameFlags := w.opts.FrameRestartFlags
+	nextFrameFlags := w.opts.FrameRestartFlags
+	restartFrame := false
+	if w.state.limiter.DictLimitReached() || (nextFrameFlags & pkg.RestartDictionaries != 0) {
+		w.state.ResetDicts()
+		nextFrameFlags = w.opts.FrameRestartFlags | pkg.RestartDictionaries
+		restartFrame = true
+	}
+
+	if nextFrameFlags & pkg.RestartCodecs != 0 {
+		w.encoder.Reset()
+		nextFrameFlags = w.opts.FrameRestartFlags | pkg.RestartCodecs
+		restartFrame = true
+	}
+
+	if w.state.limiter.FrameLimitReached() {
+		restartFrame = true
+	}
+
+	if restartFrame {
 		if err := w.restartFrame(nextFrameFlags); err != nil {
 			return err
 		}
@@ -158,14 +167,6 @@ func (w *{{.StructName}}Writer) Write() error {
 
 func (w *{{.StructName}}Writer) RecordCount() uint64 {
 	return w.recordCount
-}
-
-func (w *{{.StructName}}Writer) resetDicts() error {
-	// Reset all state so that the content that follows is not dependent on
-	// preceding content.
-	w.state.Reset()
-	w.encoder.Reset()
-	return nil
 }
 
 func (w *{{.StructName}}Writer) restartFrame(nextFrameFlags pkg.FrameFlags) error {

--- a/stefgen/templates/writer_test.go.tmpl
+++ b/stefgen/templates/writer_test.go.tmpl
@@ -33,21 +33,25 @@ func gen{{.StructName}}Records(random *rand.Rand) (records []{{.StructName}}) {
 func Test{{.StructName}}WriteRead(t *testing.T) {
 	opts := []pkg.WriterOptions{
 		{},
-		{
-			Compression: pkg.CompressionZstd,
-		},
-		{
-			MaxUncompressedFrameByteSize: 500,
-		},
-		{
-			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
-			// MaxTotalDictSize: 500,
-		},
+		{ Compression: pkg.CompressionZstd },
+		{ MaxUncompressedFrameByteSize: 500 },
+		{ MaxTotalDictSize: 500 },
 		{
 			Compression:                  pkg.CompressionZstd,
 			MaxUncompressedFrameByteSize: 500,
-			// Disable due to bug with dicts. Enable after https://github.com/splunk/stef/pull/44
-			// MaxTotalDictSize: 500,
+			MaxTotalDictSize: 500,
+		},
+		{ FrameRestartFlags: pkg.RestartDictionaries },
+		{ FrameRestartFlags: pkg.RestartCodecs },
+		{ FrameRestartFlags: pkg.RestartDictionaries | pkg.RestartCodecs },
+		{ FrameRestartFlags: pkg.RestartCompression, Compression: pkg.CompressionZstd },
+		{
+			FrameRestartFlags: pkg.RestartDictionaries | pkg.RestartCodecs | pkg.RestartCompression,
+			Compression: pkg.CompressionZstd,
+		},
+		{
+			FrameRestartFlags: pkg.RestartCodecs,
+			MaxUncompressedFrameByteSize: 500,
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/47

Previously the flags were joint and incorrectly implemented. The writers previously always reset dictionaries and encoders at the same time, while readers only reset the dictionaries.

Now the flags are separate and each indicates the resetting of either dictionaries or codecs. The writers and readers correctly implement each flag.

Enabled previously disabled randomized write/read tests, which were failing because of incorrect implementation. Also added a few more randomized tests for other combinations of write options.

There is no performance impact for this change:
```
                                │     main     │                new                │
                                │    sec/op    │   sec/op     vs base              │
SerializeNative/STEF/none-10      3.952m ± 23%   4.030m ± 4%       ~ (p=0.485 n=6)
DeserializeNative/STEF/none-10    1.764m ±  1%   1.756m ± 1%       ~ (p=0.818 n=6)
SerializeFromPdata/STEF/none-10   90.15m ±  1%   91.12m ± 4%       ~ (p=0.132 n=6)
DeserializeToPdata/STEF/none-10   22.66m ± 17%   22.62m ± 2%       ~ (p=0.699 n=6)
geomean                           10.92m         10.99m       +0.60%

                                │     main     │                new                │
                                │  sec/point   │  sec/point   vs base              │
SerializeNative/STEF/none-10      59.11n ± 23%   60.27n ± 4%       ~ (p=0.485 n=6)
DeserializeNative/STEF/none-10    26.38n ±  1%   26.27n ± 1%       ~ (p=0.818 n=6)
SerializeFromPdata/STEF/none-10   1.349µ ±  1%   1.363µ ± 4%       ~ (p=0.104 n=6)
DeserializeToPdata/STEF/none-10   339.0n ± 17%   338.3n ± 2%       ~ (p=0.615 n=6)
geomean                           163.4n         164.4n       +0.59%

                                │     main     │                new                 │
                                │     B/op     │     B/op      vs base              │
SerializeNative/STEF/none-10      3.527Mi ± 0%   3.528Mi ± 0%       ~ (p=1.000 n=6)
DeserializeNative/STEF/none-10    836.2Ki ± 0%   836.2Ki ± 0%       ~ (p=0.900 n=6)
SerializeFromPdata/STEF/none-10   124.6Mi ± 0%   124.6Mi ± 0%       ~ (p=0.485 n=6)
DeserializeToPdata/STEF/none-10   29.81Mi ± 0%   29.81Mi ± 0%       ~ (p=0.563 n=6)
geomean                           10.17Mi        10.17Mi       +0.01%

                                │    main     │                 new                 │
                                │  allocs/op  │  allocs/op   vs base                │
SerializeNative/STEF/none-10      2.777k ± 0%   2.777k ± 0%       ~ (p=0.913 n=6)
DeserializeNative/STEF/none-10    1.230k ± 0%   1.230k ± 0%       ~ (p=1.000 n=6) ¹
SerializeFromPdata/STEF/none-10   256.3k ± 0%   256.3k ± 0%       ~ (p=0.818 n=6)
DeserializeToPdata/STEF/none-10   623.3k ± 0%   623.3k ± 0%       ~ (p=1.000 n=6) ¹
geomean                           27.18k        27.18k       +0.00%
```