### PR TITLE
Correctly handle reading STEF with old schema missing a struct

### DIFF
--- a/go/otel/manual_test.go
+++ b/go/otel/manual_test.go
@@ -349,6 +349,11 @@ func TestWriteOverrideSchema(t *testing.T) {
 	// Remove "Float64" field (field #2) from "PointValue" oneof struct in the schema.
 	schem.StructFieldCount["PointValue"] = 1
 
+	// Remove HistogramValue and ExpHistogramValue structs from the schema.
+	// This verifies bug fix https://github.com/splunk/stef/issues/86
+	delete(schem.StructFieldCount, "HistogramValue")
+	delete(schem.StructFieldCount, "ExpHistogramValue")
+
 	// Write/read using reduced schema
 	readRecord = writeReadRecord(t, &schem)
 	assert.EqualValues(t, "abc", readRecord.Metric().Name())

--- a/go/otel/oteltef/anyvalue.go
+++ b/go/otel/oteltef/anyvalue.go
@@ -582,29 +582,50 @@ func (d *AnyValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	d.lastValPtr = &d.lastVal
 
 	var err error
+	if d.fieldCount <= 0 {
+		return nil // String and subsequent fields are skipped.
+	}
 	err = d.stringDecoder.Init(&state.AnyValueString, columns.AddSubColumn())
 	if err != nil {
 		return err
+	}
+	if d.fieldCount <= 1 {
+		return nil // Bool and subsequent fields are skipped.
 	}
 	err = d.boolDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err
 	}
+	if d.fieldCount <= 2 {
+		return nil // Int64 and subsequent fields are skipped.
+	}
 	err = d.int64Decoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err
+	}
+	if d.fieldCount <= 3 {
+		return nil // Float64 and subsequent fields are skipped.
 	}
 	err = d.float64Decoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err
 	}
+	if d.fieldCount <= 4 {
+		return nil // Array and subsequent fields are skipped.
+	}
 	err = d.arrayDecoder.Init(state, columns.AddSubColumn())
 	if err != nil {
 		return err
 	}
+	if d.fieldCount <= 5 {
+		return nil // KVList and subsequent fields are skipped.
+	}
 	err = d.kVListDecoder.Init(state, columns.AddSubColumn())
 	if err != nil {
 		return err
+	}
+	if d.fieldCount <= 6 {
+		return nil // Bytes and subsequent fields are skipped.
 	}
 	err = d.bytesDecoder.Init(nil, columns.AddSubColumn())
 	if err != nil {

--- a/go/otel/oteltef/exemplarvalue.go
+++ b/go/otel/oteltef/exemplarvalue.go
@@ -344,9 +344,15 @@ func (d *ExemplarValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnS
 	d.lastValPtr = &d.lastVal
 
 	var err error
+	if d.fieldCount <= 0 {
+		return nil // Int64 and subsequent fields are skipped.
+	}
 	err = d.int64Decoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err
+	}
+	if d.fieldCount <= 1 {
+		return nil // Float64 and subsequent fields are skipped.
 	}
 	err = d.float64Decoder.Init(columns.AddSubColumn())
 	if err != nil {

--- a/go/otel/oteltef/pointvalue.go
+++ b/go/otel/oteltef/pointvalue.go
@@ -432,17 +432,29 @@ func (d *PointValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	d.lastValPtr = &d.lastVal
 
 	var err error
+	if d.fieldCount <= 0 {
+		return nil // Int64 and subsequent fields are skipped.
+	}
 	err = d.int64Decoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err
+	}
+	if d.fieldCount <= 1 {
+		return nil // Float64 and subsequent fields are skipped.
 	}
 	err = d.float64Decoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err
 	}
+	if d.fieldCount <= 2 {
+		return nil // Histogram and subsequent fields are skipped.
+	}
 	err = d.histogramDecoder.Init(state, columns.AddSubColumn())
 	if err != nil {
 		return err
+	}
+	if d.fieldCount <= 3 {
+		return nil // ExpHistogram and subsequent fields are skipped.
 	}
 	err = d.expHistogramDecoder.Init(state, columns.AddSubColumn())
 	if err != nil {

--- a/stefgen/templates/go/oneof.go.tmpl
+++ b/stefgen/templates/go/oneof.go.tmpl
@@ -407,7 +407,10 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     d.lastValPtr = &d.lastVal
 
     var err error
-    {{- range .Fields }}
+    {{- range $i,$e := .Fields }}
+    if d.fieldCount <= {{$i}} {
+        return nil // {{.Name}} and subsequent fields are skipped.
+    }
     {{- if .Type.IsPrimitive}}
         {{- if .Type.DictName}}
         err = d.{{.name}}Decoder.Init(&state.{{.Type.DictName}}, columns.AddSubColumn())


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/86

When the new version of the schema adds a field to oneof and the type of the field is a new struct that is not present in the old version of the schema the initialization of the Reader fails since the decoder tries to find the new struct by the name in the old schema and fails. Instead of failing the Reader must skip the new struct and skip initializing its decoder.