### PR TITLE
Support self-recursive oneof type

### DIFF
--- a/examples/jsonl/internal/jsonstef/recordwriter_test.go
+++ b/examples/jsonl/internal/jsonstef/recordwriter_test.go
@@ -3,6 +3,7 @@ package jsonstef
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -64,6 +65,13 @@ func TestRecordWriteRead(t *testing.T) {
 	for _, opt := range opts {
 		t.Run(
 			"", func(t *testing.T) {
+				succeeded := false
+				defer func() {
+					if !succeeded {
+						fmt.Printf("Test failed with seed %v\n", seed1)
+					}
+				}()
+
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewRecordWriter(buf, opt)
 				require.NoError(t, err, "seed %v", seed1)
@@ -91,6 +99,8 @@ func TestRecordWriteRead(t *testing.T) {
 				}
 				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
+
+				succeeded = true
 			},
 		)
 	}

--- a/examples/profile/internal/profile/samplewriter_test.go
+++ b/examples/profile/internal/profile/samplewriter_test.go
@@ -3,6 +3,7 @@ package profile
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -64,6 +65,13 @@ func TestSampleWriteRead(t *testing.T) {
 	for _, opt := range opts {
 		t.Run(
 			"", func(t *testing.T) {
+				succeeded := false
+				defer func() {
+					if !succeeded {
+						fmt.Printf("Test failed with seed %v\n", seed1)
+					}
+				}()
+
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewSampleWriter(buf, opt)
 				require.NoError(t, err, "seed %v", seed1)
@@ -91,6 +99,8 @@ func TestSampleWriteRead(t *testing.T) {
 				}
 				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
+
+				succeeded = true
 			},
 		)
 	}

--- a/go/otel/oteltef/metricswriter_test.go
+++ b/go/otel/oteltef/metricswriter_test.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -64,6 +65,13 @@ func TestMetricsWriteRead(t *testing.T) {
 	for _, opt := range opts {
 		t.Run(
 			"", func(t *testing.T) {
+				succeeded := false
+				defer func() {
+					if !succeeded {
+						fmt.Printf("Test failed with seed %v\n", seed1)
+					}
+				}()
+
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewMetricsWriter(buf, opt)
 				require.NoError(t, err, "seed %v", seed1)
@@ -91,6 +99,8 @@ func TestMetricsWriteRead(t *testing.T) {
 				}
 				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
+
+				succeeded = true
 			},
 		)
 	}

--- a/go/otel/oteltef/spanswriter_test.go
+++ b/go/otel/oteltef/spanswriter_test.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -64,6 +65,13 @@ func TestSpansWriteRead(t *testing.T) {
 	for _, opt := range opts {
 		t.Run(
 			"", func(t *testing.T) {
+				succeeded := false
+				defer func() {
+					if !succeeded {
+						fmt.Printf("Test failed with seed %v\n", seed1)
+					}
+				}()
+
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewSpansWriter(buf, opt)
 				require.NoError(t, err, "seed %v", seed1)
@@ -91,6 +99,8 @@ func TestSpansWriteRead(t *testing.T) {
 				}
 				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
+
+				succeeded = true
 			},
 		)
 	}

--- a/java/src/main/java/com/example/oteltef/ExemplarValue.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarValue.java
@@ -15,9 +15,9 @@ public class ExemplarValue {
     double float64;
 
     // Pointer to parent's modifiedFields
-    private ModifiedFields parentModifiedFields;
+    ModifiedFields parentModifiedFields;
     // Bit to set in parent's modifiedFields when this oneof is modified.
-    private long parentModifiedBit;
+    long parentModifiedBit;
 
     ExemplarValue() {
         init(null, 0);
@@ -63,6 +63,8 @@ public class ExemplarValue {
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            switch (typ) {
+            }
             this.markParentModified();
         }
     }
@@ -127,8 +129,10 @@ public class ExemplarValue {
         case TypeFloat64:
             setFloat64(src.getFloat64());
             break;
+        case TypeNone:
+            setType(Type.TypeNone);
+            break;
         }
-        setType(src.typ);
     }
 
     private void markParentModified() {
@@ -177,11 +181,13 @@ public class ExemplarValue {
                 this.markParentModified();
                 modified = true;
             }
+            break;
         case TypeFloat64:
             if (!Types.Float64Equal(this.float64, v.float64)) {
                 this.markParentModified();
                 modified = true;
             }
+            break;
         }
         return modified;
     }
@@ -279,4 +285,3 @@ public class ExemplarValue {
         );
     }
 }
-

--- a/java/src/main/java/com/example/oteltef/ExemplarValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarValueDecoder.java
@@ -17,9 +17,12 @@ class ExemplarValueDecoder {
     private int fieldCount;
     private ExemplarValue.Type prevType;
 
+    // Field decoders.
     
-    private Int64Decoder int64Decoder = new Int64Decoder();
-    private Float64Decoder float64Decoder = new Float64Decoder();
+    private Int64Decoder int64Decoder;
+    private boolean isInt64Recursive = false; // Indicates Int64 field's type is recursive.
+    private Float64Decoder float64Decoder;
+    private boolean isFloat64Recursive = false; // Indicates Float64 field's type is recursive.
     
 
     // Init is called once in the lifetime of the stream.
@@ -46,10 +49,12 @@ class ExemplarValueDecoder {
             if (this.fieldCount <= 0) {
                 return; // Int64 and subsequent fields are skipped.
             }
+            int64Decoder = new Int64Decoder();
             this.int64Decoder.init(columns.addSubColumn());
             if (this.fieldCount <= 1) {
                 return; // Float64 and subsequent fields are skipped.
             }
+            float64Decoder = new Float64Decoder();
             this.float64Decoder.init(columns.addSubColumn());
         } finally {
             state.ExemplarValueDecoder = null;
@@ -67,15 +72,16 @@ class ExemplarValueDecoder {
         if (this.fieldCount <= 0) {
             return; // Int64 and subsequent fields are skipped.
         }
-        this.int64Decoder.continueDecoding();
+        int64Decoder.continueDecoding();
         if (this.fieldCount <= 1) {
             return; // Float64 and subsequent fields are skipped.
         }
-        this.float64Decoder.continueDecoding();
+        float64Decoder.continueDecoding();
     }
 
     public void reset() {
         prevType = ExemplarValue.Type.TypeNone;
+        
         int64Decoder.reset();
         float64Decoder.reset();
     }

--- a/java/src/main/java/com/example/oteltef/PointValue.java
+++ b/java/src/main/java/com/example/oteltef/PointValue.java
@@ -17,9 +17,9 @@ public class PointValue {
     ExpHistogramValue expHistogram;
 
     // Pointer to parent's modifiedFields
-    private ModifiedFields parentModifiedFields;
+    ModifiedFields parentModifiedFields;
     // Bit to set in parent's modifiedFields when this oneof is modified.
-    private long parentModifiedBit;
+    long parentModifiedBit;
 
     PointValue() {
         init(null, 0);
@@ -36,8 +36,6 @@ public class PointValue {
         
         
         
-        histogram = new HistogramValue(parentModifiedFields, parentModifiedBit);
-        expHistogram = new ExpHistogramValue(parentModifiedFields, parentModifiedBit);
     }
 
     // Type enum for oneof
@@ -69,6 +67,18 @@ public class PointValue {
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            switch (typ) {
+            case TypeHistogram:
+                if (histogram == null) {
+                    histogram = new HistogramValue(parentModifiedFields, parentModifiedBit);
+                }
+                break;
+            case TypeExpHistogram:
+                if (expHistogram == null) {
+                    expHistogram = new ExpHistogramValue(parentModifiedFields, parentModifiedBit);
+                }
+                break;
+            }
             this.markParentModified();
         }
     }
@@ -152,13 +162,17 @@ public class PointValue {
             setFloat64(src.getFloat64());
             break;
         case TypeHistogram:
+            setType(src.typ);
             histogram.copyFrom(src.histogram);
             break;
         case TypeExpHistogram:
+            setType(src.typ);
             expHistogram.copyFrom(src.expHistogram);
             break;
+        case TypeNone:
+            setType(Type.TypeNone);
+            break;
         }
-        setType(src.typ);
     }
 
     private void markParentModified() {
@@ -179,10 +193,10 @@ public class PointValue {
         case TypeFloat64:
             break;
         case TypeHistogram:
-                this.histogram.markModifiedRecursively();
+            this.histogram.markModifiedRecursively();
             break;
         case TypeExpHistogram:
-                this.expHistogram.markModifiedRecursively();
+            this.expHistogram.markModifiedRecursively();
             break;
         default:
             break;
@@ -221,21 +235,25 @@ public class PointValue {
                 this.markParentModified();
                 modified = true;
             }
+            break;
         case TypeFloat64:
             if (!Types.Float64Equal(this.float64, v.float64)) {
                 this.markParentModified();
                 modified = true;
             }
+            break;
         case TypeHistogram:
             if (this.histogram.markDiffModified(v.histogram)) {
                 this.markParentModified();
                 modified = true;
             }
+            break;
         case TypeExpHistogram:
             if (this.expHistogram.markDiffModified(v.expHistogram)) {
                 this.markParentModified();
                 modified = true;
             }
+            break;
         }
         return modified;
     }
@@ -367,4 +385,3 @@ public class PointValue {
         );
     }
 }
-

--- a/stefgen/generator/testdata/oneof_recurse_array.stef
+++ b/stefgen/generator/testdata/oneof_recurse_array.stef
@@ -1,18 +1,18 @@
 package com.example.gentest.oneof_recurse_array
 
 struct Root1 root {
-  Rec1 Rec1
+  Oneof1 Oneof1
 }
 
-oneof Rec1 {
-  Rec2 []Rec2
+oneof Oneof1 {
+  Oneof2 []Oneof2
 }
 
-oneof Rec2 {
-  Rec1 []Rec1
+oneof Oneof2 {
+  Oneof1 []Oneof1
   Val int64
 }
 
 struct Root2 root {
-  Rec2 Rec2
+  Oneof2 Oneof2
 }

--- a/stefgen/generator/testdata/oneof_recurse_multimap.stef
+++ b/stefgen/generator/testdata/oneof_recurse_multimap.stef
@@ -1,0 +1,18 @@
+package com.example.gentest.oneof_recurse_multimap
+
+struct Root1 root {
+  Oneof Oneof
+}
+
+oneof Oneof {
+  Multimap Multimap
+}
+
+multimap Multimap {
+  key string
+  value Oneof
+}
+
+struct Root2 root {
+  Multimap Multimap
+}

--- a/stefgen/generator/testdata/oneof_recurse_mutual.stef
+++ b/stefgen/generator/testdata/oneof_recurse_mutual.stef
@@ -1,0 +1,13 @@
+package com.example.gentest.oneof_recurse_mutual
+
+struct Root root {
+  Oneof1 Oneof1
+}
+
+oneof Oneof1 {
+  Oneof2 Oneof2
+}
+
+oneof Oneof2 {
+  Oneof1 Oneof1
+}

--- a/stefgen/generator/testdata/oneof_recurse_self.stef
+++ b/stefgen/generator/testdata/oneof_recurse_self.stef
@@ -1,0 +1,9 @@
+package com.example.gentest.oneof_recurse_self
+
+struct Root root {
+  Oneof Oneof
+}
+
+oneof Oneof {
+  Oneof Oneof
+}

--- a/stefgen/templates/go/oneof.go.tmpl
+++ b/stefgen/templates/go/oneof.go.tmpl
@@ -40,10 +40,7 @@ func (s *{{ $.StructName }}) init(parentModifiedFields *modifiedFields, parentMo
     s.parentModifiedBit = parentModifiedBit
 
     {{ range .Fields }}
-    {{- if .Type.Flags.StoreByPtr}}
-    s.{{.name}} = &{{ .Type.Storage }}{}
-    {{- end }}
-	{{- if not .Type.IsPrimitive }}
+	{{- if and (not .Type.IsPrimitive) (not .Type.Flags.StoreByPtr) }}
     s.{{.name}}.init(parentModifiedFields, parentModifiedBit)
     {{- end -}}
     {{- end -}}
@@ -67,7 +64,18 @@ func (s *{{ $.StructName }}) Type() {{$.StructName }}Type {
 func (s *{{ $.StructName }}) SetType(typ {{$.StructName }}Type) {
 	if s.typ!=typ {
         s.typ=typ
-		s.markParentModified()
+        switch typ {
+        {{- range .Fields }}
+        {{- if .Type.Flags.StoreByPtr}}
+        case {{ $.StructName }}Type{{.Name}}:
+            if s.{{.name}} == nil {
+                s.{{.name}} = &{{ .Type.Storage }}{}
+                s.{{.name}}.init(s.parentModifiedFields, s.parentModifiedBit)
+            }
+        {{- end -}}
+        {{- end }}
+        }
+        s.markParentModified()
     }
 }
 
@@ -94,8 +102,8 @@ func (s *{{ $.StructName }}) Set{{.Name}}(v {{if .PassByPointer}}*{{end}}{{.Type
 {{end}}
 {{ end }}
 
-func (s *{{ .StructName }}) Clone() {{.StructName}} {
-	return {{ .StructName }}{
+func (s *{{ .StructName }}) Clone() {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
+	return {{if .Type.Flags.StoreByPtr}}&{{end}}{{ .StructName }}{
         {{ range .Fields }}{{.name}}: {{if .Type.MustClone}}s.{{.name}}.Clone(){{else}}s.{{.name}}{{end}},
         {{ end }}
 	}
@@ -185,7 +193,7 @@ func (s *{{ $.StructName }}) markDiffModified(v *{{ $.StructName }}) (modified b
             modified = true
         }
     {{- else}}
-        if s.{{.name}}.markDiffModified(&v.{{.name}}) {
+        if s.{{.name}}.markDiffModified({{if .Type.Flags.TakePtr}}&{{end}}v.{{.name}}) {
             s.markParentModified()
             modified = true
         }
@@ -278,8 +286,11 @@ type {{ .StructName }}Encoder struct {
     prevType {{.StructName}}Type
     fieldCount uint
 
+    // Field encoders.
     {{ range .Fields }}
-    {{.name}}Encoder {{ .Type.EncoderType }}Encoder
+    {{.name}}Encoder {{if not .IsPrimitive}}*{{end}}{{ .Type.EncoderType }}Encoder
+    {{if not .IsPrimitive}}is{{.Name}}Recursive bool // Indicates {{.Name}} field's type is recursive.
+    {{end}}
     {{- end }}
     {{if .DictName}}
 	dict *{{ .StructName }}EncoderDict{{end}}
@@ -337,7 +348,9 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
 
     var err error
     {{ range $i, $e := .Fields }}
+    // Init encoder for {{.Name}} field.
     if e.fieldCount <= {{$i}} {
+        // {{.Name}} and all subsequent fields are skipped.
         return nil
     }
     {{- if .IsPrimitive}}
@@ -347,19 +360,30 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
         err = e.{{.name}}Encoder.Init({{if .Type.IsDictPossible}}nil, {{end}}e.limiter, columns.AddSubColumn())
         {{- end}}
     {{- else}}
-    err = e.{{.name}}Encoder.Init(state, columns.AddSubColumn())
+    if state.{{.Type.EncoderType}}Encoder != nil {
+        // Recursion detected, use the existing encoder.
+        e.{{.name}}Encoder = state.{{.Type.EncoderType}}Encoder
+        e.is{{.Name}}Recursive = true
+    } else {
+        e.{{.name}}Encoder = new({{.Type.EncoderType}}Encoder)
+        err = e.{{.name}}Encoder.Init(state, columns.AddSubColumn())
+    }
     {{- end}}
     if err != nil {
         return err
     }
-    {{- end}}
+    {{end}}
     return nil
 }
 
 func (e *{{ .StructName }}Encoder) Reset() {
     e.prevType = 0
     {{- range .Fields}}
-    e.{{.name}}Encoder.Reset()
+    {{if not .IsPrimitive}}
+    if !e.is{{.Name}}Recursive {
+        e.{{.name}}Encoder.Reset()
+    }
+    {{else}}e.{{.name}}Encoder.Reset(){{end}}
     {{- end}}
 }
 
@@ -392,12 +416,22 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
 // CollectColumns collects all buffers from all encoders into buf.
 func (e *{{ .StructName }}Encoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
     columnSet.SetBits(&e.buf)
+    colIdx := 0
     {{ range $i,$e := .Fields }}
+    // Collect {{.Name}} field.
     if e.fieldCount <= {{$i}} {
         return // {{.Name}} and subsequent fields are skipped.
     }
-    e.{{.name}}Encoder.CollectColumns(columnSet.At({{$i}}))
-    {{- end }}
+    {{if not .IsPrimitive -}}
+    if !e.is{{.Name}}Recursive {
+        e.{{.name}}Encoder.CollectColumns(columnSet.At(colIdx))
+        colIdx++
+    }
+    {{else}}
+    e.{{.name}}Encoder.CollectColumns(columnSet.At(colIdx))
+    colIdx++
+    {{end -}}
+    {{end -}}
 }
 
 // {{ .StructName }}Decoder implements decoding of {{ .StructName }}
@@ -410,8 +444,11 @@ type {{ .StructName }}Decoder struct {
 
     prevType {{.StructName}}Type
 
-    {{ range .Fields }}
-    {{.name}}Decoder {{ .Type.EncoderType }}Decoder
+    // Field decoders.
+    {{range .Fields}}
+    {{.name}}Decoder {{if not .IsPrimitive}}*{{end}}{{ .Type.EncoderType }}Decoder
+    {{if not .IsPrimitive}}is{{.Name}}Recursive bool
+    {{end}}
     {{- end }}
     {{if .DictName}}
     dict *{{ .StructName }}DecoderDict
@@ -463,7 +500,14 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
         err = d.{{.name}}Decoder.Init(columns.AddSubColumn())
         {{- end}}
     {{- else}}
-    err = d.{{.name}}Decoder.Init(state, columns.AddSubColumn())
+    if state.{{.Type.EncoderType}}Decoder != nil {
+        // Recursion detected, use the existing decoder.
+        d.{{.name}}Decoder = state.{{.Type.EncoderType}}Decoder
+        d.is{{.Name}}Recursive = true // Mark that we are using a recursive decoder.
+    } else {
+        d.{{.name}}Decoder = new({{.Type.EncoderType}}Decoder)
+        err = d.{{.name}}Decoder.Init(state, columns.AddSubColumn())
+    }
     {{- end}}
     if err != nil {
         return err
@@ -489,14 +533,22 @@ func (d *{{ .StructName }}Decoder) Continue() {
     if d.fieldCount <= {{$i}} {
         return // {{.Name}} and subsequent fields are skipped.
     }
-    d.{{.name}}Decoder.Continue()
-    {{- end }}
+    {{if not .IsPrimitive}}
+    if !d.is{{.Name}}Recursive {
+        d.{{.name}}Decoder.Continue()
+    }
+    {{else}}d.{{.name}}Decoder.Continue(){{end}}
+    {{end }}
 }
 
 func (d *{{ .StructName }}Decoder) Reset() {
     d.prevType = 0
     {{- range .Fields}}
-    d.{{.name}}Decoder.Reset()
+    {{if not .IsPrimitive}}
+    if !d.is{{.Name}}Recursive {
+        d.{{.name}}Decoder.Reset()
+    }
+    {{else}}d.{{.name}}Decoder.Reset(){{end}}
     {{- end}}
 }
 
@@ -519,7 +571,13 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
     {{- range .Fields }}
     case {{ $.StructName }}Type{{.Name}}:
         // Decode {{.Name}}
-        err := d.{{.name}}Decoder.Decode(&dst.{{.name}})
+        {{- if .Type.Flags.StoreByPtr}}
+        if dst.{{.name}} == nil {
+            dst.{{.name}} = &{{ .Type.Storage }}{}
+            dst.{{.name}}.init(dst.parentModifiedFields, dst.parentModifiedBit)
+        }
+        {{end}}
+        err := d.{{.name}}Decoder.Decode({{if .Type.Flags.DecodeByPtr}}&{{end}}dst.{{.name}})
         if err != nil {
             return err
         }

--- a/stefgen/templates/go/struct.go.tmpl
+++ b/stefgen/templates/go/struct.go.tmpl
@@ -625,7 +625,7 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
     val.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0
     {{- end}} {
 		// Field is changed and is present, decode it.
- 		err = d.{{.name}}Decoder.Decode(&val.{{.name}})
+ 		err = d.{{.name}}Decoder.Decode({{if .Type.Flags.DecodeByPtr}}&{{end}}val.{{.name}})
         if err != nil {
             return err
         }

--- a/stefgen/templates/go/writer_test.go.tmpl
+++ b/stefgen/templates/go/writer_test.go.tmpl
@@ -2,6 +2,7 @@ package {{ .PackageName }}
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -63,6 +64,13 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 	for _, opt := range opts {
 		t.Run(
 			"", func(t *testing.T) {
+				succeeded := false
+				defer func() {
+					if !succeeded {
+						fmt.Printf("Test failed with seed %v\n", seed1)
+					}
+				}()
+
 				buf := &pkg.MemChunkWriter{}
 				writer, err := New{{.StructName}}Writer(buf, opt)
 				require.NoError(t, err, "seed %v", seed1)
@@ -90,6 +98,8 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 				}
 				err = reader.Read(pkg.ReadOptions{})
 				require.Error(t, io.EOF, seed1)
+
+				succeeded = true
 			},
 		)
 	}

--- a/stefgen/templates/java/oneof.java.tmpl
+++ b/stefgen/templates/java/oneof.java.tmpl
@@ -14,9 +14,9 @@ public class {{ .StructName }} {
     {{- end }}
 
     // Pointer to parent's modifiedFields
-    private ModifiedFields parentModifiedFields;
+    ModifiedFields parentModifiedFields;
     // Bit to set in parent's modifiedFields when this oneof is modified.
-    private long parentModifiedBit;
+    long parentModifiedBit;
 
     {{ .StructName }}() {
         init(null, 0);
@@ -33,8 +33,6 @@ public class {{ .StructName }} {
         {{ range .Fields }}
         {{- if .Type.IsPrimitive }}
         {{if .Type.InitVal}}{{.name}} = {{.Type.InitVal}};{{end}}
-        {{- else}}
-        {{.name}} = new {{ .Type.Storage }}(parentModifiedFields, parentModifiedBit);
         {{- end }}
         {{- end }}
     }
@@ -67,6 +65,17 @@ public class {{ .StructName }} {
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            switch (typ) {
+            {{- range .Fields }}
+            {{- if not .Type.IsPrimitive}}
+            case Type{{.Name}}:
+                if ({{.name}} == null) {
+                    {{.name}} = new {{ .Type.Storage }}(parentModifiedFields, parentModifiedBit);
+                }
+                break;
+            {{- end -}}
+            {{- end }}
+            }
             this.markParentModified();
         }
     }
@@ -117,23 +126,18 @@ public class {{ .StructName }} {
         switch (src.typ) {
         {{- range .Fields }}
         case Type{{.Name}}:
-            {{- if .Type.MustClone }}
-            {{.name }}.copyFrom(src.{{.name}});
-            {{- else }}
-            {{- if .Optional }}
-            if (src.has{{.Name}}()) {
-                set{{.Name}}(src.get{{.Name}}());
-            } else {
-                unset{{.Name}}();
-            }
-            {{- else }}
+            {{- if .Type.IsPrimitive }}
             set{{.Name}}(src.get{{.Name}}());
-            {{- end }}
+            {{- else }}
+            setType(src.typ);
+            {{.name }}.copyFrom(src.{{.name}});
             {{- end }}
             break;
         {{- end }}
+        case TypeNone:
+            setType(Type.TypeNone);
+            break;
         }
-        setType(src.typ);
     }
 
     private void markParentModified() {
@@ -155,7 +159,7 @@ public class {{ .StructName }} {
         {{- range .Fields }}
         case Type{{.Name}}:
             {{- if not .Type.IsPrimitive }}
-                this.{{.name}}.markModifiedRecursively();
+            this.{{.name}}.markModifiedRecursively();
             {{- end }}
             break;
         {{- end }}
@@ -201,6 +205,7 @@ public class {{ .StructName }} {
                 modified = true;
             }
             {{- end}}
+            break;
         {{- end }}
         }
         return modified;
@@ -300,4 +305,3 @@ public class {{ .StructName }} {
         );
     }
 }
-

--- a/stefgen/templates/java/oneofDecoder.java.tmpl
+++ b/stefgen/templates/java/oneofDecoder.java.tmpl
@@ -16,8 +16,10 @@ class {{ .StructName }}Decoder {
     private int fieldCount;
     private {{.StructName}}.Type prevType;
 
-    {{ range .Fields }}
-    private {{ .Type.EncoderType }}Decoder {{.name}}Decoder = new {{ .Type.EncoderType }}Decoder();
+    // Field decoders.
+    {{range .Fields}}
+    private {{.Type.EncoderType}}Decoder {{.name}}Decoder;
+    private boolean is{{.Name}}Recursive = false; // Indicates {{.Name}} field's type is recursive.
     {{- end }}
     {{if .DictName}}
     private {{ .StructName }}DecoderDict dict;
@@ -51,6 +53,7 @@ class {{ .StructName }}Decoder {
                 return; // {{.Name}} and subsequent fields are skipped.
             }
             {{- if .Type.IsPrimitive}}
+            {{.name}}Decoder = new {{.Type.EncoderType}}Decoder();
                 {{- if .Type.DictName}}
             this.{{.name}}Decoder.init(state.{{.Type.DictName}}, columns.addSubColumn());
                 {{- else if .Type.IsDictPossible}}
@@ -59,7 +62,14 @@ class {{ .StructName }}Decoder {
             this.{{.name}}Decoder.init(columns.addSubColumn());
                 {{- end}}
             {{- else}}
-            this.{{.name}}Decoder.init(state, columns.addSubColumn());
+            if (state.{{.Type.EncoderType}}Decoder != null) {
+                // Recursion detected, use the existing decoder.
+                {{.name}}Decoder = state.{{.Type.EncoderType}}Decoder;
+                is{{.Name}}Recursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                {{.name}}Decoder = new {{.Type.EncoderType}}Decoder();
+                {{.name}}Decoder.init(state, columns.addSubColumn());
+            }
             {{- end}}
             {{- end }}
         } finally {
@@ -78,14 +88,24 @@ class {{ .StructName }}Decoder {
         if (this.fieldCount <= {{$i}}) {
             return; // {{.Name}} and subsequent fields are skipped.
         }
-        this.{{.name}}Decoder.continueDecoding();
+        {{if not .IsPrimitive}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Decoder.continueDecoding();
+        }
+        {{else}}{{.name}}Decoder.continueDecoding();{{end}}
         {{- end }}
     }
 
     public void reset() {
         prevType = {{.StructName}}.Type.TypeNone;
-        {{- range .Fields}}
+        {{range .Fields}}
+        {{if not .IsPrimitive -}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Decoder.reset();
+        }
+        {{- else -}}
         {{.name}}Decoder.reset();
+        {{- end}}
         {{- end}}
     }
 
@@ -104,7 +124,14 @@ class {{ .StructName }}Decoder {
         switch (dst.typ) {
         {{- range .Fields }}
         case Type{{.Name}}:
-            dst.{{.name}} = this.{{.name}}Decoder.decode({{if not .Type.IsPrimitive }}dst.{{.name}}{{end}});
+            {{if not .Type.IsPrimitive -}}
+            if (dst.{{.name}} == null) {
+                dst.{{.name}} = new {{ .Type.Storage }}(dst.parentModifiedFields, dst.parentModifiedBit);
+            }
+            dst.{{.name}} = this.{{.name}}Decoder.decode(dst.{{.name}});
+            {{- else -}}
+            dst.{{.name}} = this.{{.name}}Decoder.decode();
+            {{- end}}
             break;
         {{- end }}
         default:

--- a/stefgen/templates/java/oneofEncoder.java.tmpl
+++ b/stefgen/templates/java/oneofEncoder.java.tmpl
@@ -14,8 +14,10 @@ class {{ .StructName }}Encoder {
     private {{.StructName}}.Type prevType;
     private int fieldCount;
 
+    // Field encoders.
     {{ range .Fields }}
-    private {{ .Type.EncoderType }}Encoder {{.name}}Encoder = new {{ .Type.EncoderType }}Encoder();
+    private {{.Type.EncoderType}}Encoder {{.name}}Encoder;
+    private boolean is{{.Name}}Recursive = false; // Indicates {{.Name}} field's type is recursive.
     {{- end }}
     {{if .DictName}}
     private {{ .StructName }}EncoderDict dict;
@@ -43,17 +45,26 @@ class {{ .StructName }}Encoder {
             }
 
             {{ range $i, $e := .Fields }}
+            // Init encoder for {{.Name}} field.
             if (this.fieldCount <= {{$i}}) {
                 return; // {{.Name}} and subsequent fields are skipped.
             }
             {{- if .IsPrimitive}}
+            {{.name}}Encoder = new {{.Type.EncoderType}}Encoder();
                 {{- if .Type.DictName}}
             {{.name}}Encoder.init(state.{{.Type.DictName}}, limiter, columns.addSubColumn());
                 {{- else}}
             {{.name}}Encoder.init({{if .Type.IsDictPossible}}null, {{end}}limiter, columns.addSubColumn());
                 {{- end}}
             {{- else}}
-            {{.name}}Encoder.init(state, columns.addSubColumn());
+            if (state.{{.Type.EncoderType}}Encoder != null) {
+                // Recursion detected, use the existing encoder.
+                {{.name}}Encoder = state.{{.Type.EncoderType}}Encoder;
+                is{{.Name}}Recursive = true;
+            } else {
+                {{.name}}Encoder = new {{.Type.EncoderType}}Encoder();
+                {{.name}}Encoder.init(state, columns.addSubColumn());
+            }
             {{- end}}
             {{- end}}
         } finally {
@@ -64,7 +75,11 @@ class {{ .StructName }}Encoder {
     public void reset() {
         prevType = {{ .StructName }}.Type.TypeNone;
         {{- range .Fields}}
-        this.{{.name}}Encoder.reset();
+        {{if not .IsPrimitive}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Encoder.reset();
+        }
+        {{else}}{{.name}}Encoder.reset();{{end}}
         {{- end}}
     }
 
@@ -101,12 +116,21 @@ class {{ .StructName }}Encoder {
     // collectColumns collects all buffers from all encoders into buf.
     public void collectColumns(WriteColumnSet columnSet) {
         columnSet.setBits(this.buf);
+        int colIdx = 0;
         {{ range $i,$e := .Fields }}
+        // Collect {{.Name}} field.
         if (this.fieldCount <= {{$i}}) {
             return; // {{.Name}} and subsequent fields are skipped.
         }
-        this.{{.name}}Encoder.collectColumns(columnSet.at({{$i}}));
+        {{if not .IsPrimitive -}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Encoder.collectColumns(columnSet.at(colIdx));
+            colIdx++;
+        }
+        {{else}}
+        {{.name}}Encoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        {{end -}}
         {{- end }}
     }
 }
-


### PR DESCRIPTION
- Added 3 new oneof testcases: oneof_recurse_multimap.stef, oneof_recurse_mutual.stef and oneof_recurse_self.stef

There is no changes in the size of Otel/STEF metrics or in the speed of any benchmarks.