### PR TITLE
Fix benchmark workflow in github action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,10 @@ on:
         description: 'New Ref'
         required: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
See failure at https://github.com/splunk/stef/actions/runs/16060267344/job/45324418382?pr=104

Resolves 'Resource not accessible by integration' error when posting benchmark results as PR comments. The workflow now explicitly grants pull-requests:write permission to allow commenting on PRs from forks.