### PR TITLE
Use npm install for docs tool installation

### DIFF
--- a/makefile
+++ b/makefile
@@ -116,14 +116,10 @@ docs-install-deps:
 		exit 1; \
 	fi
 	@if [ ! -f package.json ]; then \
-		echo "Creating package.json..."; \
-		npm init -y; \
+		echo "❌ package.json not found. Cannot install dependencies."; \
+		exit 1; \
 	fi
-	@echo "Installing HTML validation tools..."
-	@npm install html-validate
-	@echo "Installing CSS validation tools..."
-	@npm install stylelint stylelint-config-standard
-	@echo "Installing link checking tools..."
-	@npm install markdown-link-check
+	@echo "Installing all dependencies from package.json..."
+	@npm install
 	@echo "✅ All docs dependencies installed successfully!"
 	@echo "Tools installed in ./node_modules/.bin/"


### PR DESCRIPTION
This should supposedly fix the build error:
https://github.com/splunk/stef/actions/runs/17238794587/job/48910819037

Change generated by Copilot.