### PR TITLE
Add enum to IDL and Schema

### DIFF
--- a/go/pkg/idl/parser_test.go
+++ b/go/pkg/idl/parser_test.go
@@ -44,6 +44,22 @@ func TestParserErrors(t *testing.T) {
 			input: "package abc\nstruct MyStruct {\nField []struct",
 			err:   "test.stef:3:10: type specifier expected after []",
 		},
+		{
+			input: "package abc\nstruct MyStruct {\nField UnknownType }",
+			err:   "test.stef:3:20: unknown type: UnknownType",
+		},
+		{
+			input: "package abc oneof A {} struct A {}",
+			err:   "test.stef:1:31: duplicate top-level identifier: A",
+		},
+		{
+			input: "package abc enum {}",
+			err:   "test.stef:1:18: enum name expected",
+		},
+		{
+			input: "package abc enum Enum { Value = }",
+			err:   "test.stef:1:33: enum field value expected",
+		},
 	}
 
 	for _, test := range tests {
@@ -79,7 +95,11 @@ func TestParserOtelSTEF(t *testing.T) {
 	jsonBytes, err := os.ReadFile("testdata/oteltef.wire.json")
 	require.NoError(t, err)
 
-	var schem schema.Schema
+	schem := schema.Schema{
+		Structs:   map[string]*schema.Struct{},
+		Multimaps: map[string]*schema.Multimap{},
+		Enums:     map[string]*schema.Enum{},
+	}
 	err = json.Unmarshal(jsonBytes, &schem)
 	require.NoError(t, err)
 

--- a/go/pkg/idl/testdata/example.stef
+++ b/go/pkg/idl/testdata/example.stef
@@ -8,7 +8,16 @@ struct Book {
     Title string                     // The title of the book.
     PublishedOn Date                 // When was it published.
     Publisher string dict(Publisher) // Publishers name, encoded with a dict.
+    Category Category
     Authors []Person                 // Zero or more authors of the book.
+}
+
+enum Category {
+    Fiction = 1
+    NonFiction = 2
+    HexMystery = 0x3
+    OctalMystery = 0o4
+    BinaryMystery = 0b101
 }
 
 // BookEvent describes either a checkout or a checkin event.

--- a/go/pkg/schema/schema.go
+++ b/go/pkg/schema/schema.go
@@ -9,6 +9,7 @@ type Schema struct {
 	PackageName string               `json:"package,omitempty"`
 	Structs     map[string]*Struct   `json:"structs"`
 	Multimaps   map[string]*Multimap `json:"multimaps"`
+	Enums       map[string]*Enum
 }
 
 type Compatibility int
@@ -301,7 +302,8 @@ type FieldType struct {
 	Array     *FieldType          `json:"array,omitempty"`
 	Struct    string              `json:"struct,omitempty"`
 	MultiMap  string              `json:"multimap,omitempty"`
-	DictName  string              `json:"dict,omitempty"`
+	Enum      string
+	DictName  string `json:"dict,omitempty"`
 }
 
 type MultimapField struct {
@@ -312,4 +314,14 @@ type Multimap struct {
 	Name  string        `json:"name,omitempty"`
 	Key   MultimapField `json:"key"`
 	Value MultimapField `json:"value"`
+}
+
+type Enum struct {
+	Name   string
+	Fields []EnumField
+}
+
+type EnumField struct {
+	Name  string
+	Value uint64
 }


### PR DESCRIPTION
It is now possible to declare enums in the IDL. We will use the enums in a future PR to generate enum code.

Contributes to https://github.com/splunk/stef/issues/51