### PR TITLE
Support recursive struct types

### DIFF
--- a/java/src/main/java/com/example/oteltef/Envelope.java
+++ b/java/src/main/java/com/example/oteltef/Envelope.java
@@ -106,8 +106,9 @@ public class Envelope {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Envelope val) {
-        if (!this.attributes.equals(val.attributes)) {
+    public boolean equals(Envelope right) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
         return true;
@@ -131,6 +132,7 @@ public class Envelope {
         }
         int c;
         
+        // Compare Attributes field.
         c = EnvelopeAttributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
@@ -141,7 +143,7 @@ public class Envelope {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 1;
+        final int fieldCount = Math.max(1,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.attributes.mutateRandom(random);

--- a/java/src/main/java/com/example/oteltef/Event.java
+++ b/java/src/main/java/com/example/oteltef/Event.java
@@ -214,17 +214,21 @@ public class Event {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Event val) {
-        if (!Types.StringEqual(this.name, val.name)) {
+    public boolean equals(Event right) {
+        // Compare Name field.
+        if (!Types.StringEqual(this.name, right.name)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.timeUnixNano, val.timeUnixNano)) {
+        // Compare TimeUnixNano field.
+        if (!Types.Uint64Equal(this.timeUnixNano, right.timeUnixNano)) {
             return false;
         }
-        if (!this.attributes.equals(val.attributes)) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.droppedAttributesCount, val.droppedAttributesCount)) {
+        // Compare DroppedAttributesCount field.
+        if (!Types.Uint64Equal(this.droppedAttributesCount, right.droppedAttributesCount)) {
             return false;
         }
         return true;
@@ -248,21 +252,25 @@ public class Event {
         }
         int c;
         
+        // Compare Name field.
         c = Types.StringCompare(left.name, right.name);
         if (c != 0) {
             return c;
         }
         
+        // Compare TimeUnixNano field.
         c = Types.Uint64Compare(left.timeUnixNano, right.timeUnixNano);
         if (c != 0) {
             return c;
         }
         
+        // Compare Attributes field.
         c = Attributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
         }
         
+        // Compare DroppedAttributesCount field.
         c = Types.Uint64Compare(left.droppedAttributesCount, right.droppedAttributesCount);
         if (c != 0) {
             return c;
@@ -273,7 +281,7 @@ public class Event {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 4;
+        final int fieldCount = Math.max(4,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setName(Types.StringRandom(random));

--- a/java/src/main/java/com/example/oteltef/Exemplar.java
+++ b/java/src/main/java/com/example/oteltef/Exemplar.java
@@ -245,20 +245,25 @@ public class Exemplar {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Exemplar val) {
-        if (!Types.Uint64Equal(this.timestamp, val.timestamp)) {
+    public boolean equals(Exemplar right) {
+        // Compare Timestamp field.
+        if (!Types.Uint64Equal(this.timestamp, right.timestamp)) {
             return false;
         }
-        if (!this.value.equals(val.value)) {
+        // Compare Value field.
+        if (!this.value.equals(right.value)) {
             return false;
         }
-        if (!Types.BytesEqual(this.spanID, val.spanID)) {
+        // Compare SpanID field.
+        if (!Types.BytesEqual(this.spanID, right.spanID)) {
             return false;
         }
-        if (!Types.BytesEqual(this.traceID, val.traceID)) {
+        // Compare TraceID field.
+        if (!Types.BytesEqual(this.traceID, right.traceID)) {
             return false;
         }
-        if (!this.filteredAttributes.equals(val.filteredAttributes)) {
+        // Compare FilteredAttributes field.
+        if (!this.filteredAttributes.equals(right.filteredAttributes)) {
             return false;
         }
         return true;
@@ -282,26 +287,31 @@ public class Exemplar {
         }
         int c;
         
+        // Compare Timestamp field.
         c = Types.Uint64Compare(left.timestamp, right.timestamp);
         if (c != 0) {
             return c;
         }
         
+        // Compare Value field.
         c = ExemplarValue.compare(left.value, right.value);
         if (c != 0) {
             return c;
         }
         
+        // Compare SpanID field.
         c = Types.BytesCompare(left.spanID, right.spanID);
         if (c != 0) {
             return c;
         }
         
+        // Compare TraceID field.
         c = Types.BytesCompare(left.traceID, right.traceID);
         if (c != 0) {
             return c;
         }
         
+        // Compare FilteredAttributes field.
         c = Attributes.compare(left.filteredAttributes, right.filteredAttributes);
         if (c != 0) {
             return c;
@@ -312,7 +322,7 @@ public class Exemplar {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 5;
+        final int fieldCount = Math.max(5,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setTimestamp(Types.Uint64Random(random));

--- a/java/src/main/java/com/example/oteltef/ExpHistogramBuckets.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramBuckets.java
@@ -142,11 +142,13 @@ public class ExpHistogramBuckets {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(ExpHistogramBuckets val) {
-        if (!Types.Int64Equal(this.offset, val.offset)) {
+    public boolean equals(ExpHistogramBuckets right) {
+        // Compare Offset field.
+        if (!Types.Int64Equal(this.offset, right.offset)) {
             return false;
         }
-        if (!this.bucketCounts.equals(val.bucketCounts)) {
+        // Compare BucketCounts field.
+        if (!this.bucketCounts.equals(right.bucketCounts)) {
             return false;
         }
         return true;
@@ -170,11 +172,13 @@ public class ExpHistogramBuckets {
         }
         int c;
         
+        // Compare Offset field.
         c = Types.Int64Compare(left.offset, right.offset);
         if (c != 0) {
             return c;
         }
         
+        // Compare BucketCounts field.
         c = Uint64Array.compare(left.bucketCounts, right.bucketCounts);
         if (c != 0) {
             return c;
@@ -185,7 +189,7 @@ public class ExpHistogramBuckets {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 2;
+        final int fieldCount = Math.max(2,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setOffset(Types.Int64Random(random));

--- a/java/src/main/java/com/example/oteltef/ExpHistogramValue.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramValue.java
@@ -452,32 +452,65 @@ public class ExpHistogramValue {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(ExpHistogramValue val) {
-        if (!Types.Uint64Equal(this.count, val.count)) {
+    public boolean equals(ExpHistogramValue right) {
+        // Compare Count field.
+        if (!Types.Uint64Equal(this.count, right.count)) {
             return false;
         }
-        if (!Types.Float64Equal(this.sum, val.sum)) {
+        // Compare Sum field.
+        boolean thisSumPresent = (this.optionalFieldsPresent & fieldPresentSum) != 0;
+        boolean rightSumPresent = (right.optionalFieldsPresent & fieldPresentSum) != 0;
+        if (thisSumPresent != rightSumPresent) {
             return false;
         }
-        if (!Types.Float64Equal(this.min, val.min)) {
+        if (thisSumPresent) { // Compare only if Sum field is present
+        if (!Types.Float64Equal(this.sum, right.sum)) {
             return false;
         }
-        if (!Types.Float64Equal(this.max, val.max)) {
+        }
+        
+        // Compare Min field.
+        boolean thisMinPresent = (this.optionalFieldsPresent & fieldPresentMin) != 0;
+        boolean rightMinPresent = (right.optionalFieldsPresent & fieldPresentMin) != 0;
+        if (thisMinPresent != rightMinPresent) {
             return false;
         }
-        if (!Types.Int64Equal(this.scale, val.scale)) {
+        if (thisMinPresent) { // Compare only if Min field is present
+        if (!Types.Float64Equal(this.min, right.min)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.zeroCount, val.zeroCount)) {
+        }
+        
+        // Compare Max field.
+        boolean thisMaxPresent = (this.optionalFieldsPresent & fieldPresentMax) != 0;
+        boolean rightMaxPresent = (right.optionalFieldsPresent & fieldPresentMax) != 0;
+        if (thisMaxPresent != rightMaxPresent) {
             return false;
         }
-        if (!this.positiveBuckets.equals(val.positiveBuckets)) {
+        if (thisMaxPresent) { // Compare only if Max field is present
+        if (!Types.Float64Equal(this.max, right.max)) {
             return false;
         }
-        if (!this.negativeBuckets.equals(val.negativeBuckets)) {
+        }
+        
+        // Compare Scale field.
+        if (!Types.Int64Equal(this.scale, right.scale)) {
             return false;
         }
-        if (!Types.Float64Equal(this.zeroThreshold, val.zeroThreshold)) {
+        // Compare ZeroCount field.
+        if (!Types.Uint64Equal(this.zeroCount, right.zeroCount)) {
+            return false;
+        }
+        // Compare PositiveBuckets field.
+        if (!this.positiveBuckets.equals(right.positiveBuckets)) {
+            return false;
+        }
+        // Compare NegativeBuckets field.
+        if (!this.negativeBuckets.equals(right.negativeBuckets)) {
+            return false;
+        }
+        // Compare ZeroThreshold field.
+        if (!Types.Float64Equal(this.zeroThreshold, right.zeroThreshold)) {
             return false;
         }
         return true;
@@ -501,46 +534,79 @@ public class ExpHistogramValue {
         }
         int c;
         
+        // Compare Count field.
         c = Types.Uint64Compare(left.count, right.count);
         if (c != 0) {
             return c;
         }
         
+        // Compare Sum field.
+        boolean leftSumPresent = (left.optionalFieldsPresent & fieldPresentSum) != 0;
+        boolean rightSumPresent = (right.optionalFieldsPresent & fieldPresentSum) != 0;
+        if (leftSumPresent != rightSumPresent) {
+            if (leftSumPresent) {
+                return 1;
+            }
+            return -1;
+        }
         c = Types.Float64Compare(left.sum, right.sum);
         if (c != 0) {
             return c;
         }
         
+        // Compare Min field.
+        boolean leftMinPresent = (left.optionalFieldsPresent & fieldPresentMin) != 0;
+        boolean rightMinPresent = (right.optionalFieldsPresent & fieldPresentMin) != 0;
+        if (leftMinPresent != rightMinPresent) {
+            if (leftMinPresent) {
+                return 1;
+            }
+            return -1;
+        }
         c = Types.Float64Compare(left.min, right.min);
         if (c != 0) {
             return c;
         }
         
+        // Compare Max field.
+        boolean leftMaxPresent = (left.optionalFieldsPresent & fieldPresentMax) != 0;
+        boolean rightMaxPresent = (right.optionalFieldsPresent & fieldPresentMax) != 0;
+        if (leftMaxPresent != rightMaxPresent) {
+            if (leftMaxPresent) {
+                return 1;
+            }
+            return -1;
+        }
         c = Types.Float64Compare(left.max, right.max);
         if (c != 0) {
             return c;
         }
         
+        // Compare Scale field.
         c = Types.Int64Compare(left.scale, right.scale);
         if (c != 0) {
             return c;
         }
         
+        // Compare ZeroCount field.
         c = Types.Uint64Compare(left.zeroCount, right.zeroCount);
         if (c != 0) {
             return c;
         }
         
+        // Compare PositiveBuckets field.
         c = ExpHistogramBuckets.compare(left.positiveBuckets, right.positiveBuckets);
         if (c != 0) {
             return c;
         }
         
+        // Compare NegativeBuckets field.
         c = ExpHistogramBuckets.compare(left.negativeBuckets, right.negativeBuckets);
         if (c != 0) {
             return c;
         }
         
+        // Compare ZeroThreshold field.
         c = Types.Float64Compare(left.zeroThreshold, right.zeroThreshold);
         if (c != 0) {
             return c;
@@ -551,7 +617,7 @@ public class ExpHistogramValue {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 9;
+        final int fieldCount = Math.max(9,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setCount(Types.Uint64Random(random));

--- a/java/src/main/java/com/example/oteltef/ExpHistogramValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramValueDecoder.java
@@ -16,15 +16,24 @@ class ExpHistogramValueDecoder {
     private int fieldCount;
 
     
-    private Uint64Decoder countDecoder = new Uint64Decoder();
-    private Float64Decoder sumDecoder = new Float64Decoder();
-    private Float64Decoder minDecoder = new Float64Decoder();
-    private Float64Decoder maxDecoder = new Float64Decoder();
-    private Int64Decoder scaleDecoder = new Int64Decoder();
-    private Uint64Decoder zeroCountDecoder = new Uint64Decoder();
-    private ExpHistogramBucketsDecoder positiveBucketsDecoder = new ExpHistogramBucketsDecoder();
-    private ExpHistogramBucketsDecoder negativeBucketsDecoder = new ExpHistogramBucketsDecoder();
-    private Float64Decoder zeroThresholdDecoder = new Float64Decoder();
+    private Uint64Decoder countDecoder;
+    private boolean isCountRecursive = false; // Indicates Count field's type is recursive.
+    private Float64Decoder sumDecoder;
+    private boolean isSumRecursive = false; // Indicates Sum field's type is recursive.
+    private Float64Decoder minDecoder;
+    private boolean isMinRecursive = false; // Indicates Min field's type is recursive.
+    private Float64Decoder maxDecoder;
+    private boolean isMaxRecursive = false; // Indicates Max field's type is recursive.
+    private Int64Decoder scaleDecoder;
+    private boolean isScaleRecursive = false; // Indicates Scale field's type is recursive.
+    private Uint64Decoder zeroCountDecoder;
+    private boolean isZeroCountRecursive = false; // Indicates ZeroCount field's type is recursive.
+    private ExpHistogramBucketsDecoder positiveBucketsDecoder;
+    private boolean isPositiveBucketsRecursive = false; // Indicates PositiveBuckets field's type is recursive.
+    private ExpHistogramBucketsDecoder negativeBucketsDecoder;
+    private boolean isNegativeBucketsRecursive = false; // Indicates NegativeBuckets field's type is recursive.
+    private Float64Decoder zeroThresholdDecoder;
+    private boolean isZeroThresholdRecursive = false; // Indicates ZeroThreshold field's type is recursive.
     
 
     // Init is called once in the lifetime of the stream.
@@ -49,38 +58,59 @@ class ExpHistogramValueDecoder {
             if (this.fieldCount <= 0) {
                 return; // Count and subsequent fields are skipped.
             }
+            countDecoder = new Uint64Decoder();
             countDecoder.init(columns.addSubColumn());
             if (this.fieldCount <= 1) {
                 return; // Sum and subsequent fields are skipped.
             }
+            sumDecoder = new Float64Decoder();
             sumDecoder.init(columns.addSubColumn());
             if (this.fieldCount <= 2) {
                 return; // Min and subsequent fields are skipped.
             }
+            minDecoder = new Float64Decoder();
             minDecoder.init(columns.addSubColumn());
             if (this.fieldCount <= 3) {
                 return; // Max and subsequent fields are skipped.
             }
+            maxDecoder = new Float64Decoder();
             maxDecoder.init(columns.addSubColumn());
             if (this.fieldCount <= 4) {
                 return; // Scale and subsequent fields are skipped.
             }
+            scaleDecoder = new Int64Decoder();
             scaleDecoder.init(columns.addSubColumn());
             if (this.fieldCount <= 5) {
                 return; // ZeroCount and subsequent fields are skipped.
             }
+            zeroCountDecoder = new Uint64Decoder();
             zeroCountDecoder.init(columns.addSubColumn());
             if (this.fieldCount <= 6) {
                 return; // PositiveBuckets and subsequent fields are skipped.
             }
-            positiveBucketsDecoder.init(state, columns.addSubColumn());
+            if (state.ExpHistogramBucketsDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                positiveBucketsDecoder = state.ExpHistogramBucketsDecoder;
+                isPositiveBucketsRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                positiveBucketsDecoder = new ExpHistogramBucketsDecoder();
+                positiveBucketsDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 7) {
                 return; // NegativeBuckets and subsequent fields are skipped.
             }
-            negativeBucketsDecoder.init(state, columns.addSubColumn());
+            if (state.ExpHistogramBucketsDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                negativeBucketsDecoder = state.ExpHistogramBucketsDecoder;
+                isNegativeBucketsRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                negativeBucketsDecoder = new ExpHistogramBucketsDecoder();
+                negativeBucketsDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 8) {
                 return; // ZeroThreshold and subsequent fields are skipped.
             }
+            zeroThresholdDecoder = new Float64Decoder();
             zeroThresholdDecoder.init(columns.addSubColumn());
         } finally {
             state.ExpHistogramValueDecoder = null;
@@ -98,51 +128,63 @@ class ExpHistogramValueDecoder {
         if (this.fieldCount <= 0) {
             return; // Count and subsequent fields are skipped.
         }
-        this.countDecoder.continueDecoding();
+        countDecoder.continueDecoding();
         if (this.fieldCount <= 1) {
             return; // Sum and subsequent fields are skipped.
         }
-        this.sumDecoder.continueDecoding();
+        sumDecoder.continueDecoding();
         if (this.fieldCount <= 2) {
             return; // Min and subsequent fields are skipped.
         }
-        this.minDecoder.continueDecoding();
+        minDecoder.continueDecoding();
         if (this.fieldCount <= 3) {
             return; // Max and subsequent fields are skipped.
         }
-        this.maxDecoder.continueDecoding();
+        maxDecoder.continueDecoding();
         if (this.fieldCount <= 4) {
             return; // Scale and subsequent fields are skipped.
         }
-        this.scaleDecoder.continueDecoding();
+        scaleDecoder.continueDecoding();
         if (this.fieldCount <= 5) {
             return; // ZeroCount and subsequent fields are skipped.
         }
-        this.zeroCountDecoder.continueDecoding();
+        zeroCountDecoder.continueDecoding();
         if (this.fieldCount <= 6) {
             return; // PositiveBuckets and subsequent fields are skipped.
         }
-        this.positiveBucketsDecoder.continueDecoding();
+        
+        if (!isPositiveBucketsRecursive) {
+            positiveBucketsDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 7) {
             return; // NegativeBuckets and subsequent fields are skipped.
         }
-        this.negativeBucketsDecoder.continueDecoding();
+        
+        if (!isNegativeBucketsRecursive) {
+            negativeBucketsDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 8) {
             return; // ZeroThreshold and subsequent fields are skipped.
         }
-        this.zeroThresholdDecoder.continueDecoding();
+        zeroThresholdDecoder.continueDecoding();
     }
 
     public void reset() {
-        this.countDecoder.reset();
-        this.sumDecoder.reset();
-        this.minDecoder.reset();
-        this.maxDecoder.reset();
-        this.scaleDecoder.reset();
-        this.zeroCountDecoder.reset();
-        this.positiveBucketsDecoder.reset();
-        this.negativeBucketsDecoder.reset();
-        this.zeroThresholdDecoder.reset();
+        countDecoder.reset();
+        sumDecoder.reset();
+        minDecoder.reset();
+        maxDecoder.reset();
+        scaleDecoder.reset();
+        zeroCountDecoder.reset();
+        if (!isPositiveBucketsRecursive) {
+            positiveBucketsDecoder.reset();
+        }
+        if (!isNegativeBucketsRecursive) {
+            negativeBucketsDecoder.reset();
+        }
+        zeroThresholdDecoder.reset();
     }
 
     public ExpHistogramValue decode(ExpHistogramValue dstPtr) throws IOException {
@@ -185,11 +227,17 @@ class ExpHistogramValueDecoder {
         
         if ((val.modifiedFields.mask & ExpHistogramValue.fieldModifiedPositiveBuckets) != 0) {
             // Field is changed and is present, decode it.
+            if (val.positiveBuckets == null) {
+                val.positiveBuckets = new ExpHistogramBuckets(val.modifiedFields, ExpHistogramValue.fieldModifiedPositiveBuckets);
+            }
             val.positiveBuckets = positiveBucketsDecoder.decode(val.positiveBuckets);
         }
         
         if ((val.modifiedFields.mask & ExpHistogramValue.fieldModifiedNegativeBuckets) != 0) {
             // Field is changed and is present, decode it.
+            if (val.negativeBuckets == null) {
+                val.negativeBuckets = new ExpHistogramBuckets(val.modifiedFields, ExpHistogramValue.fieldModifiedNegativeBuckets);
+            }
             val.negativeBuckets = negativeBucketsDecoder.decode(val.negativeBuckets);
         }
         

--- a/java/src/main/java/com/example/oteltef/HistogramValue.java
+++ b/java/src/main/java/com/example/oteltef/HistogramValue.java
@@ -313,20 +313,49 @@ public class HistogramValue {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(HistogramValue val) {
-        if (!Types.Int64Equal(this.count, val.count)) {
+    public boolean equals(HistogramValue right) {
+        // Compare Count field.
+        if (!Types.Int64Equal(this.count, right.count)) {
             return false;
         }
-        if (!Types.Float64Equal(this.sum, val.sum)) {
+        // Compare Sum field.
+        boolean thisSumPresent = (this.optionalFieldsPresent & fieldPresentSum) != 0;
+        boolean rightSumPresent = (right.optionalFieldsPresent & fieldPresentSum) != 0;
+        if (thisSumPresent != rightSumPresent) {
             return false;
         }
-        if (!Types.Float64Equal(this.min, val.min)) {
+        if (thisSumPresent) { // Compare only if Sum field is present
+        if (!Types.Float64Equal(this.sum, right.sum)) {
             return false;
         }
-        if (!Types.Float64Equal(this.max, val.max)) {
+        }
+        
+        // Compare Min field.
+        boolean thisMinPresent = (this.optionalFieldsPresent & fieldPresentMin) != 0;
+        boolean rightMinPresent = (right.optionalFieldsPresent & fieldPresentMin) != 0;
+        if (thisMinPresent != rightMinPresent) {
             return false;
         }
-        if (!this.bucketCounts.equals(val.bucketCounts)) {
+        if (thisMinPresent) { // Compare only if Min field is present
+        if (!Types.Float64Equal(this.min, right.min)) {
+            return false;
+        }
+        }
+        
+        // Compare Max field.
+        boolean thisMaxPresent = (this.optionalFieldsPresent & fieldPresentMax) != 0;
+        boolean rightMaxPresent = (right.optionalFieldsPresent & fieldPresentMax) != 0;
+        if (thisMaxPresent != rightMaxPresent) {
+            return false;
+        }
+        if (thisMaxPresent) { // Compare only if Max field is present
+        if (!Types.Float64Equal(this.max, right.max)) {
+            return false;
+        }
+        }
+        
+        // Compare BucketCounts field.
+        if (!this.bucketCounts.equals(right.bucketCounts)) {
             return false;
         }
         return true;
@@ -350,26 +379,55 @@ public class HistogramValue {
         }
         int c;
         
+        // Compare Count field.
         c = Types.Int64Compare(left.count, right.count);
         if (c != 0) {
             return c;
         }
         
+        // Compare Sum field.
+        boolean leftSumPresent = (left.optionalFieldsPresent & fieldPresentSum) != 0;
+        boolean rightSumPresent = (right.optionalFieldsPresent & fieldPresentSum) != 0;
+        if (leftSumPresent != rightSumPresent) {
+            if (leftSumPresent) {
+                return 1;
+            }
+            return -1;
+        }
         c = Types.Float64Compare(left.sum, right.sum);
         if (c != 0) {
             return c;
         }
         
+        // Compare Min field.
+        boolean leftMinPresent = (left.optionalFieldsPresent & fieldPresentMin) != 0;
+        boolean rightMinPresent = (right.optionalFieldsPresent & fieldPresentMin) != 0;
+        if (leftMinPresent != rightMinPresent) {
+            if (leftMinPresent) {
+                return 1;
+            }
+            return -1;
+        }
         c = Types.Float64Compare(left.min, right.min);
         if (c != 0) {
             return c;
         }
         
+        // Compare Max field.
+        boolean leftMaxPresent = (left.optionalFieldsPresent & fieldPresentMax) != 0;
+        boolean rightMaxPresent = (right.optionalFieldsPresent & fieldPresentMax) != 0;
+        if (leftMaxPresent != rightMaxPresent) {
+            if (leftMaxPresent) {
+                return 1;
+            }
+            return -1;
+        }
         c = Types.Float64Compare(left.max, right.max);
         if (c != 0) {
             return c;
         }
         
+        // Compare BucketCounts field.
         c = Int64Array.compare(left.bucketCounts, right.bucketCounts);
         if (c != 0) {
             return c;
@@ -380,7 +438,7 @@ public class HistogramValue {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 5;
+        final int fieldCount = Math.max(5,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setCount(Types.Int64Random(random));

--- a/java/src/main/java/com/example/oteltef/Link.java
+++ b/java/src/main/java/com/example/oteltef/Link.java
@@ -286,23 +286,29 @@ public class Link {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Link val) {
-        if (!Types.BytesEqual(this.traceID, val.traceID)) {
+    public boolean equals(Link right) {
+        // Compare TraceID field.
+        if (!Types.BytesEqual(this.traceID, right.traceID)) {
             return false;
         }
-        if (!Types.BytesEqual(this.spanID, val.spanID)) {
+        // Compare SpanID field.
+        if (!Types.BytesEqual(this.spanID, right.spanID)) {
             return false;
         }
-        if (!Types.StringEqual(this.traceState, val.traceState)) {
+        // Compare TraceState field.
+        if (!Types.StringEqual(this.traceState, right.traceState)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.flags, val.flags)) {
+        // Compare Flags field.
+        if (!Types.Uint64Equal(this.flags, right.flags)) {
             return false;
         }
-        if (!this.attributes.equals(val.attributes)) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.droppedAttributesCount, val.droppedAttributesCount)) {
+        // Compare DroppedAttributesCount field.
+        if (!Types.Uint64Equal(this.droppedAttributesCount, right.droppedAttributesCount)) {
             return false;
         }
         return true;
@@ -326,31 +332,37 @@ public class Link {
         }
         int c;
         
+        // Compare TraceID field.
         c = Types.BytesCompare(left.traceID, right.traceID);
         if (c != 0) {
             return c;
         }
         
+        // Compare SpanID field.
         c = Types.BytesCompare(left.spanID, right.spanID);
         if (c != 0) {
             return c;
         }
         
+        // Compare TraceState field.
         c = Types.StringCompare(left.traceState, right.traceState);
         if (c != 0) {
             return c;
         }
         
+        // Compare Flags field.
         c = Types.Uint64Compare(left.flags, right.flags);
         if (c != 0) {
             return c;
         }
         
+        // Compare Attributes field.
         c = Attributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
         }
         
+        // Compare DroppedAttributesCount field.
         c = Types.Uint64Compare(left.droppedAttributesCount, right.droppedAttributesCount);
         if (c != 0) {
             return c;
@@ -361,7 +373,7 @@ public class Link {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 6;
+        final int fieldCount = Math.max(6,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setTraceID(Types.BytesRandom(random));

--- a/java/src/main/java/com/example/oteltef/Metric.java
+++ b/java/src/main/java/com/example/oteltef/Metric.java
@@ -353,29 +353,37 @@ public class Metric {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Metric val) {
-        if (!Types.StringEqual(this.name, val.name)) {
+    public boolean equals(Metric right) {
+        // Compare Name field.
+        if (!Types.StringEqual(this.name, right.name)) {
             return false;
         }
-        if (!Types.StringEqual(this.description, val.description)) {
+        // Compare Description field.
+        if (!Types.StringEqual(this.description, right.description)) {
             return false;
         }
-        if (!Types.StringEqual(this.unit, val.unit)) {
+        // Compare Unit field.
+        if (!Types.StringEqual(this.unit, right.unit)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.type_, val.type_)) {
+        // Compare Type field.
+        if (!Types.Uint64Equal(this.type_, right.type_)) {
             return false;
         }
-        if (!this.metadata.equals(val.metadata)) {
+        // Compare Metadata field.
+        if (!this.metadata.equals(right.metadata)) {
             return false;
         }
-        if (!this.histogramBounds.equals(val.histogramBounds)) {
+        // Compare HistogramBounds field.
+        if (!this.histogramBounds.equals(right.histogramBounds)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.aggregationTemporality, val.aggregationTemporality)) {
+        // Compare AggregationTemporality field.
+        if (!Types.Uint64Equal(this.aggregationTemporality, right.aggregationTemporality)) {
             return false;
         }
-        if (!Types.BoolEqual(this.monotonic, val.monotonic)) {
+        // Compare Monotonic field.
+        if (!Types.BoolEqual(this.monotonic, right.monotonic)) {
             return false;
         }
         return true;
@@ -399,41 +407,49 @@ public class Metric {
         }
         int c;
         
+        // Compare Name field.
         c = Types.StringCompare(left.name, right.name);
         if (c != 0) {
             return c;
         }
         
+        // Compare Description field.
         c = Types.StringCompare(left.description, right.description);
         if (c != 0) {
             return c;
         }
         
+        // Compare Unit field.
         c = Types.StringCompare(left.unit, right.unit);
         if (c != 0) {
             return c;
         }
         
+        // Compare Type field.
         c = Types.Uint64Compare(left.type_, right.type_);
         if (c != 0) {
             return c;
         }
         
+        // Compare Metadata field.
         c = Attributes.compare(left.metadata, right.metadata);
         if (c != 0) {
             return c;
         }
         
+        // Compare HistogramBounds field.
         c = Float64Array.compare(left.histogramBounds, right.histogramBounds);
         if (c != 0) {
             return c;
         }
         
+        // Compare AggregationTemporality field.
         c = Types.Uint64Compare(left.aggregationTemporality, right.aggregationTemporality);
         if (c != 0) {
             return c;
         }
         
+        // Compare Monotonic field.
         c = Types.BoolCompare(left.monotonic, right.monotonic);
         if (c != 0) {
             return c;
@@ -444,7 +460,7 @@ public class Metric {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 8;
+        final int fieldCount = Math.max(8,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setName(Types.StringRandom(random));

--- a/java/src/main/java/com/example/oteltef/Metrics.java
+++ b/java/src/main/java/com/example/oteltef/Metrics.java
@@ -261,23 +261,29 @@ public class Metrics {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Metrics val) {
-        if (!this.envelope.equals(val.envelope)) {
+    public boolean equals(Metrics right) {
+        // Compare Envelope field.
+        if (!this.envelope.equals(right.envelope)) {
             return false;
         }
-        if (!this.metric.equals(val.metric)) {
+        // Compare Metric field.
+        if (!this.metric.equals(right.metric)) {
             return false;
         }
-        if (!this.resource.equals(val.resource)) {
+        // Compare Resource field.
+        if (!this.resource.equals(right.resource)) {
             return false;
         }
-        if (!this.scope.equals(val.scope)) {
+        // Compare Scope field.
+        if (!this.scope.equals(right.scope)) {
             return false;
         }
-        if (!this.attributes.equals(val.attributes)) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
-        if (!this.point.equals(val.point)) {
+        // Compare Point field.
+        if (!this.point.equals(right.point)) {
             return false;
         }
         return true;
@@ -301,31 +307,37 @@ public class Metrics {
         }
         int c;
         
+        // Compare Envelope field.
         c = Envelope.compare(left.envelope, right.envelope);
         if (c != 0) {
             return c;
         }
         
+        // Compare Metric field.
         c = Metric.compare(left.metric, right.metric);
         if (c != 0) {
             return c;
         }
         
+        // Compare Resource field.
         c = Resource.compare(left.resource, right.resource);
         if (c != 0) {
             return c;
         }
         
+        // Compare Scope field.
         c = Scope.compare(left.scope, right.scope);
         if (c != 0) {
             return c;
         }
         
+        // Compare Attributes field.
         c = Attributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
         }
         
+        // Compare Point field.
         c = Point.compare(left.point, right.point);
         if (c != 0) {
             return c;
@@ -336,7 +348,7 @@ public class Metrics {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 6;
+        final int fieldCount = Math.max(6,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.envelope.mutateRandom(random);

--- a/java/src/main/java/com/example/oteltef/MetricsDecoder.java
+++ b/java/src/main/java/com/example/oteltef/MetricsDecoder.java
@@ -16,12 +16,18 @@ class MetricsDecoder {
     private int fieldCount;
 
     
-    private EnvelopeDecoder envelopeDecoder = new EnvelopeDecoder();
-    private MetricDecoder metricDecoder = new MetricDecoder();
-    private ResourceDecoder resourceDecoder = new ResourceDecoder();
-    private ScopeDecoder scopeDecoder = new ScopeDecoder();
-    private AttributesDecoder attributesDecoder = new AttributesDecoder();
-    private PointDecoder pointDecoder = new PointDecoder();
+    private EnvelopeDecoder envelopeDecoder;
+    private boolean isEnvelopeRecursive = false; // Indicates Envelope field's type is recursive.
+    private MetricDecoder metricDecoder;
+    private boolean isMetricRecursive = false; // Indicates Metric field's type is recursive.
+    private ResourceDecoder resourceDecoder;
+    private boolean isResourceRecursive = false; // Indicates Resource field's type is recursive.
+    private ScopeDecoder scopeDecoder;
+    private boolean isScopeRecursive = false; // Indicates Scope field's type is recursive.
+    private AttributesDecoder attributesDecoder;
+    private boolean isAttributesRecursive = false; // Indicates Attributes field's type is recursive.
+    private PointDecoder pointDecoder;
+    private boolean isPointRecursive = false; // Indicates Point field's type is recursive.
     
 
     // Init is called once in the lifetime of the stream.
@@ -46,27 +52,69 @@ class MetricsDecoder {
             if (this.fieldCount <= 0) {
                 return; // Envelope and subsequent fields are skipped.
             }
-            envelopeDecoder.init(state, columns.addSubColumn());
+            if (state.EnvelopeDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                envelopeDecoder = state.EnvelopeDecoder;
+                isEnvelopeRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                envelopeDecoder = new EnvelopeDecoder();
+                envelopeDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 1) {
                 return; // Metric and subsequent fields are skipped.
             }
-            metricDecoder.init(state, columns.addSubColumn());
+            if (state.MetricDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                metricDecoder = state.MetricDecoder;
+                isMetricRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                metricDecoder = new MetricDecoder();
+                metricDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 2) {
                 return; // Resource and subsequent fields are skipped.
             }
-            resourceDecoder.init(state, columns.addSubColumn());
+            if (state.ResourceDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                resourceDecoder = state.ResourceDecoder;
+                isResourceRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                resourceDecoder = new ResourceDecoder();
+                resourceDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 3) {
                 return; // Scope and subsequent fields are skipped.
             }
-            scopeDecoder.init(state, columns.addSubColumn());
+            if (state.ScopeDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                scopeDecoder = state.ScopeDecoder;
+                isScopeRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                scopeDecoder = new ScopeDecoder();
+                scopeDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 4) {
                 return; // Attributes and subsequent fields are skipped.
             }
-            attributesDecoder.init(state, columns.addSubColumn());
+            if (state.AttributesDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                attributesDecoder = state.AttributesDecoder;
+                isAttributesRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                attributesDecoder = new AttributesDecoder();
+                attributesDecoder.init(state, columns.addSubColumn());
+            }
             if (this.fieldCount <= 5) {
                 return; // Point and subsequent fields are skipped.
             }
-            pointDecoder.init(state, columns.addSubColumn());
+            if (state.PointDecoder != null) {
+                // Recursion detected, use the existing decoder.
+                pointDecoder = state.PointDecoder;
+                isPointRecursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                pointDecoder = new PointDecoder();
+                pointDecoder.init(state, columns.addSubColumn());
+            }
         } finally {
             state.MetricsDecoder = null;
         }
@@ -83,36 +131,72 @@ class MetricsDecoder {
         if (this.fieldCount <= 0) {
             return; // Envelope and subsequent fields are skipped.
         }
-        this.envelopeDecoder.continueDecoding();
+        
+        if (!isEnvelopeRecursive) {
+            envelopeDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 1) {
             return; // Metric and subsequent fields are skipped.
         }
-        this.metricDecoder.continueDecoding();
+        
+        if (!isMetricRecursive) {
+            metricDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 2) {
             return; // Resource and subsequent fields are skipped.
         }
-        this.resourceDecoder.continueDecoding();
+        
+        if (!isResourceRecursive) {
+            resourceDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 3) {
             return; // Scope and subsequent fields are skipped.
         }
-        this.scopeDecoder.continueDecoding();
+        
+        if (!isScopeRecursive) {
+            scopeDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 4) {
             return; // Attributes and subsequent fields are skipped.
         }
-        this.attributesDecoder.continueDecoding();
+        
+        if (!isAttributesRecursive) {
+            attributesDecoder.continueDecoding();
+        }
+        
         if (this.fieldCount <= 5) {
             return; // Point and subsequent fields are skipped.
         }
-        this.pointDecoder.continueDecoding();
+        
+        if (!isPointRecursive) {
+            pointDecoder.continueDecoding();
+        }
+        
     }
 
     public void reset() {
-        this.envelopeDecoder.reset();
-        this.metricDecoder.reset();
-        this.resourceDecoder.reset();
-        this.scopeDecoder.reset();
-        this.attributesDecoder.reset();
-        this.pointDecoder.reset();
+        if (!isEnvelopeRecursive) {
+            envelopeDecoder.reset();
+        }
+        if (!isMetricRecursive) {
+            metricDecoder.reset();
+        }
+        if (!isResourceRecursive) {
+            resourceDecoder.reset();
+        }
+        if (!isScopeRecursive) {
+            scopeDecoder.reset();
+        }
+        if (!isAttributesRecursive) {
+            attributesDecoder.reset();
+        }
+        if (!isPointRecursive) {
+            pointDecoder.reset();
+        }
     }
 
     public Metrics decode(Metrics dstPtr) throws IOException {
@@ -123,31 +207,49 @@ class MetricsDecoder {
         
         if ((val.modifiedFields.mask & Metrics.fieldModifiedEnvelope) != 0) {
             // Field is changed and is present, decode it.
+            if (val.envelope == null) {
+                val.envelope = new Envelope(val.modifiedFields, Metrics.fieldModifiedEnvelope);
+            }
             val.envelope = envelopeDecoder.decode(val.envelope);
         }
         
         if ((val.modifiedFields.mask & Metrics.fieldModifiedMetric) != 0) {
             // Field is changed and is present, decode it.
+            if (val.metric == null) {
+                val.metric = new Metric(val.modifiedFields, Metrics.fieldModifiedMetric);
+            }
             val.metric = metricDecoder.decode(val.metric);
         }
         
         if ((val.modifiedFields.mask & Metrics.fieldModifiedResource) != 0) {
             // Field is changed and is present, decode it.
+            if (val.resource == null) {
+                val.resource = new Resource(val.modifiedFields, Metrics.fieldModifiedResource);
+            }
             val.resource = resourceDecoder.decode(val.resource);
         }
         
         if ((val.modifiedFields.mask & Metrics.fieldModifiedScope) != 0) {
             // Field is changed and is present, decode it.
+            if (val.scope == null) {
+                val.scope = new Scope(val.modifiedFields, Metrics.fieldModifiedScope);
+            }
             val.scope = scopeDecoder.decode(val.scope);
         }
         
         if ((val.modifiedFields.mask & Metrics.fieldModifiedAttributes) != 0) {
             // Field is changed and is present, decode it.
+            if (val.attributes == null) {
+                val.attributes = new Attributes(val.modifiedFields, Metrics.fieldModifiedAttributes);
+            }
             val.attributes = attributesDecoder.decode(val.attributes);
         }
         
         if ((val.modifiedFields.mask & Metrics.fieldModifiedPoint) != 0) {
             // Field is changed and is present, decode it.
+            if (val.point == null) {
+                val.point = new Point(val.modifiedFields, Metrics.fieldModifiedPoint);
+            }
             val.point = pointDecoder.decode(val.point);
         }
         

--- a/java/src/main/java/com/example/oteltef/Point.java
+++ b/java/src/main/java/com/example/oteltef/Point.java
@@ -209,17 +209,21 @@ public class Point {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Point val) {
-        if (!Types.Uint64Equal(this.startTimestamp, val.startTimestamp)) {
+    public boolean equals(Point right) {
+        // Compare StartTimestamp field.
+        if (!Types.Uint64Equal(this.startTimestamp, right.startTimestamp)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.timestamp, val.timestamp)) {
+        // Compare Timestamp field.
+        if (!Types.Uint64Equal(this.timestamp, right.timestamp)) {
             return false;
         }
-        if (!this.value.equals(val.value)) {
+        // Compare Value field.
+        if (!this.value.equals(right.value)) {
             return false;
         }
-        if (!this.exemplars.equals(val.exemplars)) {
+        // Compare Exemplars field.
+        if (!this.exemplars.equals(right.exemplars)) {
             return false;
         }
         return true;
@@ -243,21 +247,25 @@ public class Point {
         }
         int c;
         
+        // Compare StartTimestamp field.
         c = Types.Uint64Compare(left.startTimestamp, right.startTimestamp);
         if (c != 0) {
             return c;
         }
         
+        // Compare Timestamp field.
         c = Types.Uint64Compare(left.timestamp, right.timestamp);
         if (c != 0) {
             return c;
         }
         
+        // Compare Value field.
         c = PointValue.compare(left.value, right.value);
         if (c != 0) {
             return c;
         }
         
+        // Compare Exemplars field.
         c = ExemplarArray.compare(left.exemplars, right.exemplars);
         if (c != 0) {
             return c;
@@ -268,7 +276,7 @@ public class Point {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 4;
+        final int fieldCount = Math.max(4,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setStartTimestamp(Types.Uint64Random(random));

--- a/java/src/main/java/com/example/oteltef/Resource.java
+++ b/java/src/main/java/com/example/oteltef/Resource.java
@@ -178,14 +178,17 @@ public class Resource {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Resource val) {
-        if (!Types.StringEqual(this.schemaURL, val.schemaURL)) {
+    public boolean equals(Resource right) {
+        // Compare SchemaURL field.
+        if (!Types.StringEqual(this.schemaURL, right.schemaURL)) {
             return false;
         }
-        if (!this.attributes.equals(val.attributes)) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.droppedAttributesCount, val.droppedAttributesCount)) {
+        // Compare DroppedAttributesCount field.
+        if (!Types.Uint64Equal(this.droppedAttributesCount, right.droppedAttributesCount)) {
             return false;
         }
         return true;
@@ -209,16 +212,19 @@ public class Resource {
         }
         int c;
         
+        // Compare SchemaURL field.
         c = Types.StringCompare(left.schemaURL, right.schemaURL);
         if (c != 0) {
             return c;
         }
         
+        // Compare Attributes field.
         c = Attributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
         }
         
+        // Compare DroppedAttributesCount field.
         c = Types.Uint64Compare(left.droppedAttributesCount, right.droppedAttributesCount);
         if (c != 0) {
             return c;
@@ -229,7 +235,7 @@ public class Resource {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 3;
+        final int fieldCount = Math.max(3,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setSchemaURL(Types.StringRandom(random));

--- a/java/src/main/java/com/example/oteltef/Scope.java
+++ b/java/src/main/java/com/example/oteltef/Scope.java
@@ -250,20 +250,25 @@ public class Scope {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Scope val) {
-        if (!Types.StringEqual(this.name, val.name)) {
+    public boolean equals(Scope right) {
+        // Compare Name field.
+        if (!Types.StringEqual(this.name, right.name)) {
             return false;
         }
-        if (!Types.StringEqual(this.version, val.version)) {
+        // Compare Version field.
+        if (!Types.StringEqual(this.version, right.version)) {
             return false;
         }
-        if (!Types.StringEqual(this.schemaURL, val.schemaURL)) {
+        // Compare SchemaURL field.
+        if (!Types.StringEqual(this.schemaURL, right.schemaURL)) {
             return false;
         }
-        if (!this.attributes.equals(val.attributes)) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.droppedAttributesCount, val.droppedAttributesCount)) {
+        // Compare DroppedAttributesCount field.
+        if (!Types.Uint64Equal(this.droppedAttributesCount, right.droppedAttributesCount)) {
             return false;
         }
         return true;
@@ -287,26 +292,31 @@ public class Scope {
         }
         int c;
         
+        // Compare Name field.
         c = Types.StringCompare(left.name, right.name);
         if (c != 0) {
             return c;
         }
         
+        // Compare Version field.
         c = Types.StringCompare(left.version, right.version);
         if (c != 0) {
             return c;
         }
         
+        // Compare SchemaURL field.
         c = Types.StringCompare(left.schemaURL, right.schemaURL);
         if (c != 0) {
             return c;
         }
         
+        // Compare Attributes field.
         c = Attributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
         }
         
+        // Compare DroppedAttributesCount field.
         c = Types.Uint64Compare(left.droppedAttributesCount, right.droppedAttributesCount);
         if (c != 0) {
             return c;
@@ -317,7 +327,7 @@ public class Scope {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 5;
+        final int fieldCount = Math.max(5,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setName(Types.StringRandom(random));

--- a/java/src/main/java/com/example/oteltef/Span.java
+++ b/java/src/main/java/com/example/oteltef/Span.java
@@ -559,47 +559,61 @@ public class Span {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Span val) {
-        if (!Types.BytesEqual(this.traceID, val.traceID)) {
+    public boolean equals(Span right) {
+        // Compare TraceID field.
+        if (!Types.BytesEqual(this.traceID, right.traceID)) {
             return false;
         }
-        if (!Types.BytesEqual(this.spanID, val.spanID)) {
+        // Compare SpanID field.
+        if (!Types.BytesEqual(this.spanID, right.spanID)) {
             return false;
         }
-        if (!Types.StringEqual(this.traceState, val.traceState)) {
+        // Compare TraceState field.
+        if (!Types.StringEqual(this.traceState, right.traceState)) {
             return false;
         }
-        if (!Types.BytesEqual(this.parentSpanID, val.parentSpanID)) {
+        // Compare ParentSpanID field.
+        if (!Types.BytesEqual(this.parentSpanID, right.parentSpanID)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.flags, val.flags)) {
+        // Compare Flags field.
+        if (!Types.Uint64Equal(this.flags, right.flags)) {
             return false;
         }
-        if (!Types.StringEqual(this.name, val.name)) {
+        // Compare Name field.
+        if (!Types.StringEqual(this.name, right.name)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.kind, val.kind)) {
+        // Compare Kind field.
+        if (!Types.Uint64Equal(this.kind, right.kind)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.startTimeUnixNano, val.startTimeUnixNano)) {
+        // Compare StartTimeUnixNano field.
+        if (!Types.Uint64Equal(this.startTimeUnixNano, right.startTimeUnixNano)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.endTimeUnixNano, val.endTimeUnixNano)) {
+        // Compare EndTimeUnixNano field.
+        if (!Types.Uint64Equal(this.endTimeUnixNano, right.endTimeUnixNano)) {
             return false;
         }
-        if (!this.attributes.equals(val.attributes)) {
+        // Compare Attributes field.
+        if (!this.attributes.equals(right.attributes)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.droppedAttributesCount, val.droppedAttributesCount)) {
+        // Compare DroppedAttributesCount field.
+        if (!Types.Uint64Equal(this.droppedAttributesCount, right.droppedAttributesCount)) {
             return false;
         }
-        if (!this.events.equals(val.events)) {
+        // Compare Events field.
+        if (!this.events.equals(right.events)) {
             return false;
         }
-        if (!this.links.equals(val.links)) {
+        // Compare Links field.
+        if (!this.links.equals(right.links)) {
             return false;
         }
-        if (!this.status.equals(val.status)) {
+        // Compare Status field.
+        if (!this.status.equals(right.status)) {
             return false;
         }
         return true;
@@ -623,71 +637,85 @@ public class Span {
         }
         int c;
         
+        // Compare TraceID field.
         c = Types.BytesCompare(left.traceID, right.traceID);
         if (c != 0) {
             return c;
         }
         
+        // Compare SpanID field.
         c = Types.BytesCompare(left.spanID, right.spanID);
         if (c != 0) {
             return c;
         }
         
+        // Compare TraceState field.
         c = Types.StringCompare(left.traceState, right.traceState);
         if (c != 0) {
             return c;
         }
         
+        // Compare ParentSpanID field.
         c = Types.BytesCompare(left.parentSpanID, right.parentSpanID);
         if (c != 0) {
             return c;
         }
         
+        // Compare Flags field.
         c = Types.Uint64Compare(left.flags, right.flags);
         if (c != 0) {
             return c;
         }
         
+        // Compare Name field.
         c = Types.StringCompare(left.name, right.name);
         if (c != 0) {
             return c;
         }
         
+        // Compare Kind field.
         c = Types.Uint64Compare(left.kind, right.kind);
         if (c != 0) {
             return c;
         }
         
+        // Compare StartTimeUnixNano field.
         c = Types.Uint64Compare(left.startTimeUnixNano, right.startTimeUnixNano);
         if (c != 0) {
             return c;
         }
         
+        // Compare EndTimeUnixNano field.
         c = Types.Uint64Compare(left.endTimeUnixNano, right.endTimeUnixNano);
         if (c != 0) {
             return c;
         }
         
+        // Compare Attributes field.
         c = Attributes.compare(left.attributes, right.attributes);
         if (c != 0) {
             return c;
         }
         
+        // Compare DroppedAttributesCount field.
         c = Types.Uint64Compare(left.droppedAttributesCount, right.droppedAttributesCount);
         if (c != 0) {
             return c;
         }
         
+        // Compare Events field.
         c = EventArray.compare(left.events, right.events);
         if (c != 0) {
             return c;
         }
         
+        // Compare Links field.
         c = LinkArray.compare(left.links, right.links);
         if (c != 0) {
             return c;
         }
         
+        // Compare Status field.
         c = SpanStatus.compare(left.status, right.status);
         if (c != 0) {
             return c;
@@ -698,7 +726,7 @@ public class Span {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 14;
+        final int fieldCount = Math.max(14,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setTraceID(Types.BytesRandom(random));

--- a/java/src/main/java/com/example/oteltef/SpanEncoder.java
+++ b/java/src/main/java/com/example/oteltef/SpanEncoder.java
@@ -20,20 +20,34 @@ class SpanEncoder {
     private boolean forceModifiedFields;
 
     
-    private BytesEncoder traceIDEncoder = new BytesEncoder();
-    private BytesEncoder spanIDEncoder = new BytesEncoder();
-    private StringEncoder traceStateEncoder = new StringEncoder();
-    private BytesEncoder parentSpanIDEncoder = new BytesEncoder();
-    private Uint64Encoder flagsEncoder = new Uint64Encoder();
-    private StringEncoder nameEncoder = new StringEncoder();
-    private Uint64Encoder kindEncoder = new Uint64Encoder();
-    private Uint64Encoder startTimeUnixNanoEncoder = new Uint64Encoder();
-    private Uint64Encoder endTimeUnixNanoEncoder = new Uint64Encoder();
-    private AttributesEncoder attributesEncoder = new AttributesEncoder();
-    private Uint64Encoder droppedAttributesCountEncoder = new Uint64Encoder();
-    private EventArrayEncoder eventsEncoder = new EventArrayEncoder();
-    private LinkArrayEncoder linksEncoder = new LinkArrayEncoder();
-    private SpanStatusEncoder statusEncoder = new SpanStatusEncoder();
+    private BytesEncoder traceIDEncoder;
+    private boolean isTraceIDRecursive = false; // Indicates TraceID field's type is recursive.
+    private BytesEncoder spanIDEncoder;
+    private boolean isSpanIDRecursive = false; // Indicates SpanID field's type is recursive.
+    private StringEncoder traceStateEncoder;
+    private boolean isTraceStateRecursive = false; // Indicates TraceState field's type is recursive.
+    private BytesEncoder parentSpanIDEncoder;
+    private boolean isParentSpanIDRecursive = false; // Indicates ParentSpanID field's type is recursive.
+    private Uint64Encoder flagsEncoder;
+    private boolean isFlagsRecursive = false; // Indicates Flags field's type is recursive.
+    private StringEncoder nameEncoder;
+    private boolean isNameRecursive = false; // Indicates Name field's type is recursive.
+    private Uint64Encoder kindEncoder;
+    private boolean isKindRecursive = false; // Indicates Kind field's type is recursive.
+    private Uint64Encoder startTimeUnixNanoEncoder;
+    private boolean isStartTimeUnixNanoRecursive = false; // Indicates StartTimeUnixNano field's type is recursive.
+    private Uint64Encoder endTimeUnixNanoEncoder;
+    private boolean isEndTimeUnixNanoRecursive = false; // Indicates EndTimeUnixNano field's type is recursive.
+    private AttributesEncoder attributesEncoder;
+    private boolean isAttributesRecursive = false; // Indicates Attributes field's type is recursive.
+    private Uint64Encoder droppedAttributesCountEncoder;
+    private boolean isDroppedAttributesCountRecursive = false; // Indicates DroppedAttributesCount field's type is recursive.
+    private EventArrayEncoder eventsEncoder;
+    private boolean isEventsRecursive = false; // Indicates Events field's type is recursive.
+    private LinkArrayEncoder linksEncoder;
+    private boolean isLinksRecursive = false; // Indicates Links field's type is recursive.
+    private SpanStatusEncoder statusEncoder;
+    private boolean isStatusRecursive = false; // Indicates Status field's type is recursive.
     
 
     private long keepFieldMask;
@@ -59,62 +73,114 @@ class SpanEncoder {
             }
 
             
+            // Init encoder for TraceID field.
             if (this.fieldCount <= 0) {
                 return; // TraceID and subsequent fields are skipped.
             }
+            traceIDEncoder = new BytesEncoder();
             this.traceIDEncoder.init(null, this.limiter, columns.addSubColumn());
+            // Init encoder for SpanID field.
             if (this.fieldCount <= 1) {
                 return; // SpanID and subsequent fields are skipped.
             }
+            spanIDEncoder = new BytesEncoder();
             this.spanIDEncoder.init(null, this.limiter, columns.addSubColumn());
+            // Init encoder for TraceState field.
             if (this.fieldCount <= 2) {
                 return; // TraceState and subsequent fields are skipped.
             }
+            traceStateEncoder = new StringEncoder();
             this.traceStateEncoder.init(null, this.limiter, columns.addSubColumn());
+            // Init encoder for ParentSpanID field.
             if (this.fieldCount <= 3) {
                 return; // ParentSpanID and subsequent fields are skipped.
             }
+            parentSpanIDEncoder = new BytesEncoder();
             this.parentSpanIDEncoder.init(null, this.limiter, columns.addSubColumn());
+            // Init encoder for Flags field.
             if (this.fieldCount <= 4) {
                 return; // Flags and subsequent fields are skipped.
             }
+            flagsEncoder = new Uint64Encoder();
             this.flagsEncoder.init(this.limiter, columns.addSubColumn());
+            // Init encoder for Name field.
             if (this.fieldCount <= 5) {
                 return; // Name and subsequent fields are skipped.
             }
+            nameEncoder = new StringEncoder();
             this.nameEncoder.init(state.SpanName, this.limiter, columns.addSubColumn());
+            // Init encoder for Kind field.
             if (this.fieldCount <= 6) {
                 return; // Kind and subsequent fields are skipped.
             }
+            kindEncoder = new Uint64Encoder();
             this.kindEncoder.init(this.limiter, columns.addSubColumn());
+            // Init encoder for StartTimeUnixNano field.
             if (this.fieldCount <= 7) {
                 return; // StartTimeUnixNano and subsequent fields are skipped.
             }
+            startTimeUnixNanoEncoder = new Uint64Encoder();
             this.startTimeUnixNanoEncoder.init(this.limiter, columns.addSubColumn());
+            // Init encoder for EndTimeUnixNano field.
             if (this.fieldCount <= 8) {
                 return; // EndTimeUnixNano and subsequent fields are skipped.
             }
+            endTimeUnixNanoEncoder = new Uint64Encoder();
             this.endTimeUnixNanoEncoder.init(this.limiter, columns.addSubColumn());
+            // Init encoder for Attributes field.
             if (this.fieldCount <= 9) {
                 return; // Attributes and subsequent fields are skipped.
             }
-            this.attributesEncoder.init(state, columns.addSubColumn());
+            if (state.AttributesEncoder != null) {
+                // Recursion detected, use the existing encoder.
+                attributesEncoder = state.AttributesEncoder;
+                isAttributesRecursive = true;
+            } else {
+                attributesEncoder = new AttributesEncoder();
+                attributesEncoder.init(state, columns.addSubColumn());
+            }
+            // Init encoder for DroppedAttributesCount field.
             if (this.fieldCount <= 10) {
                 return; // DroppedAttributesCount and subsequent fields are skipped.
             }
+            droppedAttributesCountEncoder = new Uint64Encoder();
             this.droppedAttributesCountEncoder.init(this.limiter, columns.addSubColumn());
+            // Init encoder for Events field.
             if (this.fieldCount <= 11) {
                 return; // Events and subsequent fields are skipped.
             }
-            this.eventsEncoder.init(state, columns.addSubColumn());
+            if (state.EventArrayEncoder != null) {
+                // Recursion detected, use the existing encoder.
+                eventsEncoder = state.EventArrayEncoder;
+                isEventsRecursive = true;
+            } else {
+                eventsEncoder = new EventArrayEncoder();
+                eventsEncoder.init(state, columns.addSubColumn());
+            }
+            // Init encoder for Links field.
             if (this.fieldCount <= 12) {
                 return; // Links and subsequent fields are skipped.
             }
-            this.linksEncoder.init(state, columns.addSubColumn());
+            if (state.LinkArrayEncoder != null) {
+                // Recursion detected, use the existing encoder.
+                linksEncoder = state.LinkArrayEncoder;
+                isLinksRecursive = true;
+            } else {
+                linksEncoder = new LinkArrayEncoder();
+                linksEncoder.init(state, columns.addSubColumn());
+            }
+            // Init encoder for Status field.
             if (this.fieldCount <= 13) {
                 return; // Status and subsequent fields are skipped.
             }
-            this.statusEncoder.init(state, columns.addSubColumn());
+            if (state.SpanStatusEncoder != null) {
+                // Recursion detected, use the existing encoder.
+                statusEncoder = state.SpanStatusEncoder;
+                isStatusRecursive = true;
+            } else {
+                statusEncoder = new SpanStatusEncoder();
+                statusEncoder.init(state, columns.addSubColumn());
+            }
         } finally {
             state.SpanEncoder = null;
         }
@@ -122,22 +188,38 @@ class SpanEncoder {
 
     public void reset() {
         // Since we are resetting the state of encoder make sure the next encode()
-        // call forcedly writes all fields and does not attempt to skip.
+        // call forcefully writes all fields and does not attempt to skip.
         this.forceModifiedFields = true;
-        this.traceIDEncoder.reset();
-        this.spanIDEncoder.reset();
-        this.traceStateEncoder.reset();
-        this.parentSpanIDEncoder.reset();
-        this.flagsEncoder.reset();
-        this.nameEncoder.reset();
-        this.kindEncoder.reset();
-        this.startTimeUnixNanoEncoder.reset();
-        this.endTimeUnixNanoEncoder.reset();
-        this.attributesEncoder.reset();
-        this.droppedAttributesCountEncoder.reset();
-        this.eventsEncoder.reset();
-        this.linksEncoder.reset();
-        this.statusEncoder.reset();
+        traceIDEncoder.reset();
+        spanIDEncoder.reset();
+        traceStateEncoder.reset();
+        parentSpanIDEncoder.reset();
+        flagsEncoder.reset();
+        nameEncoder.reset();
+        kindEncoder.reset();
+        startTimeUnixNanoEncoder.reset();
+        endTimeUnixNanoEncoder.reset();
+        
+        if (!isAttributesRecursive) {
+            attributesEncoder.reset();
+        }
+        
+        droppedAttributesCountEncoder.reset();
+        
+        if (!isEventsRecursive) {
+            eventsEncoder.reset();
+        }
+        
+        
+        if (!isLinksRecursive) {
+            linksEncoder.reset();
+        }
+        
+        
+        if (!isStatusRecursive) {
+            statusEncoder.reset();
+        }
+        
     }
 
     // encode encodes val into buf
@@ -258,63 +340,124 @@ class SpanEncoder {
     // collectColumns collects all buffers from all encoders into buf.
     public void collectColumns(WriteColumnSet columnSet) {
         columnSet.setBits(this.buf);
+        int colIdx = 0;
         
+        // Collect TraceID field.
         if (this.fieldCount <= 0) {
             return; // TraceID and subsequent fields are skipped.
         }
-        this.traceIDEncoder.collectColumns(columnSet.at(0));
+        
+        traceIDEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect SpanID field.
         if (this.fieldCount <= 1) {
             return; // SpanID and subsequent fields are skipped.
         }
-        this.spanIDEncoder.collectColumns(columnSet.at(1));
+        
+        spanIDEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect TraceState field.
         if (this.fieldCount <= 2) {
             return; // TraceState and subsequent fields are skipped.
         }
-        this.traceStateEncoder.collectColumns(columnSet.at(2));
+        
+        traceStateEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect ParentSpanID field.
         if (this.fieldCount <= 3) {
             return; // ParentSpanID and subsequent fields are skipped.
         }
-        this.parentSpanIDEncoder.collectColumns(columnSet.at(3));
+        
+        parentSpanIDEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect Flags field.
         if (this.fieldCount <= 4) {
             return; // Flags and subsequent fields are skipped.
         }
-        this.flagsEncoder.collectColumns(columnSet.at(4));
+        
+        flagsEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect Name field.
         if (this.fieldCount <= 5) {
             return; // Name and subsequent fields are skipped.
         }
-        this.nameEncoder.collectColumns(columnSet.at(5));
+        
+        nameEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect Kind field.
         if (this.fieldCount <= 6) {
             return; // Kind and subsequent fields are skipped.
         }
-        this.kindEncoder.collectColumns(columnSet.at(6));
+        
+        kindEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect StartTimeUnixNano field.
         if (this.fieldCount <= 7) {
             return; // StartTimeUnixNano and subsequent fields are skipped.
         }
-        this.startTimeUnixNanoEncoder.collectColumns(columnSet.at(7));
+        
+        startTimeUnixNanoEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect EndTimeUnixNano field.
         if (this.fieldCount <= 8) {
             return; // EndTimeUnixNano and subsequent fields are skipped.
         }
-        this.endTimeUnixNanoEncoder.collectColumns(columnSet.at(8));
+        
+        endTimeUnixNanoEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect Attributes field.
         if (this.fieldCount <= 9) {
             return; // Attributes and subsequent fields are skipped.
         }
-        this.attributesEncoder.collectColumns(columnSet.at(9));
+        if (!isAttributesRecursive) {
+            attributesEncoder.collectColumns(columnSet.at(colIdx));
+            colIdx++;
+        }
+        
+        // Collect DroppedAttributesCount field.
         if (this.fieldCount <= 10) {
             return; // DroppedAttributesCount and subsequent fields are skipped.
         }
-        this.droppedAttributesCountEncoder.collectColumns(columnSet.at(10));
+        
+        droppedAttributesCountEncoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        
+        // Collect Events field.
         if (this.fieldCount <= 11) {
             return; // Events and subsequent fields are skipped.
         }
-        this.eventsEncoder.collectColumns(columnSet.at(11));
+        if (!isEventsRecursive) {
+            eventsEncoder.collectColumns(columnSet.at(colIdx));
+            colIdx++;
+        }
+        
+        // Collect Links field.
         if (this.fieldCount <= 12) {
             return; // Links and subsequent fields are skipped.
         }
-        this.linksEncoder.collectColumns(columnSet.at(12));
+        if (!isLinksRecursive) {
+            linksEncoder.collectColumns(columnSet.at(colIdx));
+            colIdx++;
+        }
+        
+        // Collect Status field.
         if (this.fieldCount <= 13) {
             return; // Status and subsequent fields are skipped.
         }
-        this.statusEncoder.collectColumns(columnSet.at(13));
+        if (!isStatusRecursive) {
+            statusEncoder.collectColumns(columnSet.at(colIdx));
+            colIdx++;
+        }
+        
     }
 }
 

--- a/java/src/main/java/com/example/oteltef/SpanStatus.java
+++ b/java/src/main/java/com/example/oteltef/SpanStatus.java
@@ -147,11 +147,13 @@ public class SpanStatus {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(SpanStatus val) {
-        if (!Types.StringEqual(this.message, val.message)) {
+    public boolean equals(SpanStatus right) {
+        // Compare Message field.
+        if (!Types.StringEqual(this.message, right.message)) {
             return false;
         }
-        if (!Types.Uint64Equal(this.code, val.code)) {
+        // Compare Code field.
+        if (!Types.Uint64Equal(this.code, right.code)) {
             return false;
         }
         return true;
@@ -175,11 +177,13 @@ public class SpanStatus {
         }
         int c;
         
+        // Compare Message field.
         c = Types.StringCompare(left.message, right.message);
         if (c != 0) {
             return c;
         }
         
+        // Compare Code field.
         c = Types.Uint64Compare(left.code, right.code);
         if (c != 0) {
             return c;
@@ -190,7 +194,7 @@ public class SpanStatus {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 2;
+        final int fieldCount = Math.max(2,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.setMessage(Types.StringRandom(random));

--- a/java/src/main/java/com/example/oteltef/SpanStatusDecoder.java
+++ b/java/src/main/java/com/example/oteltef/SpanStatusDecoder.java
@@ -16,8 +16,10 @@ class SpanStatusDecoder {
     private int fieldCount;
 
     
-    private StringDecoder messageDecoder = new StringDecoder();
-    private Uint64Decoder codeDecoder = new Uint64Decoder();
+    private StringDecoder messageDecoder;
+    private boolean isMessageRecursive = false; // Indicates Message field's type is recursive.
+    private Uint64Decoder codeDecoder;
+    private boolean isCodeRecursive = false; // Indicates Code field's type is recursive.
     
 
     // Init is called once in the lifetime of the stream.
@@ -42,10 +44,12 @@ class SpanStatusDecoder {
             if (this.fieldCount <= 0) {
                 return; // Message and subsequent fields are skipped.
             }
+            messageDecoder = new StringDecoder();
             messageDecoder.init(null, columns.addSubColumn());
             if (this.fieldCount <= 1) {
                 return; // Code and subsequent fields are skipped.
             }
+            codeDecoder = new Uint64Decoder();
             codeDecoder.init(columns.addSubColumn());
         } finally {
             state.SpanStatusDecoder = null;
@@ -63,16 +67,16 @@ class SpanStatusDecoder {
         if (this.fieldCount <= 0) {
             return; // Message and subsequent fields are skipped.
         }
-        this.messageDecoder.continueDecoding();
+        messageDecoder.continueDecoding();
         if (this.fieldCount <= 1) {
             return; // Code and subsequent fields are skipped.
         }
-        this.codeDecoder.continueDecoding();
+        codeDecoder.continueDecoding();
     }
 
     public void reset() {
-        this.messageDecoder.reset();
-        this.codeDecoder.reset();
+        messageDecoder.reset();
+        codeDecoder.reset();
     }
 
     public SpanStatus decode(SpanStatus dstPtr) throws IOException {

--- a/java/src/main/java/com/example/oteltef/Spans.java
+++ b/java/src/main/java/com/example/oteltef/Spans.java
@@ -199,17 +199,21 @@ public class Spans {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals(Spans val) {
-        if (!this.envelope.equals(val.envelope)) {
+    public boolean equals(Spans right) {
+        // Compare Envelope field.
+        if (!this.envelope.equals(right.envelope)) {
             return false;
         }
-        if (!this.resource.equals(val.resource)) {
+        // Compare Resource field.
+        if (!this.resource.equals(right.resource)) {
             return false;
         }
-        if (!this.scope.equals(val.scope)) {
+        // Compare Scope field.
+        if (!this.scope.equals(right.scope)) {
             return false;
         }
-        if (!this.span.equals(val.span)) {
+        // Compare Span field.
+        if (!this.span.equals(right.span)) {
             return false;
         }
         return true;
@@ -233,21 +237,25 @@ public class Spans {
         }
         int c;
         
+        // Compare Envelope field.
         c = Envelope.compare(left.envelope, right.envelope);
         if (c != 0) {
             return c;
         }
         
+        // Compare Resource field.
         c = Resource.compare(left.resource, right.resource);
         if (c != 0) {
             return c;
         }
         
+        // Compare Scope field.
         c = Scope.compare(left.scope, right.scope);
         if (c != 0) {
             return c;
         }
         
+        // Compare Span field.
         c = Span.compare(left.span, right.span);
         if (c != 0) {
             return c;
@@ -258,7 +266,7 @@ public class Spans {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = 4;
+        final int fieldCount = Math.max(4,2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         
         if (random.nextInt(fieldCount) == 0) {
             this.envelope.mutateRandom(random);

--- a/stefgen/generator/testdata/struct_recurse_mutual.stef
+++ b/stefgen/generator/testdata/struct_recurse_mutual.stef
@@ -1,0 +1,13 @@
+package com.example.gentest.struct_recurse_mutual
+
+struct Root root {
+  RStruct1 RStruct1
+}
+
+struct RStruct1 {
+  RStruct2 RStruct2 optional
+}
+
+struct RStruct2 {
+  RStruct1 RStruct1 optional
+}

--- a/stefgen/generator/testdata/struct_recurse_oneof.stef
+++ b/stefgen/generator/testdata/struct_recurse_oneof.stef
@@ -1,0 +1,13 @@
+package com.example.gentest.struct_recurse_oneof
+
+struct Root root {
+  RStruct RStruct
+}
+
+struct RStruct {
+  ROneof ROneof optional
+}
+
+oneof ROneof {
+  RStruct RStruct
+}

--- a/stefgen/generator/testdata/struct_recurse_self.stef
+++ b/stefgen/generator/testdata/struct_recurse_self.stef
@@ -1,0 +1,9 @@
+package com.example.gentest.struct_recurse_self
+
+struct Root root {
+  RStruct RStruct
+}
+
+struct RStruct {
+  RStruct RStruct optional
+}

--- a/stefgen/templates/go/struct.go.tmpl
+++ b/stefgen/templates/go/struct.go.tmpl
@@ -71,11 +71,15 @@ func (s *{{ $.StructName }}) init(parentModifiedFields *modifiedFields, parentMo
     s.modifiedFields.parentBit = parentModifiedBit
 
     {{ range .Fields }}
+    {{- if not .Type.IsPrimitive }}
     {{- if .Type.Flags.StoreByPtr}}
+    {{- if not .Optional}}
     s.{{.name}} = &{{ .Type.Storage }}{}
-    {{- end }}
-	{{- if not .Type.IsPrimitive }}
     s.{{.name}}.init(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+    {{- end}}
+    {{- else }}
+    s.{{.name}}.init(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+    {{- end }}
     {{- end -}}
     {{- end -}}
 }
@@ -177,8 +181,8 @@ func (s *{{ $.StructName }}) markDiffModified(v *{{ $.StructName }}) (modified b
     return modified
 }
 
-func (s *{{ .StructName }}) Clone() {{if .DictName}}*{{end}}{{.StructName}} {
-	return {{if .DictName}}&{{end}}{{ .StructName }}{
+func (s *{{ .StructName }}) Clone() {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
+	return {{if .Type.Flags.StoreByPtr}}&{{end}}{{ .StructName }}{
         {{ range .Fields }}{{.name}}: {{if .Type.MustClone}}s.{{.name}}.Clone(){{else}}s.{{.name}}{{end}},
         {{ end }}
 	}
@@ -196,9 +200,19 @@ func (s *{{ .StructName }}) byteSize() uint {
 func copy{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}) {
     {{- range .Fields -}}
     {{- if .Type.MustClone}}
-    copy{{.Type.TypeName}}(
-        {{- if .Type.Flags.TakePtr}}&{{end}}dst.{{.name }},
-        {{- if .Type.Flags.TakePtr}}&{{end}}src.{{.name}})
+    {{- if .Type.Flags.StoreByPtr}}
+    if src.{{.name}} != nil {
+        if dst.{{.name}} == nil {
+            dst.{{.name}} = &{{ .Type.Storage }}{}
+            dst.{{.name}}.init(&dst.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+        }
+    {{- end}}
+        copy{{.Type.TypeName}}(
+            {{- if .Type.Flags.TakePtr}}&{{end}}dst.{{.name }},
+            {{- if .Type.Flags.TakePtr}}&{{end}}src.{{.name}})
+    {{- if .Type.Flags.StoreByPtr}}
+    }
+    {{- end}}
     {{- else}}
 	{{- if .Optional}}
 	if src.Has{{.Name}}() {
@@ -234,11 +248,23 @@ func (s* {{.StructName}}) markUnmodified() {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator.
 func (s *{{ .StructName }}) mutateRandom(random *rand.Rand) {
-    const fieldCount = {{len .Fields}}
+    const fieldCount = max({{len .Fields}},2) // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
 {{- range .Fields }}
     if random.IntN(fieldCount)==0 {
     {{- if not .Type.IsPrimitive }}
+        {{- if .Optional}}
+        // Flip the optional field presence bit.
+        s.optionalFieldsPresent ^= fieldPresent{{ $.StructName }}{{.Name}}
+        if s.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} !=0 {
+            if s.{{.name}} == nil {
+                s.{{.name}} = &{{ .Type.Storage }}{}
+                s.{{.name}}.init(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+            }
+            s.{{.name}}.mutateRandom(random)
+        }
+        {{- else}}
         s.{{.name}}.mutateRandom(random)
+        {{- end}}
     {{- else }}
         s.Set{{.Name}}({{.Type.RandomFunc}})
     {{- end}}
@@ -246,18 +272,30 @@ func (s *{{ .StructName }}) mutateRandom(random *rand.Rand) {
 {{- end }}
 }
 
-// IsEqual performs deep comparison and returns true if struct is equal to val.
-func (e *{{ .StructName }}) IsEqual(val *{{ .StructName }}) bool {
+// IsEqual performs deep comparison and returns true if struct is equal to right.
+func (s *{{ .StructName }}) IsEqual(right *{{ .StructName }}) bool {
     {{- range .Fields }}
+    // Compare {{.Name}} field.
+    {{- if .Optional}}
+    s{{.Name}}Present := s.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0
+    right{{.Name}}Present := right.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0
+    if s{{.Name}}Present != right{{.Name}}Present{
+        return false
+    }
+    if s{{.Name}}Present { // Compare only if {{.Name}} field is present
+    {{- end}}
     {{- if .Type.IsPrimitive }}
-    if !{{ .Type.EqualFunc }}(e.{{.name}}, val.{{.name}}) {
+    if !{{ .Type.EqualFunc }}(s.{{.name}}, right.{{.name}}) {
         return false
     }
     {{- else }}
-    if !e.{{.name}}.IsEqual({{- if .Type.Flags.TakePtr}}&{{end}}val.{{.name}}) {
+    if !s.{{.name}}.IsEqual({{- if .Type.Flags.TakePtr}}&{{end}}right.{{.name}}) {
         return false
     }
     {{- end }}
+    {{- if .Optional}}
+    }
+    {{end}}
     {{- end }}
 
     return true
@@ -280,12 +318,23 @@ func Cmp{{.StructName}}(left, right *{{.StructName}}) int {
         return 1
     }
     {{ range .Fields }}
+    // Compare {{.Name}} field.
+    {{- if .Optional}}
+    left{{.Name}}Present := left.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0
+    right{{.Name}}Present := right.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0
+    if left{{.Name}}Present != right{{.Name}}Present{
+        if left{{.Name}}Present {
+            return 1
+        }
+        return -1
+    }
+    {{- end}}
     if c := {{ .Type.CompareFunc }}(
             {{- if .Type.Flags.TakePtr}}&{{end}}left.{{.name}},
             {{- if .Type.Flags.TakePtr}}&{{end}}right.{{.name}}); c != 0 {
         return c
-    }{{ end }}
-
+    }
+    {{ end }}
     return 0
 }
 
@@ -301,7 +350,9 @@ type {{ .StructName }}Encoder struct {
     forceModifiedFields bool
 
     {{ range .Fields }}
-    {{.name}}Encoder {{ .Type.EncoderType }}Encoder
+    {{.name}}Encoder {{if not .IsPrimitive}}*{{end}}{{ .Type.EncoderType }}Encoder
+    {{if not .IsPrimitive}}is{{.Name}}Recursive bool // Indicates {{.Name}} field's type is recursive.
+    {{end}}
     {{- end }}
     {{if .DictName}}
 	dict *{{ .StructName }}EncoderDict{{end}}
@@ -365,27 +416,33 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
         e.keepFieldMask = ^uint64(0)
     }
 
+    var err error
     {{ range $i, $e := .Fields }}
+    // Init encoder for {{.Name}} field.
     if e.fieldCount <= {{$i}} {
-        return nil // {{.Name}} and subsequent fields are skipped.
+        // {{.Name}} and all subsequent fields are skipped.
+        return nil
     }
     {{- if .IsPrimitive}}
         {{- if .Type.DictName}}
-        if err := e.{{.name}}Encoder.Init(&state.{{.Type.DictName}}, e.limiter, columns.AddSubColumn()); err != nil {
-            return err
-        }
+        err = e.{{.name}}Encoder.Init(&state.{{.Type.DictName}}, e.limiter, columns.AddSubColumn())
         {{- else}}
-        if err := e.{{.name}}Encoder.Init({{if .Type.IsDictPossible}}nil, {{end}}e.limiter, columns.AddSubColumn()); err != nil {
-            return err
-        }
+        err = e.{{.name}}Encoder.Init({{if .Type.IsDictPossible}}nil, {{end}}e.limiter, columns.AddSubColumn())
         {{- end}}
     {{- else}}
-    if err := e.{{.name}}Encoder.Init(state, columns.AddSubColumn()); err != nil {
-        return err
+    if state.{{.Type.EncoderType}}Encoder != nil {
+        // Recursion detected, use the existing encoder.
+        e.{{.name}}Encoder = state.{{.Type.EncoderType}}Encoder
+        e.is{{.Name}}Recursive = true
+    } else {
+        e.{{.name}}Encoder = new({{.Type.EncoderType}}Encoder)
+        err = e.{{.name}}Encoder.Init(state, columns.AddSubColumn())
     }
     {{- end}}
-    {{- end}}
-
+    if err != nil {
+        return err
+    }
+    {{end}}
     return nil
 }
 
@@ -395,7 +452,11 @@ func (e *{{ .StructName }}Encoder) Reset() {
     e.forceModifiedFields = true
 
     {{- range .Fields}}
-    e.{{.name}}Encoder.Reset()
+    {{if not .IsPrimitive}}
+    if !e.is{{.Name}}Recursive {
+        e.{{.name}}Encoder.Reset()
+    }
+    {{else}}e.{{.name}}Encoder.Reset(){{end}}
     {{- end}}
 }
 
@@ -480,12 +541,22 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
 // CollectColumns collects all buffers from all encoders into buf.
 func (e *{{ .StructName }}Encoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
     columnSet.SetBits(&e.buf)
-	{{ range $i,$e := .Fields }}
+    colIdx := 0
+    {{ range $i,$e := .Fields }}
+    // Collect {{.Name}} field.
     if e.fieldCount <= {{$i}} {
         return // {{.Name}} and subsequent fields are skipped.
     }
-	e.{{.name}}Encoder.CollectColumns(columnSet.At({{$i}}))
-    {{- end }}
+    {{if not .IsPrimitive -}}
+    if !e.is{{.Name}}Recursive {
+        e.{{.name}}Encoder.CollectColumns(columnSet.At(colIdx))
+        colIdx++
+    }
+    {{else}}
+    e.{{.name}}Encoder.CollectColumns(columnSet.At(colIdx))
+    colIdx++
+    {{end -}}
+    {{end -}}
 }
 
 // {{ .StructName }}Decoder implements decoding of {{ .StructName }}
@@ -497,7 +568,9 @@ type {{ .StructName }}Decoder struct {
     fieldCount uint
 
     {{ range .Fields }}
-    {{.name}}Decoder {{ .Type.EncoderType }}Decoder
+    {{.name}}Decoder {{if not .IsPrimitive}}*{{end}}{{ .Type.EncoderType }}Decoder
+    {{if not .IsPrimitive}}is{{.Name}}Recursive bool
+    {{end}}
     {{- end }}
     {{if .DictName}}
     dict *{{ .StructName }}DecoderDict
@@ -553,11 +626,18 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
             err = d.{{.name}}Decoder.Init(columns.AddSubColumn())
         {{- end}}
     {{- else}}
+    if state.{{.Type.EncoderType}}Decoder != nil {
+        // Recursion detected, use the existing decoder.
+        d.{{.name}}Decoder = state.{{.Type.EncoderType}}Decoder
+        d.is{{.Name}}Recursive = true // Mark that we are using a recursive decoder.
+    } else {
+        d.{{.name}}Decoder = new({{.Type.EncoderType}}Decoder)
         err = d.{{.name}}Decoder.Init(state, columns.AddSubColumn())
+    }
     {{- end}}
-        if err != nil {
-            return err
-        }
+    if err != nil {
+        return err
+    }
     {{- end }}
 
     return nil
@@ -575,13 +655,21 @@ func (d *{{ .StructName }}Decoder) Continue() {
     if d.fieldCount <= {{$i}} {
         return // {{.Name}} and subsequent fields are skipped.
     }
-    d.{{.name}}Decoder.Continue()
+    {{if not .IsPrimitive}}
+    if !d.is{{.Name}}Recursive {
+        d.{{.name}}Decoder.Continue()
+    }
+    {{else}}d.{{.name}}Decoder.Continue(){{end}}
     {{- end }}
 }
 
 func (d *{{ .StructName }}Decoder) Reset() {
     {{- range .Fields}}
-    d.{{.name}}Decoder.Reset()
+    {{if not .IsPrimitive}}
+    if !d.is{{.Name}}Recursive {
+        d.{{.name}}Decoder.Reset()
+    }
+    {{else}}d.{{.name}}Decoder.Reset(){{end}}
     {{- end}}
 }
 
@@ -625,6 +713,12 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
     val.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0
     {{- end}} {
 		// Field is changed and is present, decode it.
+        {{- if .Type.Flags.StoreByPtr}}
+        if val.{{.name}} == nil {
+            val.{{.name}} = &{{ .Type.Storage }}{}
+            val.{{.name}}.init(&val.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+        }
+        {{end}}
  		err = d.{{.name}}Decoder.Decode({{if .Type.Flags.DecodeByPtr}}&{{end}}val.{{.name}})
         if err != nil {
             return err

--- a/stefgen/templates/java/struct.java.tmpl
+++ b/stefgen/templates/java/struct.java.tmpl
@@ -55,7 +55,9 @@ public class {{ .StructName }} {
         {{- if .Type.IsPrimitive }}
         {{if .Type.InitVal}}{{.name}} = {{.Type.InitVal}};{{end}}
         {{- else}}
+        {{- if not .Optional}}
         {{.name}} = new {{ .Type.Storage }}(modifiedFields, fieldModified{{.Name}});
+        {{- end}}
         {{- end }}
         {{- end }}
     }
@@ -190,7 +192,16 @@ public class {{ .StructName }} {
     public void copyFrom({{.StructName}} src) {
         {{- range .Fields }}
         {{- if .Type.MustClone }}
+        {{- if .Optional }}
+        if (src.{{.name}} != null) {
+            if ({{.name}} == null) {
+               {{.name}} = new {{ .Type.Storage }}(modifiedFields, fieldModified{{.Name}});
+            }
+            {{.name }}.copyFrom(src.{{.name}});
+        }
+        {{- else }}
         {{.name }}.copyFrom(src.{{.name}});
+        {{- end}}
         {{- else }}
         {{- if .Optional }}
         if (src.has{{.Name}}()) {
@@ -206,17 +217,29 @@ public class {{ .StructName }} {
     }
 
     // equals performs deep comparison and returns true if struct is equal to val.
-    public boolean equals({{ .StructName }} val) {
+    public boolean equals({{ .StructName }} right) {
         {{- range .Fields }}
+        // Compare {{.Name}} field.
+        {{- if .Optional}}
+        boolean this{{.Name}}Present = (this.optionalFieldsPresent & fieldPresent{{.Name}}) != 0;
+        boolean right{{.Name}}Present = (right.optionalFieldsPresent & fieldPresent{{.Name}}) != 0;
+        if (this{{.Name}}Present != right{{.Name}}Present) {
+            return false;
+        }
+        if (this{{.Name}}Present) { // Compare only if {{.Name}} field is present
+        {{- end}}
         {{- if .Type.IsPrimitive }}
-        if (!{{ .Type.EqualFunc }}(this.{{.name}}, val.{{.name}})) {
+        if (!{{ .Type.EqualFunc }}(this.{{.name}}, right.{{.name}})) {
             return false;
         }
         {{- else }}
-        if (!this.{{.name}}.equals(val.{{.name}})) {
+        if (!this.{{.name}}.equals(right.{{.name}})) {
             return false;
         }
         {{- end }}
+        {{- if .Optional}}
+        }
+        {{end}}
         {{- end }}
         return true;
     }
@@ -239,6 +262,17 @@ public class {{ .StructName }} {
         }
         int c;
         {{ range .Fields }}
+        // Compare {{.Name}} field.
+        {{- if .Optional}}
+        boolean left{{.Name}}Present = (left.optionalFieldsPresent & fieldPresent{{.Name}}) != 0;
+        boolean right{{.Name}}Present = (right.optionalFieldsPresent & fieldPresent{{.Name}}) != 0;
+        if (left{{.Name}}Present != right{{.Name}}Present) {
+            if (left{{.Name}}Present) {
+                return 1;
+            }
+            return -1;
+        }
+        {{- end}}
         c = {{ .Type.CompareFunc }}(left.{{.name}}, right.{{.name}});
         if (c != 0) {
             return c;
@@ -249,11 +283,22 @@ public class {{ .StructName }} {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random) {
-        final int fieldCount = {{len .Fields}};
+        final int fieldCount = Math.max({{len .Fields}},2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
         {{ range .Fields }}
         if (random.nextInt(fieldCount) == 0) {
             {{- if not .Type.IsPrimitive }}
+            {{- if .Optional}}
+            // Flip the optional field presence bit.
+            this.optionalFieldsPresent ^= fieldPresent{{.Name}};
+            if ((this.optionalFieldsPresent & fieldPresent{{.Name}}) !=0) {
+                if (this.{{.name}} == null) {
+                    this.{{.name}} = new {{ .Type.Storage }}(this.modifiedFields, fieldModified{{.Name}});
+                }
+                this.{{.name}}.mutateRandom(random);
+            }
+            {{- else}}
             this.{{.name}}.mutateRandom(random);
+            {{- end}}
             {{- else }}
             this.set{{.Name}}({{.Type.RandomFunc}});
             {{- end }}

--- a/stefgen/templates/java/structDecoder.java.tmpl
+++ b/stefgen/templates/java/structDecoder.java.tmpl
@@ -15,7 +15,8 @@ class {{ .StructName }}Decoder {
     private int fieldCount;
 
     {{ range .Fields }}
-    private {{ .Type.EncoderType }}Decoder {{.name}}Decoder = new {{ .Type.EncoderType }}Decoder();
+    private {{ .Type.EncoderType }}Decoder {{.name}}Decoder;
+    private boolean is{{.Name}}Recursive = false; // Indicates {{.Name}} field's type is recursive.
     {{- end }}
     {{if .DictName}}
     private {{ .StructName }}DecoderDict dict;
@@ -50,15 +51,23 @@ class {{ .StructName }}Decoder {
                 return; // {{.Name}} and subsequent fields are skipped.
             }
             {{- if .Type.IsPrimitive}}
-                {{- if .Type.DictName}}
+            {{.name}}Decoder = new {{.Type.EncoderType}}Decoder();
+            {{- if .Type.DictName}}
             {{.name}}Decoder.init(state.{{.Type.DictName}}, columns.addSubColumn());
-                {{- else if .Type.IsDictPossible}}
+            {{- else if .Type.IsDictPossible}}
             {{.name}}Decoder.init(null, columns.addSubColumn());
-                {{- else}}
-            {{.name}}Decoder.init(columns.addSubColumn());
-                {{- end}}
             {{- else}}
-            {{.name}}Decoder.init(state, columns.addSubColumn());
+            {{.name}}Decoder.init(columns.addSubColumn());
+            {{- end}}
+            {{- else}}
+            if (state.{{.Type.EncoderType}}Decoder != null) {
+                // Recursion detected, use the existing decoder.
+                {{.name}}Decoder = state.{{.Type.EncoderType}}Decoder;
+                is{{.Name}}Recursive = true; // Mark that we are using a recursive decoder.
+            } else {
+                {{.name}}Decoder = new {{.Type.EncoderType}}Decoder();
+                {{.name}}Decoder.init(state, columns.addSubColumn());
+            }
             {{- end}}
             {{- end }}
         } finally {
@@ -77,13 +86,23 @@ class {{ .StructName }}Decoder {
         if (this.fieldCount <= {{$i}}) {
             return; // {{.Name}} and subsequent fields are skipped.
         }
-        this.{{.name}}Decoder.continueDecoding();
+        {{if not .IsPrimitive}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Decoder.continueDecoding();
+        }
+        {{else}}{{.name}}Decoder.continueDecoding();{{end}}
         {{- end }}
     }
 
     public void reset() {
         {{- range .Fields}}
-        this.{{.name}}Decoder.reset();
+        {{if not .IsPrimitive -}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Decoder.reset();
+        }
+        {{- else -}}
+        {{.name}}Decoder.reset();
+        {{- end}}
         {{- end}}
     }
 
@@ -119,7 +138,14 @@ class {{ .StructName }}Decoder {
         if ((val.modifiedFields.mask & {{ $.StructName }}.fieldModified{{.Name}}) != 0
             {{- if .Optional}} && (val.optionalFieldsPresent & {{ $.StructName }}.fieldPresent{{.Name}}) != 0{{end}}) {
             // Field is changed and is present, decode it.
-            val.{{.name}} = {{.name}}Decoder.decode({{if not .Type.IsPrimitive}}val.{{.name}}{{end}});
+            {{if not .Type.IsPrimitive -}}
+            if (val.{{.name}} == null) {
+                val.{{.name}} = new {{ .Type.Storage }}(val.modifiedFields, {{ $.StructName }}.fieldModified{{.Name}});
+            }
+            val.{{.name}} = {{.name}}Decoder.decode(val.{{.name}});
+            {{- else -}}
+            val.{{.name}} = {{.name}}Decoder.decode();
+            {{- end}}
         }
         {{ end }}
         {{if .DictName}}

--- a/stefgen/templates/java/structEncoder.java.tmpl
+++ b/stefgen/templates/java/structEncoder.java.tmpl
@@ -19,7 +19,8 @@ class {{ .StructName }}Encoder {
     private boolean forceModifiedFields;
 
     {{ range .Fields }}
-    private {{ .Type.EncoderType }}Encoder {{.name}}Encoder = new {{ .Type.EncoderType }}Encoder();
+    private {{ .Type.EncoderType }}Encoder {{.name}}Encoder;
+    private boolean is{{.Name}}Recursive = false; // Indicates {{.Name}} field's type is recursive.
     {{- end }}
     {{if .DictName}}
     private {{ .StructName }}EncoderDict dict;
@@ -51,17 +52,26 @@ class {{ .StructName }}Encoder {
             }
 
             {{ range $i, $e := .Fields }}
+            // Init encoder for {{.Name}} field.
             if (this.fieldCount <= {{$i}}) {
                 return; // {{.Name}} and subsequent fields are skipped.
             }
             {{- if .IsPrimitive}}
+            {{.name}}Encoder = new {{.Type.EncoderType}}Encoder();
             {{- if .Type.DictName}}
             this.{{.name}}Encoder.init(state.{{.Type.DictName}}, this.limiter, columns.addSubColumn());
             {{- else}}
             this.{{.name}}Encoder.init({{if .Type.IsDictPossible}}null, {{end}}this.limiter, columns.addSubColumn());
             {{- end}}
             {{- else}}
-            this.{{.name}}Encoder.init(state, columns.addSubColumn());
+            if (state.{{.Type.EncoderType}}Encoder != null) {
+                // Recursion detected, use the existing encoder.
+                {{.name}}Encoder = state.{{.Type.EncoderType}}Encoder;
+                is{{.Name}}Recursive = true;
+            } else {
+                {{.name}}Encoder = new {{.Type.EncoderType}}Encoder();
+                {{.name}}Encoder.init(state, columns.addSubColumn());
+            }
             {{- end}}
             {{- end }}
         } finally {
@@ -71,10 +81,14 @@ class {{ .StructName }}Encoder {
 
     public void reset() {
         // Since we are resetting the state of encoder make sure the next encode()
-        // call forcedly writes all fields and does not attempt to skip.
+        // call forcefully writes all fields and does not attempt to skip.
         this.forceModifiedFields = true;
         {{- range .Fields}}
-        this.{{.name}}Encoder.reset();
+        {{if not .IsPrimitive}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Encoder.reset();
+        }
+        {{else}}{{.name}}Encoder.reset();{{end}}
         {{- end}}
     }
 
@@ -148,11 +162,21 @@ class {{ .StructName }}Encoder {
     // collectColumns collects all buffers from all encoders into buf.
     public void collectColumns(WriteColumnSet columnSet) {
         columnSet.setBits(this.buf);
+        int colIdx = 0;
         {{ range $i,$e := .Fields }}
+        // Collect {{.Name}} field.
         if (this.fieldCount <= {{$i}}) {
             return; // {{.Name}} and subsequent fields are skipped.
         }
-        this.{{.name}}Encoder.collectColumns(columnSet.at({{$i}}));
+        {{if not .IsPrimitive -}}
+        if (!is{{.Name}}Recursive) {
+            {{.name}}Encoder.collectColumns(columnSet.at(colIdx));
+            colIdx++;
+        }
+        {{else}}
+        {{.name}}Encoder.collectColumns(columnSet.at(colIdx));
+        colIdx++;
+        {{end -}}
         {{- end }}
     }
 }


### PR DESCRIPTION
Structs can recurse via optional fields. This fixes support for that use case.

When reviewing ignore the generated code and just review the *.tmpl files and the new test cases in stefgen/generator/testdata/

The changes mostly mirror the changes previously done for oneof in https://github.com/splunk/stef/pull/112