### PR TITLE
Refactor Reader.Read API

### DIFF
--- a/benchmarks/benchmarks_test.go
+++ b/benchmarks/benchmarks_test.go
@@ -291,12 +291,9 @@ func BenchmarkSTEFReaderRead(b *testing.B) {
 		}
 
 		for {
-			readRecord, err := reader.Read()
+			err := reader.Read(pkg.ReadOptions{})
 			if err == io.EOF {
 				break
-			}
-			if readRecord == nil {
-				panic("nil record")
 			}
 			if err != nil {
 				log.Fatal(err)

--- a/benchmarks/cmd/stats/main.go
+++ b/benchmarks/cmd/stats/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/splunk/stef/go/otel/oteltef"
+	"github.com/splunk/stef/go/pkg"
 
 	"github.com/splunk/stef/benchmarks/cmd"
 )
@@ -141,13 +142,14 @@ func CollectRecordStats(reader *oteltef.MetricsReader, fileStats *MetricsStats) 
 	}
 
 	for {
-		record, err := reader.Read()
+		err := reader.Read(pkg.ReadOptions{})
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
 			return err
 		}
+		record := &reader.Record
 
 		fileStats.DatapointCount++
 		fileStats.UniqueMetricNames[string(record.Metric().Name())] = true

--- a/benchmarks/cmd/stefbench/main.go
+++ b/benchmarks/cmd/stefbench/main.go
@@ -61,8 +61,7 @@ func readBench(inputFilePath string) {
 	recordCount := 0
 	start := time.Now()
 	for {
-		record, err := reader.Read()
-		record = record
+		err := reader.Read(pkg.ReadOptions{})
 		if err != nil {
 			if err == io.EOF {
 				break
@@ -108,13 +107,14 @@ func writeBench(inputFilePath string) {
 	recordCount := 0
 	start := time.Now()
 	for {
-		record, err := reader.Read()
+		err = reader.Read(pkg.ReadOptions{})
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
 			log.Fatalf("Error reading from %s: %v", inputFilePath, err)
 		}
+		record := &reader.Record
 
 		if record.IsEnvelopeModified() {
 			writer.Record.Envelope().CopyFrom(record.Envelope())

--- a/benchmarks/correctness_test.go
+++ b/benchmarks/correctness_test.go
@@ -96,7 +96,6 @@ func TestTEFMultiPart(t *testing.T) {
 		"testdata/hostandcollector-otelmetrics.zst",
 	}
 
-	//stefEncoding := stef.STEFEncoding{}
 	tefEncoding := stef.STEFEncoding{}
 
 	for _, inputFile := range testInputOtlpFiles {
@@ -106,46 +105,27 @@ func TestTEFMultiPart(t *testing.T) {
 				parts, err := testutils.ReadMultipartOTLPFile(inputFile)
 				require.NoError(t, err)
 
-				//stefStream, err := stefEncoding.StartMultipart("")
-				//require.NoError(t, err)
-
 				tefStream, err := tefEncoding.StartMultipart("")
 				require.NoError(t, err)
 
 				for _, part := range parts {
-					//err = stefStream.AppendPart(part)
-					//require.NoError(t, err)
 					err = tefStream.AppendPart(part)
 					require.NoError(t, err)
 				}
-				//stefBytes, err := stefStream.FinishStream()
-				//require.NoError(t, err)
 
 				tefBytes, err := tefStream.FinishStream()
 				require.NoError(t, err)
-
-				//stefReader, err := metrics.NewReader(bytes.NewBuffer(stefBytes))
-				//require.NoError(t, err)
 
 				tefReader, err := oteltef.NewMetricsReader(bytes.NewBuffer(tefBytes))
 				require.NoError(t, err)
 
 				i := 0
 				for {
-					//stefRec, err := stefReader.Read()
-					//stefRec = stefRec
-					//if err == io.EOF {
-					//	break
-					//}
-					//require.NoError(t, err)
-
-					tefRec, err := tefReader.Read()
+					err := tefReader.Read(pkg.ReadOptions{})
 					if err == io.EOF {
 						break
 					}
 					require.NoError(t, err, i)
-					require.NotNil(t, tefRec, i)
-					//oteltef.EqualRecord(t, stefRec, tefRec)
 					i++
 				}
 			},

--- a/benchmarks/encodings/stef/stef.go
+++ b/benchmarks/encodings/stef/stef.go
@@ -54,12 +54,9 @@ func (d *STEFEncoding) Decode(b []byte) (any, error) {
 	}
 
 	for {
-		readRecord, err := r.Read()
+		err := r.Read(pkg.ReadOptions{})
 		if err == io.EOF {
 			break
-		}
-		if readRecord == nil {
-			panic("nil record")
 		}
 		if err != nil {
 			return nil, err

--- a/benchmarks/encodings/stef/stefs.go
+++ b/benchmarks/encodings/stef/stefs.go
@@ -57,12 +57,9 @@ func (d *STEFSEncoding) Decode(b []byte) (any, error) {
 	}
 
 	for {
-		readRecord, err := r.Read()
+		err := r.Read(pkg.ReadOptions{})
 		if err == io.EOF {
 			break
-		}
-		if readRecord == nil {
-			panic("nil record")
 		}
 		if err != nil {
 			return nil, err

--- a/benchmarks/encodings/stef/stefu.go
+++ b/benchmarks/encodings/stef/stefu.go
@@ -54,12 +54,9 @@ func (d *STEFUEncoding) Decode(b []byte) (any, error) {
 	}
 
 	for {
-		readRecord, err := r.Read()
+		err := r.Read(pkg.ReadOptions{})
 		if err == io.EOF {
 			break
-		}
-		if readRecord == nil {
-			panic("nil record")
 		}
 		if err != nil {
 			return nil, err

--- a/benchmarks/readwrite_test.go
+++ b/benchmarks/readwrite_test.go
@@ -40,7 +40,7 @@ func TestCopy(t *testing.T) {
 
 		recCount := 0
 		for {
-			readRec, err := tefReader.Read()
+			err := tefReader.Read(pkg.ReadOptions{})
 			if err == io.EOF {
 				break
 			}
@@ -50,7 +50,7 @@ func TestCopy(t *testing.T) {
 				_ = recCount
 			}
 
-			copyModified(&tefWriter.Record, readRec)
+			copyModified(&tefWriter.Record, &tefReader.Record)
 
 			err = tefWriter.Write()
 			require.NoError(t, err)
@@ -89,18 +89,15 @@ func BenchmarkReadSTEF(b *testing.B) {
 
 	recCount := 0
 	for {
-		readRec, err := tefSrc.Read()
+		err := tefSrc.Read(pkg.ReadOptions{})
 		if err == io.EOF {
 			break
-		}
-		if readRec == nil {
-			panic("nil record")
 		}
 		if err != nil {
 			panic(err)
 		}
 
-		copyModified(&tefWriter.Record, readRec)
+		copyModified(&tefWriter.Record, &tefSrc.Record)
 
 		err = tefWriter.Write()
 		if err != nil {
@@ -121,8 +118,7 @@ func BenchmarkReadSTEF(b *testing.B) {
 		}
 
 		for i := 0; i < recCount; i++ {
-			tefRec, err := reader.Read()
-			_ = tefRec
+			err := reader.Read(pkg.ReadOptions{})
 			if err == io.EOF {
 				break
 			}
@@ -148,8 +144,7 @@ func BenchmarkReadSTEFZ(b *testing.B) {
 
 		recCount = 0
 		for {
-			tefRec, err := reader.Read()
-			_ = tefRec
+			err := reader.Read(pkg.ReadOptions{})
 			if err == io.EOF {
 				break
 			}
@@ -182,24 +177,15 @@ func BenchmarkReadSTEFZWriteSTEF(b *testing.B) {
 
 		recCount = 0
 		for {
-			readRec, err := tefReader.Read()
+			err := tefReader.Read(pkg.ReadOptions{})
 			if err == io.EOF {
 				break
-			}
-			if err == io.EOF {
-				break
-			}
-			if err == io.EOF {
-				break
-			}
-			if readRec == nil {
-				panic("nil record")
 			}
 			if err != nil {
 				panic(err)
 			}
 
-			copyModified(&tefWriter.Record, readRec)
+			copyModified(&tefWriter.Record, &tefReader.Record)
 
 			err = tefWriter.Write()
 			if err != nil {

--- a/benchmarks/size_test.go
+++ b/benchmarks/size_test.go
@@ -327,12 +327,12 @@ func TestSTEFVeryShortFrames(t *testing.T) {
 		require.NoError(t, err)
 
 		for {
-			readRecord, err := tefReader.Read()
+			err := tefReader.Read(pkg.ReadOptions{})
 			if err == io.EOF {
 				break
 			}
 
-			tefWriter.Record.CopyFrom(readRecord)
+			tefWriter.Record.CopyFrom(&tefReader.Record)
 
 			err = tefWriter.Write()
 			if err != nil {

--- a/go/otel/grpc_test.go
+++ b/go/otel/grpc_test.go
@@ -49,9 +49,9 @@ func TestGrpcWriteRead(t *testing.T) {
 			require.NoError(t, err)
 
 			// Read and verify that received records match what was sent.
-			record, err := reader.Read()
+			err = reader.Read(pkg.ReadOptions{})
 			require.NoError(t, err)
-			require.EqualValues(t, "abc", record.Metric().Name())
+			require.EqualValues(t, "abc", reader.Record.Metric().Name())
 
 			// Send acknowledgment to the client.
 			err = ackFunc(reader.RecordCount())
@@ -181,9 +181,9 @@ func TestDictReset(t *testing.T) {
 
 			// Read and verify that received records match what was sent.
 			for i, metricName := range metricNames {
-				record, err := reader.Read()
+				err := reader.Read(pkg.ReadOptions{})
 				require.NoError(t, err)
-				assert.EqualValues(t, metricName, record.Metric().Name(), i)
+				assert.EqualValues(t, metricName, reader.Record.Metric().Name(), i)
 			}
 
 			// Send acknowledgment to the client.

--- a/go/otel/manual_test.go
+++ b/go/otel/manual_test.go
@@ -72,25 +72,21 @@ func TestWriterDictLimit(t *testing.T) {
 	reader, err := oteltef.NewMetricsReader(bytes.NewBuffer(buf.Bytes()))
 	require.NoError(t, err)
 
-	readRecord, err := reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, readRecord)
-	assert.EqualValues(t, "cpu.utilization", readRecord.Metric().Name())
+	assert.EqualValues(t, "cpu.utilization", reader.Record.Metric().Name())
 
-	readRecord, err = reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, readRecord)
-	assert.EqualValues(t, schemaUrl1, readRecord.Resource().SchemaURL())
+	assert.EqualValues(t, schemaUrl1, reader.Record.Resource().SchemaURL())
 
-	readRecord, err = reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, readRecord)
-	assert.EqualValues(t, schemaUrl2, readRecord.Resource().SchemaURL())
+	assert.EqualValues(t, schemaUrl2, reader.Record.Resource().SchemaURL())
 
-	readRecord, err = reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, readRecord)
-	assert.EqualValues(t, schemaUrl2, readRecord.Resource().SchemaURL())
+	assert.EqualValues(t, schemaUrl2, reader.Record.Resource().SchemaURL())
 }
 
 func TestWriterFrameLimit(t *testing.T) {
@@ -295,11 +291,10 @@ func TestAnyValue(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < len(writeAttrs); i++ {
-		readRecord, err := reader.Read()
+		err := reader.Read(pkg.ReadOptions{})
 		require.NoError(t, err, i)
-		require.NotNil(t, readRecord, i)
 
-		readAttr := tefToMap(readRecord.Attributes())
+		readAttr := tefToMap(reader.Record.Attributes())
 		require.EqualValues(t, writeAttrs[i], readAttr, i)
 	}
 }
@@ -323,10 +318,10 @@ func writeReadRecord(t *testing.T, withSchema *schema.WireSchema) *oteltef.Metri
 	reader, err := oteltef.NewMetricsReader(bytes.NewBuffer(buf.Bytes()))
 	require.NoError(t, err)
 
-	readRecord, err := reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
 
-	return readRecord
+	return &reader.Record
 }
 
 func TestWriteOverrideSchema(t *testing.T) {
@@ -412,15 +407,13 @@ func TestLargeMultimap(t *testing.T) {
 	reader, err := oteltef.NewMetricsReader(bytes.NewBuffer(buf.Bytes()))
 	require.NoError(t, err)
 
-	readRecord, err := reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, readRecord)
 
-	require.True(t, readRecord.Attributes().IsEqual(&attrs1Copy))
+	require.True(t, reader.Record.Attributes().IsEqual(&attrs1Copy))
 
-	readRecord, err = reader.Read()
+	err = reader.Read(pkg.ReadOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, readRecord)
 
-	require.True(t, readRecord.Attributes().IsEqual(&attrs2Copy))
+	require.True(t, reader.Record.Attributes().IsEqual(&attrs2Copy))
 }

--- a/go/otel/oteltef/metricsreader.go
+++ b/go/otel/oteltef/metricsreader.go
@@ -10,11 +10,13 @@ import (
 )
 
 type MetricsReader struct {
-	base pkg.BaseReader
+	// Record contains the record that was just read by the last Read() operation.
+	// Do not modify this field externally. The next Read() will overwrite the Record.
+	Record Metrics
 
+	base      pkg.BaseReader
 	decoder   MetricsDecoder
 	state     ReaderState
-	record    Metrics
 	recordPtr *Metrics
 }
 
@@ -22,8 +24,8 @@ func NewMetricsReader(source io.Reader) (*MetricsReader, error) {
 	bufferedSource := bufio.NewReaderSize(source, 64*1024)
 	reader := &MetricsReader{}
 
-	reader.record.Init()
-	reader.recordPtr = &reader.record
+	reader.Record.Init()
+	reader.recordPtr = &reader.Record
 
 	if err := reader.base.Init(bufferedSource); err != nil {
 		return nil, err
@@ -62,16 +64,27 @@ func (f *MetricsReader) UserData() map[string]string {
 	return f.base.VarHeader.UserData
 }
 
-func (r *MetricsReader) Read() (*Metrics, error) {
+// Read the next record. After Read() returns successfully the record
+// will be accessible in MetricsReader.Record field.
+//
+// If Read() encounters a decoding error one of the pkg.Err values will
+// be returned.
+// If underlying source io.Reader returns any error then Read() will
+// either return that error or a decoding error if source io.Reader
+// returned an error prematurely while more data was expected in STEF stream.
+//
+// For well-formed streams that don't encounter decoding errors Read() will
+// return io.EOF once end of the underlying source io.Reader is reached
+// (assuming io.Reader returns io.EOF itself).
+func (r *MetricsReader) Read(opts pkg.ReadOptions) error {
 	for r.base.FrameRecordCount == 0 {
 		if err := r.nextFrame(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	r.base.FrameRecordCount--
 	r.base.RecordCount++
-	err := r.decoder.Decode(r.recordPtr)
-	return r.recordPtr, err
+	return r.decoder.Decode(r.recordPtr)
 }
 
 func (r *MetricsReader) RecordCount() uint64 {

--- a/go/otel/oteltef/metricswriter_test.go
+++ b/go/otel/oteltef/metricswriter_test.go
@@ -84,12 +84,12 @@ func TestMetricsWriteRead(t *testing.T) {
 				require.NoError(t, err, "seed %v", seed1)
 
 				for i := 0; i < len(records); i++ {
-					readRecord, err := reader.Read()
+					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, readRecord, "record %d seed %v", i, seed1)
-					require.True(t, readRecord.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
 				}
-				_, err = reader.Read()
+				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
 			},
 		)

--- a/go/otel/oteltef/spanswriter_test.go
+++ b/go/otel/oteltef/spanswriter_test.go
@@ -84,12 +84,12 @@ func TestSpansWriteRead(t *testing.T) {
 				require.NoError(t, err, "seed %v", seed1)
 
 				for i := 0; i < len(records); i++ {
-					readRecord, err := reader.Read()
+					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, readRecord, "record %d seed %v", i, seed1)
-					require.True(t, readRecord.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
 				}
-				_, err = reader.Read()
+				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
 			},
 		)

--- a/go/pdata/metrics/pict_test.go
+++ b/go/pdata/metrics/pict_test.go
@@ -99,11 +99,10 @@ func FuzzReader(f *testing.F) {
 				return
 			}
 			for {
-				record, err := reader.Read()
+				err = reader.Read(pkg.ReadOptions{})
 				if err != nil {
 					break
 				}
-				require.NotNil(t, record)
 			}
 		},
 	)

--- a/go/pdata/metrics/stef2otlp.go
+++ b/go/pdata/metrics/stef2otlp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/splunk/stef/go/otel/oteltef"
 	"github.com/splunk/stef/go/pdata/internal/otlptools"
 	"github.com/splunk/stef/go/pdata/metrics/internal"
+	"github.com/splunk/stef/go/pkg"
 )
 
 type STEFToOTLPUnsorted struct {
@@ -23,13 +24,14 @@ func (c *STEFToOTLPUnsorted) Convert(reader *oteltef.MetricsReader) (pmetric.Met
 	metrics := pmetric.NewMetrics()
 	modified := true
 	for {
-		record, err := reader.Read()
+		err := reader.Read(pkg.ReadOptions{})
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
 			return metrics, err
 		}
+		record := &reader.Record
 
 		if modified || record.IsResourceModified() {
 			modified = true

--- a/go/pdata/metrics/stef2sortedtree.go
+++ b/go/pdata/metrics/stef2sortedtree.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/splunk/stef/go/otel/oteltef"
 	"github.com/splunk/stef/go/pdata/metrics/sortedbyresource"
+	"github.com/splunk/stef/go/pkg"
 )
 
 type STEFToSortedTree struct {
@@ -20,13 +21,14 @@ func (c *STEFToSortedTree) FromTef(reader *oteltef.MetricsReader) (*sortedbyreso
 
 	i := 0
 	for {
-		record, err := reader.Read()
+		err := reader.Read(pkg.ReadOptions{})
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err
 		}
+		record := &reader.Record
 
 		resource := sm.ByResource(record.Resource())
 		scope := resource.ByScope(record.Scope())

--- a/go/pkg/readopts.go
+++ b/go/pkg/readopts.go
@@ -1,0 +1,3 @@
+package pkg
+
+type ReadOptions struct{}

--- a/otelcol/cmd/stefmockserver/main.go
+++ b/otelcol/cmd/stefmockserver/main.go
@@ -13,6 +13,7 @@ import (
 	tefgrpc "github.com/splunk/stef/go/grpc"
 	"github.com/splunk/stef/go/grpc/stef_proto"
 	"github.com/splunk/stef/go/otel/oteltef"
+	"github.com/splunk/stef/go/pkg"
 )
 
 func newGrpcServer(port int) (*grpc.Server, net.Listener, int) {
@@ -77,7 +78,7 @@ func onStream(grpcReader tefgrpc.GrpcReader, ackFunc func(sequenceId uint64) err
 	}()
 
 	for {
-		_, err := reader.Read()
+		err = reader.Read(pkg.ReadOptions{})
 		if err != nil {
 			log.Printf("Cannot read from STEF/gRPC connection: %v.\n", err)
 			return err

--- a/stefgen/templates/reader.go.tmpl
+++ b/stefgen/templates/reader.go.tmpl
@@ -9,11 +9,13 @@ import (
 )
 
 type {{.StructName}}Reader struct {
-	base pkg.BaseReader
+	// Record contains the record that was just read by the last Read() operation.
+	// Do not modify this field externally. The next Read() will overwrite the Record.
+	Record {{.StructName}}
 
+	base pkg.BaseReader
 	decoder {{.StructName}}Decoder
 	state ReaderState
-	record {{.StructName}}
 	recordPtr *{{.StructName}}
 }
 
@@ -21,8 +23,8 @@ func New{{.StructName}}Reader(source io.Reader) (*{{.StructName}}Reader, error) 
 	bufferedSource := bufio.NewReaderSize(source, 64 * 1024)
 	reader := &{{.StructName}}Reader{}
 
-	reader.record.Init()
-	reader.recordPtr = &reader.record
+	reader.Record.Init()
+	reader.recordPtr = &reader.Record
 
 	if err := reader.base.Init(bufferedSource); err != nil {
 		return nil, err
@@ -61,16 +63,27 @@ func (f *{{.StructName}}Reader) UserData() map[string]string {
 	return f.base.VarHeader.UserData
 }
 
-func (r *{{.StructName}}Reader) Read() (*{{.StructName}}, error) {
+// Read the next record. After Read() returns successfully the record
+// will be accessible in {{.StructName}}Reader.Record field.
+//
+// If Read() encounters a decoding error one of the pkg.Err values will
+// be returned.
+// If underlying source io.Reader returns any error then Read() will
+// either return that error or a decoding error if source io.Reader
+// returned an error prematurely while more data was expected in STEF stream.
+//
+// For well-formed streams that don't encounter decoding errors Read() will
+// return io.EOF once end of the underlying source io.Reader is reached
+// (assuming io.Reader returns io.EOF itself).
+func (r *{{.StructName}}Reader) Read(opts pkg.ReadOptions) error {
 	for r.base.FrameRecordCount == 0 {
 		if err := r.nextFrame(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	r.base.FrameRecordCount--
 	r.base.RecordCount++
-	err := r.decoder.Decode(r.recordPtr)
-	return r.recordPtr, err
+	return r.decoder.Decode(r.recordPtr)
 }
 
 func (r *{{.StructName}}Reader) RecordCount() uint64 {

--- a/stefgen/templates/writer_test.go.tmpl
+++ b/stefgen/templates/writer_test.go.tmpl
@@ -83,12 +83,12 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 				require.NoError(t, err, "seed %v", seed1)
 
 				for i := 0; i < len(records); i++ {
-					readRecord, err := reader.Read()
+					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, readRecord, "record %d seed %v", i, seed1)
-					require.True(t, readRecord.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
 				}
-				_, err = reader.Read()
+				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
 			},
 		)


### PR DESCRIPTION
The API was inconsistent with Writer.Write() and was error-prone.

The new API is consistent with Writer.Write(). Both Writer.Write() and Reader.Read() now work with a Record that is an exporter field in the Writer/Reader struct. This makes it obvious that the Record is owned by the struct. Previously it was not clear if the pointer to the record returned by Reader.Read() was owned by the caller and could be modified and what it's lifetime was. Now it is more intuitively clear that the caller does not own the record and should not touch it and that the next Read() operation is going to overwrite it.

Also added pkg.ReadOptions to support reading options. The struct does not have any options yet, but options are coming in a future PR.

This is stacked on top of https://github.com/splunk/stef/pull/48