### PR TITLE
Use custom allocators to improve performance

### DIFF
--- a/examples/jsonl/internal/jsonstef/common.go
+++ b/examples/jsonl/internal/jsonstef/common.go
@@ -72,3 +72,8 @@ func (s *StructFieldCounts) RecordFieldCount() (uint, error) {
 func (s *StructFieldCounts) AllFetched() bool {
 	return s.overrideSchema == false || s.overrideSchemaIter.Done()
 }
+
+type Allocators struct {
+	JsonValue JsonValueAllocator
+	Record    RecordAllocator
+}

--- a/examples/jsonl/internal/jsonstef/readerstate.go
+++ b/examples/jsonl/internal/jsonstef/readerstate.go
@@ -18,6 +18,8 @@ type ReaderState struct {
 	JsonValueDecoder      *JsonValueDecoder
 	JsonValueArrayDecoder *JsonValueArrayDecoder
 	RecordDecoder         *RecordDecoder
+
+	Allocators Allocators
 }
 
 func (d *ReaderState) Init(overrideSchema *schema.WireSchema) {

--- a/examples/jsonl/internal/jsonstef/writerstate.go
+++ b/examples/jsonl/internal/jsonstef/writerstate.go
@@ -20,6 +20,8 @@ type WriterState struct {
 	JsonValueEncoder      *JsonValueEncoder
 	JsonValueArrayEncoder *JsonValueArrayEncoder
 	RecordEncoder         *RecordEncoder
+
+	Allocators Allocators
 }
 
 func (d *WriterState) Init(opts *pkg.WriterOptions) {

--- a/examples/profile/internal/profile/common.go
+++ b/examples/profile/internal/profile/common.go
@@ -120,3 +120,16 @@ func (s *StructFieldCounts) SampleValueTypeFieldCount() (uint, error) {
 func (s *StructFieldCounts) AllFetched() bool {
 	return s.overrideSchema == false || s.overrideSchemaIter.Done()
 }
+
+type Allocators struct {
+	Function        FunctionAllocator
+	LabelValue      LabelValueAllocator
+	Line            LineAllocator
+	Location        LocationAllocator
+	Mapping         MappingAllocator
+	NumValue        NumValueAllocator
+	ProfileMetadata ProfileMetadataAllocator
+	Sample          SampleAllocator
+	SampleValue     SampleValueAllocator
+	SampleValueType SampleValueTypeAllocator
+}

--- a/examples/profile/internal/profile/labels.go
+++ b/examples/profile/internal/profile/labels.go
@@ -37,6 +37,10 @@ func (m *Labels) init(parentModifiedFields *modifiedFields, parentModifiedBit ui
 	m.modifiedElems.init(parentModifiedFields, parentModifiedBit)
 }
 
+func (m *Labels) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	m.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the multimap to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (m *Labels) reset() {
@@ -51,9 +55,9 @@ func (m *Labels) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of Labels
-func (m *Labels) Clone() Labels {
+func (m *Labels) Clone(allocators *Allocators) Labels {
 	clone := Labels{}
-	copyLabels(&clone, m)
+	copyToNewLabels(&clone, m, allocators)
 	return clone
 }
 
@@ -126,6 +130,7 @@ func (m *Labels) byteSize() uint {
 	return uint(unsafe.Sizeof(LabelsElem{}))*uint(len(m.elems)) + uint(unsafe.Sizeof(m.elems))
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyLabels(dst *Labels, src *Labels) {
 	if len(dst.elems) != len(src.elems) {
 		dst.EnsureLen(len(src.elems))
@@ -142,6 +147,21 @@ func copyLabels(dst *Labels, src *Labels) {
 			dst.modifiedElems.markValModified(i)
 		}
 	}
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewLabels(dst *Labels, src *Labels, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.EnsureLen(len(src.elems))
+	for i := 0; i < len(src.elems); i++ {
+		dst.elems[i].key = src.elems[i].key
+
+		copyToNewLabelValue(&dst.elems[i].value, &src.elems[i].value, allocators)
+	}
+
 }
 
 func (m *Labels) CopyFrom(src *Labels) {

--- a/examples/profile/internal/profile/linearray.go
+++ b/examples/profile/internal/profile/linearray.go
@@ -28,6 +28,10 @@ func (e *LineArray) init(parentModifiedFields *modifiedFields, parentModifiedBit
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *LineArray) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *LineArray) reset() {
@@ -42,9 +46,9 @@ func (e *LineArray) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of LineArray
-func (e *LineArray) Clone() LineArray {
+func (e *LineArray) Clone(allocators *Allocators) LineArray {
 	var clone LineArray
-	copyLineArray(&clone, e)
+	copyToNewLineArray(&clone, e, allocators)
 	return clone
 }
 
@@ -87,6 +91,7 @@ func (e *LineArray) markUnmodifiedRecursively() {
 
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyLineArray(dst *LineArray, src *LineArray) {
 	isModified := false
 
@@ -122,6 +127,23 @@ func copyLineArray(dst *LineArray, src *LineArray) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewLineArray(dst *LineArray, src *LineArray, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	// Need to allocate new elements for the part of the array that has grown.
+	for j := 0; j < len(dst.elems); j++ {
+		// Alloc and init the element.
+		dst.elems[j] = allocators.Line.Alloc()
+		dst.elems[j].initAlloc(dst.parentModifiedFields, dst.parentModifiedBit, allocators)
+		// Copy the element.
+		copyToNewLine(dst.elems[j], src.elems[j], allocators)
+	}
+}
+
 // Len returns the number of elements in the array.
 func (e *LineArray) Len() int {
 	return len(e.elems)
@@ -144,6 +166,26 @@ func (e *LineArray) EnsureLen(newLen int) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = new(Line)
 			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
+		}
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *LineArray) ensureLen(newLen int, allocators *Allocators) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]*Line, newLen-oldLen)...)
+		e.markModified()
+		// Initialize newly added elements.
+		for ; oldLen < newLen; oldLen++ {
+			e.elems[oldLen] = allocators.Line.Alloc()
+			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 	} else if oldLen > newLen {
 		// Shrink it
@@ -272,6 +314,7 @@ type LineArrayDecoder struct {
 	column      *pkg.ReadableColumn
 	elemDecoder *LineDecoder
 	isRecursive bool
+	allocators  *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -293,6 +336,8 @@ func (d *LineArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) 
 			return err
 		}
 	}
+
+	d.allocators = &state.Allocators
 
 	return nil
 }
@@ -318,7 +363,7 @@ func (d *LineArrayDecoder) Reset() {
 func (d *LineArrayDecoder) Decode(dst *LineArray) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		err := d.elemDecoder.Decode(dst.elems[i])

--- a/examples/profile/internal/profile/locationarray.go
+++ b/examples/profile/internal/profile/locationarray.go
@@ -28,6 +28,10 @@ func (e *LocationArray) init(parentModifiedFields *modifiedFields, parentModifie
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *LocationArray) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *LocationArray) reset() {
@@ -42,9 +46,9 @@ func (e *LocationArray) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of LocationArray
-func (e *LocationArray) Clone() LocationArray {
+func (e *LocationArray) Clone(allocators *Allocators) LocationArray {
 	var clone LocationArray
-	copyLocationArray(&clone, e)
+	copyToNewLocationArray(&clone, e, allocators)
 	return clone
 }
 
@@ -87,6 +91,7 @@ func (e *LocationArray) markUnmodifiedRecursively() {
 
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyLocationArray(dst *LocationArray, src *LocationArray) {
 	isModified := false
 
@@ -122,6 +127,23 @@ func copyLocationArray(dst *LocationArray, src *LocationArray) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewLocationArray(dst *LocationArray, src *LocationArray, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	// Need to allocate new elements for the part of the array that has grown.
+	for j := 0; j < len(dst.elems); j++ {
+		// Alloc and init the element.
+		dst.elems[j] = allocators.Location.Alloc()
+		dst.elems[j].initAlloc(dst.parentModifiedFields, dst.parentModifiedBit, allocators)
+		// Copy the element.
+		copyToNewLocation(dst.elems[j], src.elems[j], allocators)
+	}
+}
+
 // Len returns the number of elements in the array.
 func (e *LocationArray) Len() int {
 	return len(e.elems)
@@ -144,6 +166,26 @@ func (e *LocationArray) EnsureLen(newLen int) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = new(Location)
 			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
+		}
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *LocationArray) ensureLen(newLen int, allocators *Allocators) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]*Location, newLen-oldLen)...)
+		e.markModified()
+		// Initialize newly added elements.
+		for ; oldLen < newLen; oldLen++ {
+			e.elems[oldLen] = allocators.Location.Alloc()
+			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 	} else if oldLen > newLen {
 		// Shrink it
@@ -272,6 +314,7 @@ type LocationArrayDecoder struct {
 	column      *pkg.ReadableColumn
 	elemDecoder *LocationDecoder
 	isRecursive bool
+	allocators  *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -293,6 +336,8 @@ func (d *LocationArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnS
 			return err
 		}
 	}
+
+	d.allocators = &state.Allocators
 
 	return nil
 }
@@ -318,7 +363,7 @@ func (d *LocationArrayDecoder) Reset() {
 func (d *LocationArrayDecoder) Decode(dst *LocationArray) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		err := d.elemDecoder.Decode(&dst.elems[i])

--- a/examples/profile/internal/profile/readerstate.go
+++ b/examples/profile/internal/profile/readerstate.go
@@ -41,6 +41,8 @@ type ReaderState struct {
 	SampleValueArrayDecoder *SampleValueArrayDecoder
 	SampleValueTypeDecoder  *SampleValueTypeDecoder
 	StringArrayDecoder      *StringArrayDecoder
+
+	Allocators Allocators
 }
 
 func (d *ReaderState) Init(overrideSchema *schema.WireSchema) {

--- a/examples/profile/internal/profile/samplevaluearray.go
+++ b/examples/profile/internal/profile/samplevaluearray.go
@@ -28,6 +28,10 @@ func (e *SampleValueArray) init(parentModifiedFields *modifiedFields, parentModi
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *SampleValueArray) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *SampleValueArray) reset() {
@@ -42,9 +46,9 @@ func (e *SampleValueArray) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of SampleValueArray
-func (e *SampleValueArray) Clone() SampleValueArray {
+func (e *SampleValueArray) Clone(allocators *Allocators) SampleValueArray {
 	var clone SampleValueArray
-	copySampleValueArray(&clone, e)
+	copyToNewSampleValueArray(&clone, e, allocators)
 	return clone
 }
 
@@ -87,6 +91,7 @@ func (e *SampleValueArray) markUnmodifiedRecursively() {
 
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copySampleValueArray(dst *SampleValueArray, src *SampleValueArray) {
 	isModified := false
 
@@ -122,6 +127,23 @@ func copySampleValueArray(dst *SampleValueArray, src *SampleValueArray) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewSampleValueArray(dst *SampleValueArray, src *SampleValueArray, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	// Need to allocate new elements for the part of the array that has grown.
+	for j := 0; j < len(dst.elems); j++ {
+		// Alloc and init the element.
+		dst.elems[j] = allocators.SampleValue.Alloc()
+		dst.elems[j].initAlloc(dst.parentModifiedFields, dst.parentModifiedBit, allocators)
+		// Copy the element.
+		copyToNewSampleValue(dst.elems[j], src.elems[j], allocators)
+	}
+}
+
 // Len returns the number of elements in the array.
 func (e *SampleValueArray) Len() int {
 	return len(e.elems)
@@ -144,6 +166,26 @@ func (e *SampleValueArray) EnsureLen(newLen int) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = new(SampleValue)
 			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
+		}
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *SampleValueArray) ensureLen(newLen int, allocators *Allocators) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]*SampleValue, newLen-oldLen)...)
+		e.markModified()
+		// Initialize newly added elements.
+		for ; oldLen < newLen; oldLen++ {
+			e.elems[oldLen] = allocators.SampleValue.Alloc()
+			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 	} else if oldLen > newLen {
 		// Shrink it
@@ -272,6 +314,7 @@ type SampleValueArrayDecoder struct {
 	column      *pkg.ReadableColumn
 	elemDecoder *SampleValueDecoder
 	isRecursive bool
+	allocators  *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -293,6 +336,8 @@ func (d *SampleValueArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColu
 			return err
 		}
 	}
+
+	d.allocators = &state.Allocators
 
 	return nil
 }
@@ -318,7 +363,7 @@ func (d *SampleValueArrayDecoder) Reset() {
 func (d *SampleValueArrayDecoder) Decode(dst *SampleValueArray) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		err := d.elemDecoder.Decode(dst.elems[i])

--- a/examples/profile/internal/profile/writerstate.go
+++ b/examples/profile/internal/profile/writerstate.go
@@ -43,6 +43,8 @@ type WriterState struct {
 	SampleValueArrayEncoder *SampleValueArrayEncoder
 	SampleValueTypeEncoder  *SampleValueTypeEncoder
 	StringArrayEncoder      *StringArrayEncoder
+
+	Allocators Allocators
 }
 
 func (d *WriterState) Init(opts *pkg.WriterOptions) {

--- a/examples/profile/pprof2stef_test.go
+++ b/examples/profile/pprof2stef_test.go
@@ -96,7 +96,12 @@ func BenchmarkDeserialization(b *testing.B) {
 		b.Run(
 			"file="+file.Name()+"/format=pprof", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					pprof.ParseUncompressed(pprofData)
+					p, err := pprof.ParseUncompressed(pprofData)
+					if err != nil {
+						b.Fatalf("failed to parse pprof data: %v", err)
+					}
+					recCount := len(p.Sample)
+					b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*recCount), "ns/sample")
 				}
 			},
 		)
@@ -111,11 +116,14 @@ func BenchmarkDeserialization(b *testing.B) {
 					if err != nil {
 						b.Fatalf("failed to create STEF reader: %v", err)
 					}
+					recCount := 0
 					for {
 						if err := reader.Read(pkg.ReadOptions{}); err != nil {
 							break
 						}
+						recCount++
 					}
+					b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*recCount), "ns/sample")
 				}
 			},
 		)

--- a/go/otel/manual_test.go
+++ b/go/otel/manual_test.go
@@ -412,7 +412,8 @@ func TestLargeMultimap(t *testing.T) {
 		attrs.SetKey(i, strconv.Itoa(i))
 		attrs.At(i).Value().SetInt64(int64(i))
 	}
-	attrs1Copy := attrs.Clone()
+	allocators := &oteltef.Allocators{}
+	attrs1Copy := attrs.Clone(allocators)
 	err = w.Write()
 	require.NoError(t, err)
 
@@ -420,7 +421,7 @@ func TestLargeMultimap(t *testing.T) {
 	// but since the multimap is large it will use full encoding. This is
 	// precisely the case that this test verifies.
 	attrs.At(0).Value().SetString("abc")
-	attrs2Copy := attrs.Clone()
+	attrs2Copy := attrs.Clone(allocators)
 	err = w.Write()
 	require.NoError(t, err)
 

--- a/go/otel/oteltef/attributes.go
+++ b/go/otel/oteltef/attributes.go
@@ -37,6 +37,10 @@ func (m *Attributes) init(parentModifiedFields *modifiedFields, parentModifiedBi
 	m.modifiedElems.init(parentModifiedFields, parentModifiedBit)
 }
 
+func (m *Attributes) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	m.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the multimap to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (m *Attributes) reset() {
@@ -51,9 +55,9 @@ func (m *Attributes) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of Attributes
-func (m *Attributes) Clone() Attributes {
+func (m *Attributes) Clone(allocators *Allocators) Attributes {
 	clone := Attributes{}
-	copyAttributes(&clone, m)
+	copyToNewAttributes(&clone, m, allocators)
 	return clone
 }
 
@@ -126,6 +130,7 @@ func (m *Attributes) byteSize() uint {
 	return uint(unsafe.Sizeof(AttributesElem{}))*uint(len(m.elems)) + uint(unsafe.Sizeof(m.elems))
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyAttributes(dst *Attributes, src *Attributes) {
 	if len(dst.elems) != len(src.elems) {
 		dst.EnsureLen(len(src.elems))
@@ -142,6 +147,21 @@ func copyAttributes(dst *Attributes, src *Attributes) {
 			dst.modifiedElems.markValModified(i)
 		}
 	}
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewAttributes(dst *Attributes, src *Attributes, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.EnsureLen(len(src.elems))
+	for i := 0; i < len(src.elems); i++ {
+		dst.elems[i].key = src.elems[i].key
+
+		copyToNewAnyValue(&dst.elems[i].value, &src.elems[i].value, allocators)
+	}
+
 }
 
 func (m *Attributes) CopyFrom(src *Attributes) {

--- a/go/otel/oteltef/common.go
+++ b/go/otel/oteltef/common.go
@@ -180,3 +180,26 @@ func (s *StructFieldCounts) SummaryValueFieldCount() (uint, error) {
 func (s *StructFieldCounts) AllFetched() bool {
 	return s.overrideSchema == false || s.overrideSchemaIter.Done()
 }
+
+type Allocators struct {
+	AnyValue            AnyValueAllocator
+	Envelope            EnvelopeAllocator
+	Event               EventAllocator
+	Exemplar            ExemplarAllocator
+	ExemplarValue       ExemplarValueAllocator
+	ExpHistogramBuckets ExpHistogramBucketsAllocator
+	ExpHistogramValue   ExpHistogramValueAllocator
+	HistogramValue      HistogramValueAllocator
+	Link                LinkAllocator
+	Metric              MetricAllocator
+	Metrics             MetricsAllocator
+	Point               PointAllocator
+	PointValue          PointValueAllocator
+	QuantileValue       QuantileValueAllocator
+	Resource            ResourceAllocator
+	Scope               ScopeAllocator
+	Span                SpanAllocator
+	SpanStatus          SpanStatusAllocator
+	Spans               SpansAllocator
+	SummaryValue        SummaryValueAllocator
+}

--- a/go/otel/oteltef/envelopeattributes.go
+++ b/go/otel/oteltef/envelopeattributes.go
@@ -37,6 +37,10 @@ func (m *EnvelopeAttributes) init(parentModifiedFields *modifiedFields, parentMo
 	m.modifiedElems.init(parentModifiedFields, parentModifiedBit)
 }
 
+func (m *EnvelopeAttributes) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	m.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the multimap to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (m *EnvelopeAttributes) reset() {
@@ -51,9 +55,9 @@ func (m *EnvelopeAttributes) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of EnvelopeAttributes
-func (m *EnvelopeAttributes) Clone() EnvelopeAttributes {
+func (m *EnvelopeAttributes) Clone(allocators *Allocators) EnvelopeAttributes {
 	clone := EnvelopeAttributes{}
-	copyEnvelopeAttributes(&clone, m)
+	copyToNewEnvelopeAttributes(&clone, m, allocators)
 	return clone
 }
 
@@ -134,6 +138,7 @@ func (m *EnvelopeAttributes) byteSize() uint {
 	return uint(unsafe.Sizeof(EnvelopeAttributesElem{}))*uint(len(m.elems)) + uint(unsafe.Sizeof(m.elems))
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyEnvelopeAttributes(dst *EnvelopeAttributes, src *EnvelopeAttributes) {
 	if len(dst.elems) != len(src.elems) {
 		dst.EnsureLen(len(src.elems))
@@ -151,6 +156,17 @@ func copyEnvelopeAttributes(dst *EnvelopeAttributes, src *EnvelopeAttributes) {
 		}
 
 	}
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewEnvelopeAttributes(dst *EnvelopeAttributes, src *EnvelopeAttributes, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.EnsureLen(len(src.elems))
+	copy(dst.elems, src.elems)
+
 }
 
 func (m *EnvelopeAttributes) CopyFrom(src *EnvelopeAttributes) {

--- a/go/otel/oteltef/exemplararray.go
+++ b/go/otel/oteltef/exemplararray.go
@@ -28,6 +28,10 @@ func (e *ExemplarArray) init(parentModifiedFields *modifiedFields, parentModifie
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *ExemplarArray) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *ExemplarArray) reset() {
@@ -42,9 +46,9 @@ func (e *ExemplarArray) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of ExemplarArray
-func (e *ExemplarArray) Clone() ExemplarArray {
+func (e *ExemplarArray) Clone(allocators *Allocators) ExemplarArray {
 	var clone ExemplarArray
-	copyExemplarArray(&clone, e)
+	copyToNewExemplarArray(&clone, e, allocators)
 	return clone
 }
 
@@ -87,6 +91,7 @@ func (e *ExemplarArray) markUnmodifiedRecursively() {
 
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyExemplarArray(dst *ExemplarArray, src *ExemplarArray) {
 	isModified := false
 
@@ -122,6 +127,23 @@ func copyExemplarArray(dst *ExemplarArray, src *ExemplarArray) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewExemplarArray(dst *ExemplarArray, src *ExemplarArray, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	// Need to allocate new elements for the part of the array that has grown.
+	for j := 0; j < len(dst.elems); j++ {
+		// Alloc and init the element.
+		dst.elems[j] = allocators.Exemplar.Alloc()
+		dst.elems[j].initAlloc(dst.parentModifiedFields, dst.parentModifiedBit, allocators)
+		// Copy the element.
+		copyToNewExemplar(dst.elems[j], src.elems[j], allocators)
+	}
+}
+
 // Len returns the number of elements in the array.
 func (e *ExemplarArray) Len() int {
 	return len(e.elems)
@@ -144,6 +166,26 @@ func (e *ExemplarArray) EnsureLen(newLen int) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = new(Exemplar)
 			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
+		}
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *ExemplarArray) ensureLen(newLen int, allocators *Allocators) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]*Exemplar, newLen-oldLen)...)
+		e.markModified()
+		// Initialize newly added elements.
+		for ; oldLen < newLen; oldLen++ {
+			e.elems[oldLen] = allocators.Exemplar.Alloc()
+			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 	} else if oldLen > newLen {
 		// Shrink it
@@ -272,6 +314,7 @@ type ExemplarArrayDecoder struct {
 	column      *pkg.ReadableColumn
 	elemDecoder *ExemplarDecoder
 	isRecursive bool
+	allocators  *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -293,6 +336,8 @@ func (d *ExemplarArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnS
 			return err
 		}
 	}
+
+	d.allocators = &state.Allocators
 
 	return nil
 }
@@ -318,7 +363,7 @@ func (d *ExemplarArrayDecoder) Reset() {
 func (d *ExemplarArrayDecoder) Decode(dst *ExemplarArray) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		err := d.elemDecoder.Decode(dst.elems[i])

--- a/go/otel/oteltef/exemplarvalue.go
+++ b/go/otel/oteltef/exemplarvalue.go
@@ -40,6 +40,12 @@ func (s *ExemplarValue) init(parentModifiedFields *modifiedFields, parentModifie
 
 }
 
+func (s *ExemplarValue) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	s.parentModifiedFields = parentModifiedFields
+	s.parentModifiedBit = parentModifiedBit
+
+}
+
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *ExemplarValue) reset() {
@@ -108,7 +114,7 @@ func (s *ExemplarValue) SetFloat64(v float64) {
 	}
 }
 
-func (s *ExemplarValue) Clone() ExemplarValue {
+func (s *ExemplarValue) Clone(allocators *Allocators) ExemplarValue {
 	return ExemplarValue{
 		int64:   s.int64,
 		float64: s.float64,
@@ -122,6 +128,7 @@ func (s *ExemplarValue) byteSize() uint {
 		0
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyExemplarValue(dst *ExemplarValue, src *ExemplarValue) {
 	switch src.typ {
 	case ExemplarValueTypeInt64:
@@ -130,6 +137,20 @@ func copyExemplarValue(dst *ExemplarValue, src *ExemplarValue) {
 		dst.SetFloat64(src.float64)
 	case ExemplarValueTypeNone:
 		dst.SetType(src.typ)
+	default:
+		panic("copyExemplarValue: unexpected type: " + fmt.Sprint(src.typ))
+	}
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewExemplarValue(dst *ExemplarValue, src *ExemplarValue, allocators *Allocators) {
+	dst.typ = src.typ
+	switch src.typ {
+	case ExemplarValueTypeInt64:
+		dst.int64 = src.int64
+	case ExemplarValueTypeFloat64:
+		dst.float64 = src.float64
+	case ExemplarValueTypeNone:
 	default:
 		panic("copyExemplarValue: unexpected type: " + fmt.Sprint(src.typ))
 	}
@@ -364,6 +385,8 @@ type ExemplarValueDecoder struct {
 	int64Decoder encoders.Int64Decoder
 
 	float64Decoder encoders.Float64Decoder
+
+	allocators *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -374,6 +397,8 @@ func (d *ExemplarValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnS
 	}
 	state.ExemplarValueDecoder = d
 	defer func() { state.ExemplarValueDecoder = nil }()
+
+	d.allocators = &state.Allocators
 
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ExemplarValueFieldCount()
@@ -466,4 +491,35 @@ func (d *ExemplarValueDecoder) Decode(dstPtr *ExemplarValue) error {
 		}
 	}
 	return nil
+}
+
+// ExemplarValueAllocator implements a custom allocator for ExemplarValue.
+// It maintains a pool of pre-allocated ExemplarValue and grows the pool
+// dynamically as needed, up to a maximum size of 64 elements.
+type ExemplarValueAllocator struct {
+	pool []ExemplarValue
+	ofs  int
+}
+
+// Alloc returns the next available ExemplarValue from the pool.
+// If the pool is exhausted, it grows the pool by doubling its size
+// up to a maximum of 64 elements.
+func (a *ExemplarValueAllocator) Alloc() *ExemplarValue {
+	if a.ofs < len(a.pool) {
+		// Get the next available ExemplarValue from the pool
+		a.ofs++
+		return &a.pool[a.ofs-1]
+	}
+	// We've exhausted the current pool, prealloc a new pool.
+	return a.prealloc()
+}
+
+//go:noinline
+func (a *ExemplarValueAllocator) prealloc() *ExemplarValue {
+	// prealloc expands the pool by doubling its size, up to a maximum of 64 elements.
+	// If the pool is empty, it starts with 1 element.
+	newLen := min(max(len(a.pool)*2, 1), 64)
+	a.pool = make([]ExemplarValue, newLen)
+	a.ofs = 1
+	return &a.pool[0]
 }

--- a/go/otel/oteltef/int64array.go
+++ b/go/otel/oteltef/int64array.go
@@ -30,6 +30,10 @@ func (e *Int64Array) init(parentModifiedFields *modifiedFields, parentModifiedBi
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *Int64Array) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *Int64Array) reset() {
@@ -44,9 +48,9 @@ func (e *Int64Array) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of Int64Array
-func (e *Int64Array) Clone() Int64Array {
+func (e *Int64Array) Clone(allocators *Allocators) Int64Array {
 	var clone Int64Array
-	copyInt64Array(&clone, e)
+	copyToNewInt64Array(&clone, e, allocators)
 	return clone
 }
 
@@ -91,6 +95,7 @@ func (e *Int64Array) markUnmodifiedRecursively() {
 
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyInt64Array(dst *Int64Array, src *Int64Array) {
 	isModified := false
 
@@ -120,6 +125,18 @@ func copyInt64Array(dst *Int64Array, src *Int64Array) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewInt64Array(dst *Int64Array, src *Int64Array, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	for i := 0; i < len(dst.elems); i++ {
+		dst.elems[i] = src.elems[i]
+	}
+}
+
 // Len returns the number of elements in the array.
 func (e *Int64Array) Len() int {
 	return len(e.elems)
@@ -133,6 +150,21 @@ func (m *Int64Array) At(i int) int64 {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *Int64Array) EnsureLen(newLen int) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]int64, newLen-oldLen)...)
+		e.markModified()
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *Int64Array) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
 		// Grow the array
@@ -256,6 +288,7 @@ type Int64ArrayDecoder struct {
 	column      *pkg.ReadableColumn
 	elemDecoder *encoders.Int64Decoder
 	isRecursive bool
+	allocators  *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -266,6 +299,8 @@ func (d *Int64ArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	if err != nil {
 		return err
 	}
+
+	d.allocators = &state.Allocators
 
 	return nil
 }
@@ -291,7 +326,7 @@ func (d *Int64ArrayDecoder) Reset() {
 func (d *Int64ArrayDecoder) Decode(dst *Int64Array) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		err := d.elemDecoder.Decode(&dst.elems[i])

--- a/go/otel/oteltef/quantilevaluearray.go
+++ b/go/otel/oteltef/quantilevaluearray.go
@@ -28,6 +28,10 @@ func (e *QuantileValueArray) init(parentModifiedFields *modifiedFields, parentMo
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *QuantileValueArray) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *QuantileValueArray) reset() {
@@ -42,9 +46,9 @@ func (e *QuantileValueArray) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of QuantileValueArray
-func (e *QuantileValueArray) Clone() QuantileValueArray {
+func (e *QuantileValueArray) Clone(allocators *Allocators) QuantileValueArray {
 	var clone QuantileValueArray
-	copyQuantileValueArray(&clone, e)
+	copyToNewQuantileValueArray(&clone, e, allocators)
 	return clone
 }
 
@@ -87,6 +91,7 @@ func (e *QuantileValueArray) markUnmodifiedRecursively() {
 
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copyQuantileValueArray(dst *QuantileValueArray, src *QuantileValueArray) {
 	isModified := false
 
@@ -122,6 +127,23 @@ func copyQuantileValueArray(dst *QuantileValueArray, src *QuantileValueArray) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewQuantileValueArray(dst *QuantileValueArray, src *QuantileValueArray, allocators *Allocators) {
+	if len(src.elems) == 0 {
+		return
+	}
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	// Need to allocate new elements for the part of the array that has grown.
+	for j := 0; j < len(dst.elems); j++ {
+		// Alloc and init the element.
+		dst.elems[j] = allocators.QuantileValue.Alloc()
+		dst.elems[j].initAlloc(dst.parentModifiedFields, dst.parentModifiedBit, allocators)
+		// Copy the element.
+		copyToNewQuantileValue(dst.elems[j], src.elems[j], allocators)
+	}
+}
+
 // Len returns the number of elements in the array.
 func (e *QuantileValueArray) Len() int {
 	return len(e.elems)
@@ -144,6 +166,26 @@ func (e *QuantileValueArray) EnsureLen(newLen int) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = new(QuantileValue)
 			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
+		}
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *QuantileValueArray) ensureLen(newLen int, allocators *Allocators) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]*QuantileValue, newLen-oldLen)...)
+		e.markModified()
+		// Initialize newly added elements.
+		for ; oldLen < newLen; oldLen++ {
+			e.elems[oldLen] = allocators.QuantileValue.Alloc()
+			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 	} else if oldLen > newLen {
 		// Shrink it
@@ -272,6 +314,7 @@ type QuantileValueArrayDecoder struct {
 	column      *pkg.ReadableColumn
 	elemDecoder *QuantileValueDecoder
 	isRecursive bool
+	allocators  *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -293,6 +336,8 @@ func (d *QuantileValueArrayDecoder) Init(state *ReaderState, columns *pkg.ReadCo
 			return err
 		}
 	}
+
+	d.allocators = &state.Allocators
 
 	return nil
 }
@@ -318,7 +363,7 @@ func (d *QuantileValueArrayDecoder) Reset() {
 func (d *QuantileValueArrayDecoder) Decode(dst *QuantileValueArray) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		err := d.elemDecoder.Decode(dst.elems[i])

--- a/go/otel/oteltef/readerstate.go
+++ b/go/otel/oteltef/readerstate.go
@@ -58,6 +58,8 @@ type ReaderState struct {
 	SpansDecoder               *SpansDecoder
 	SummaryValueDecoder        *SummaryValueDecoder
 	Uint64ArrayDecoder         *Uint64ArrayDecoder
+
+	Allocators Allocators
 }
 
 func (d *ReaderState) Init(overrideSchema *schema.WireSchema) {

--- a/go/otel/oteltef/summaryvalue.go
+++ b/go/otel/oteltef/summaryvalue.go
@@ -54,6 +54,13 @@ func (s *SummaryValue) init(parentModifiedFields *modifiedFields, parentModified
 	s.quantileValues.init(&s.modifiedFields, fieldModifiedSummaryValueQuantileValues)
 }
 
+func (s *SummaryValue) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	s.modifiedFields.parent = parentModifiedFields
+	s.modifiedFields.parentBit = parentModifiedBit
+
+	s.quantileValues.initAlloc(&s.modifiedFields, fieldModifiedSummaryValueQuantileValues, allocators)
+}
+
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *SummaryValue) reset() {
@@ -159,12 +166,15 @@ func (s *SummaryValue) markUnmodifiedRecursively() {
 	s.modifiedFields.mask = 0
 }
 
-func (s *SummaryValue) Clone() SummaryValue {
-	return SummaryValue{
+func (s *SummaryValue) Clone(allocators *Allocators) SummaryValue {
+
+	c := SummaryValue{
+
 		count:          s.count,
 		sum:            s.sum,
-		quantileValues: s.quantileValues.Clone(),
+		quantileValues: s.quantileValues.Clone(allocators),
 	}
+	return c
 }
 
 // ByteSize returns approximate memory usage in bytes. Used to calculate
@@ -174,10 +184,18 @@ func (s *SummaryValue) byteSize() uint {
 		s.quantileValues.byteSize() + 0
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copySummaryValue(dst *SummaryValue, src *SummaryValue) {
 	dst.SetCount(src.count)
 	dst.SetSum(src.sum)
 	copyQuantileValueArray(&dst.quantileValues, &src.quantileValues)
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNewSummaryValue(dst *SummaryValue, src *SummaryValue, allocators *Allocators) {
+	dst.count = src.count
+	dst.sum = src.sum
+	copyToNewQuantileValueArray(&dst.quantileValues, &src.quantileValues, allocators)
 }
 
 // CopyFrom() performs a deep copy from src.
@@ -297,6 +315,8 @@ type SummaryValueEncoder struct {
 	quantileValuesEncoder     *QuantileValueArrayEncoder
 	isQuantileValuesRecursive bool // Indicates QuantileValues field's type is recursive.
 
+	allocators *Allocators
+
 	keepFieldMask uint64
 	fieldCount    uint
 }
@@ -310,6 +330,7 @@ func (e *SummaryValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnS
 	defer func() { state.SummaryValueEncoder = nil }()
 
 	e.limiter = &state.limiter
+	e.allocators = &state.Allocators
 
 	// Number of fields in the output data schema.
 	var err error
@@ -472,6 +493,8 @@ type SummaryValueDecoder struct {
 
 	quantileValuesDecoder     *QuantileValueArrayDecoder
 	isQuantileValuesRecursive bool
+
+	allocators *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -482,6 +505,8 @@ func (d *SummaryValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSe
 	}
 	state.SummaryValueDecoder = d
 	defer func() { state.SummaryValueDecoder = nil }()
+
+	d.allocators = &state.Allocators
 
 	// Number of fields in the input data schema.
 	var err error
@@ -603,4 +628,35 @@ func (d *SummaryValueDecoder) Decode(dstPtr *SummaryValue) error {
 	}
 
 	return nil
+}
+
+// SummaryValueAllocator implements a custom allocator for SummaryValue.
+// It maintains a pool of pre-allocated SummaryValue and grows the pool
+// dynamically as needed, up to a maximum size of 64 elements.
+type SummaryValueAllocator struct {
+	pool []SummaryValue
+	ofs  int
+}
+
+// Alloc returns the next available SummaryValue from the pool.
+// If the pool is exhausted, it grows the pool by doubling its size
+// up to a maximum of 64 elements.
+func (a *SummaryValueAllocator) Alloc() *SummaryValue {
+	if a.ofs < len(a.pool) {
+		// Get the next available SummaryValue from the pool
+		a.ofs++
+		return &a.pool[a.ofs-1]
+	}
+	// We've exhausted the current pool, prealloc a new pool.
+	return a.prealloc()
+}
+
+//go:noinline
+func (a *SummaryValueAllocator) prealloc() *SummaryValue {
+	// prealloc expands the pool by doubling its size, up to a maximum of 64 elements.
+	// If the pool is empty, it starts with 1 element.
+	newLen := min(max(len(a.pool)*2, 1), 64)
+	a.pool = make([]SummaryValue, newLen)
+	a.ofs = 1
+	return &a.pool[0]
 }

--- a/go/otel/oteltef/writerstate.go
+++ b/go/otel/oteltef/writerstate.go
@@ -60,6 +60,8 @@ type WriterState struct {
 	SpansEncoder               *SpansEncoder
 	SummaryValueEncoder        *SummaryValueEncoder
 	Uint64ArrayEncoder         *Uint64ArrayEncoder
+
+	Allocators Allocators
 }
 
 func (d *WriterState) Init(opts *pkg.WriterOptions) {

--- a/go/pdata/metrics/sortedbyresource/sortedresource.go
+++ b/go/pdata/metrics/sortedbyresource/sortedresource.go
@@ -15,20 +15,24 @@ import (
 type SortedTree struct {
 	internal.BaseSTEFToOTLP
 	byResource *b.Tree[*oteltef.Resource, *ByResource]
+	allocators oteltef.Allocators
 }
 
 type ByResource struct {
-	byScope *b.Tree[*oteltef.Scope, *ByScope]
+	byScope    *b.Tree[*oteltef.Scope, *ByScope]
+	allocators *oteltef.Allocators
 }
 
 type ByScope struct {
-	byMetrics *b.Tree[*oteltef.Metric, *ByMetric]
+	byMetrics  *b.Tree[*oteltef.Metric, *ByMetric]
+	allocators *oteltef.Allocators
 }
 
 type Points []*oteltef.Point
 
 type ByMetric struct {
-	byAttrs *b.Tree[*oteltef.Attributes, *Points]
+	byAttrs    *b.Tree[*oteltef.Attributes, *Points]
+	allocators *oteltef.Allocators
 }
 
 func NewSortedByResource() *SortedTree {
@@ -86,8 +90,8 @@ func (s *SortedTree) ToOtlp() (pmetric.Metrics, error) {
 func (s *SortedTree) ByResource(resource *oteltef.Resource) *ByResource {
 	elem, exists := s.byResource.Get(resource)
 	if !exists {
-		elem = &ByResource{byScope: b.TreeNew[*oteltef.Scope, *ByScope](oteltef.CmpScope)}
-		s.byResource.Set(resource.Clone(), elem)
+		elem = &ByResource{byScope: b.TreeNew[*oteltef.Scope, *ByScope](oteltef.CmpScope), allocators: &s.allocators}
+		s.byResource.Set(resource.Clone(&s.allocators), elem)
 	}
 	return elem
 }
@@ -95,8 +99,8 @@ func (s *SortedTree) ByResource(resource *oteltef.Resource) *ByResource {
 func (m *ByResource) ByScope(scope *oteltef.Scope) *ByScope {
 	elem, exists := m.byScope.Get(scope)
 	if !exists {
-		elem = &ByScope{byMetrics: b.TreeNew[*oteltef.Metric, *ByMetric](oteltef.CmpMetric)}
-		m.byScope.Set(scope.Clone(), elem)
+		elem = &ByScope{byMetrics: b.TreeNew[*oteltef.Metric, *ByMetric](oteltef.CmpMetric), allocators: m.allocators}
+		m.byScope.Set(scope.Clone(m.allocators), elem)
 	}
 	return elem
 }
@@ -107,9 +111,10 @@ func (m *ByScope) ByMetric(
 	elem, exists := m.byMetrics.Get(metric)
 	if !exists {
 		elem = &ByMetric{
-			byAttrs: b.TreeNew[*oteltef.Attributes, *Points](oteltef.CmpAttributes),
+			byAttrs:    b.TreeNew[*oteltef.Attributes, *Points](oteltef.CmpAttributes),
+			allocators: m.allocators,
 		}
-		m.byMetrics.Set(metric.Clone(), elem)
+		m.byMetrics.Set(metric.Clone(m.allocators), elem)
 	}
 	return elem
 }
@@ -117,7 +122,7 @@ func (m *ByScope) ByMetric(
 func (m *ByMetric) ByAttrs(attrs *oteltef.Attributes) *Points {
 	elem, exists := m.byAttrs.Get(attrs)
 	if !exists {
-		clone := attrs.Clone()
+		clone := attrs.Clone(m.allocators)
 		elem = &Points{}
 		m.byAttrs.Set(&clone, elem)
 	}

--- a/stefgen/templates/go/allreaderstate.go.tmpl
+++ b/stefgen/templates/go/allreaderstate.go.tmpl
@@ -19,6 +19,8 @@ type ReaderState struct {
     {{range $name, $val := .Encoders -}}
     {{$name}}Decoder *{{$name}}Decoder
     {{end}}
+
+    Allocators Allocators
 }
 
 func (d* ReaderState) Init(overrideSchema *schema.WireSchema) {

--- a/stefgen/templates/go/allwriterstate.go.tmpl
+++ b/stefgen/templates/go/allwriterstate.go.tmpl
@@ -21,6 +21,8 @@ type WriterState struct {
     {{range $name, $val := .Encoders -}}
     {{$name}}Encoder *{{$name}}Encoder
     {{end}}
+
+    Allocators Allocators
 }
 
 func (d *WriterState) Init(opts *pkg.WriterOptions) {

--- a/stefgen/templates/go/array.go.tmpl
+++ b/stefgen/templates/go/array.go.tmpl
@@ -29,6 +29,10 @@ func (e *{{.ArrayName}}) init(parentModifiedFields *modifiedFields, parentModifi
 	e.parentModifiedBit = parentModifiedBit
 }
 
+func (e *{{.ArrayName}}) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	e.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the array to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (e *{{.ArrayName}}) reset() {
@@ -43,9 +47,9 @@ func (e *{{.ArrayName}}) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of {{ .ArrayName }}
-func (e *{{.ArrayName}}) Clone() {{ .ArrayName }} {
+func (e *{{.ArrayName}}) Clone(allocators *Allocators) {{ .ArrayName }} {
     var clone {{ .ArrayName }}
-    copy{{.ArrayName}}(&clone, e)
+    copyToNew{{.ArrayName}}(&clone, e, allocators)
     return clone
 }
 
@@ -104,6 +108,7 @@ func (e* {{.ArrayName}}) markUnmodifiedRecursively() {
 {{end}}
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copy{{.ArrayName}}(dst* {{.ArrayName}}, src *{{.ArrayName}}) {
 	isModified := false
 
@@ -158,6 +163,32 @@ func copy{{.ArrayName}}(dst* {{.ArrayName}}, src *{{.ArrayName}}) {
 	}
 }
 
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNew{{.ArrayName}}(dst* {{.ArrayName}}, src *{{.ArrayName}}, allocators *Allocators) {
+    if len(src.elems)==0 {
+        return
+    }
+
+	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+
+	{{- if .ElemType.MustClone}}
+    // Need to allocate new elements for the part of the array that has grown.
+    for j := 0; j<len(dst.elems); j++ {
+        {{if not .ElemType.IsPrimitive -}}
+        // Alloc and init the element.
+        dst.elems[j] = allocators.{{.ElemType.Storage}}.Alloc()
+        dst.elems[j].initAlloc(dst.parentModifiedFields, dst.parentModifiedBit, allocators)
+        {{- end}}
+        // Copy the element.
+        copyToNew{{.ElemType.TypeName}}(dst.elems[j], src.elems[j], allocators)
+    }
+	{{- else}}
+	for i:=0; i < len(dst.elems); i++ {
+		dst.elems[i] = src.elems[i]
+	}
+	{{- end}}
+}
+
 // Len returns the number of elements in the array.
 func (e *{{.ArrayName}}) Len() int {
 	return len(e.elems)
@@ -181,6 +212,28 @@ func (e *{{.ArrayName}}) EnsureLen(newLen int) {
 		for ; oldLen<newLen; oldLen++ {
 			e.elems[oldLen] = new({{.ElemType.Storage}})
 			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
+		}
+		{{- end}}
+	} else if oldLen > newLen {
+		// Shrink it
+		e.elems = e.elems[:newLen]
+		e.markModified()
+	}
+}
+
+// EnsureLen ensures the length of the array is equal to newLen.
+// It will grow or shrink the array if needed.
+func (e *{{.ArrayName}}) ensureLen(newLen int, allocators *Allocators) {
+	oldLen := len(e.elems)
+	if newLen > oldLen {
+		// Grow the array
+		e.elems = append(e.elems, make([]{{if .IsStructType}}*{{end}}{{.ElemType.Storage}}, newLen-oldLen)...)
+		e.markModified()
+		{{- if .IsStructType}}
+		// Initialize newly added elements.
+		for ; oldLen<newLen; oldLen++ {
+			e.elems[oldLen] = allocators.{{.ElemType.Storage}}.Alloc()
+			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 		{{- end}}
 	} else if oldLen > newLen {
@@ -331,6 +384,7 @@ type {{ .ArrayName }}Decoder struct {
 	column *pkg.ReadableColumn
 	elemDecoder *{{.ElemType.EncoderType}}Decoder
 	isRecursive bool
+	allocators *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -368,6 +422,8 @@ func (d *{{ .ArrayName }}Decoder) Init(state* ReaderState, columns *pkg.ReadColu
 	}
 {{- end}}
 
+    d.allocators = &state.Allocators
+
 	return nil
 }
 
@@ -392,7 +448,7 @@ func (d *{{ .ArrayName }}Decoder) Reset() {
 func (d *{{ .ArrayName }}Decoder) Decode(dst *{{.ArrayName}}) error {
 	newLen := int(d.buf.ReadUvarintCompact())
 
-	dst.EnsureLen(newLen)
+	dst.ensureLen(newLen, d.allocators)
 
 	for i := 0; i < newLen; i++ {
 		{{- if .ElemType.IsPrimitive}}

--- a/stefgen/templates/go/common.go.tmpl
+++ b/stefgen/templates/go/common.go.tmpl
@@ -71,3 +71,9 @@ func (s* StructFieldCounts) {{$name}}FieldCount() (uint, error) {
 func (s *StructFieldCounts) AllFetched() bool {
     return s.overrideSchema == false || s.overrideSchemaIter.Done()
 }
+
+type Allocators struct {
+    {{range $name, $val := .Structs -}}
+    {{$name}} {{$name}}Allocator
+    {{end}}
+}

--- a/stefgen/templates/go/multimap.go.tmpl
+++ b/stefgen/templates/go/multimap.go.tmpl
@@ -37,6 +37,10 @@ func (m *{{.MultimapName}}) init(parentModifiedFields *modifiedFields, parentMod
 	m.modifiedElems.init(parentModifiedFields, parentModifiedBit)
 }
 
+func (m *{{.MultimapName}}) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+	m.init(parentModifiedFields, parentModifiedBit)
+}
+
 // reset the multimap to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (m *{{.MultimapName}}) reset() {
@@ -51,9 +55,9 @@ func (m *{{.MultimapName}}) fixParent(parentModifiedFields *modifiedFields) {
 }
 
 // Clone() creates a deep copy of {{.MultimapName}}
-func (m *{{.MultimapName}}) Clone() {{.MultimapName}} {
+func (m *{{.MultimapName}}) Clone(allocators *Allocators) {{.MultimapName}} {
 	clone := {{.MultimapName}}{}
-	copy{{.MultimapName}}(&clone, m)
+	copyToNew{{.MultimapName}}(&clone, m, allocators)
 	return clone
 }
 
@@ -172,6 +176,7 @@ func (m *{{.MultimapName}}) byteSize() uint {
 	return uint(unsafe.Sizeof({{.MultimapName}}Elem{}))*uint(len(m.elems))+uint(unsafe.Sizeof(m.elems))
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copy{{.MultimapName}}(dst *{{.MultimapName}}, src *{{.MultimapName}}) {
 	if len(dst.elems)!=len(src.elems) {
 		dst.EnsureLen(len(src.elems))
@@ -202,6 +207,33 @@ func copy{{.MultimapName}}(dst *{{.MultimapName}}, src *{{.MultimapName}}) {
 		}
 		{{- end}}
 	}
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNew{{.MultimapName}}(dst *{{.MultimapName}}, src *{{.MultimapName}}, allocators *Allocators) {
+	if len(src.elems) == 0 {
+        return
+	}
+
+	dst.EnsureLen(len(src.elems))
+
+	{{- if and .Key.Type.IsPrimitive .Value.Type.IsPrimitive}}
+	copy(dst.elems, src.elems)
+	{{else}}
+	for i:=0; i < len(src.elems); i++ {
+		{{- if .Key.Type.IsPrimitive}}
+		dst.elems[i].key = src.elems[i].key
+		{{else}}
+		copyToNew{{.Key.Type.TypeName}}(&dst.elems[i].key, &src.elems[i].key, allocators)
+		{{end}}
+
+		{{- if .Value.Type.IsPrimitive}}
+		dst.elems[i].value = src.elems[i].value
+		{{else}}
+		copyToNew{{.Value.Type.TypeName}}(&dst.elems[i].value, &src.elems[i].value, allocators)
+		{{- end}}
+	}
+	{{end}}
 }
 
 func (m *{{.MultimapName}}) CopyFrom(src *{{.MultimapName}}) {

--- a/stefgen/templates/go/oneof.go.tmpl
+++ b/stefgen/templates/go/oneof.go.tmpl
@@ -47,6 +47,17 @@ func (s *{{ $.StructName }}) init(parentModifiedFields *modifiedFields, parentMo
     {{- end -}}
 }
 
+func (s *{{ $.StructName }}) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+    s.parentModifiedFields = parentModifiedFields
+    s.parentModifiedBit = parentModifiedBit
+
+    {{ range .Fields }}
+	{{- if and (not .Type.IsPrimitive) (not .Type.Flags.StoreByPtr) }}
+    s.{{.name}}.initAlloc(parentModifiedFields, parentModifiedBit, allocators)
+    {{- end -}}
+    {{- end -}}
+}
+
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *{{ $.StructName }}) reset() {
@@ -127,9 +138,9 @@ func (s *{{ $.StructName }}) Set{{.Name}}(v {{if .PassByPointer}}*{{end}}{{.Type
 {{end}}
 {{ end }}
 
-func (s *{{ .StructName }}) Clone() {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
+func (s *{{ .StructName }}) Clone(allocators *Allocators) {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
 	return {{if .Type.Flags.StoreByPtr}}&{{end}}{{ .StructName }}{
-        {{ range .Fields }}{{.name}}: {{if .Type.MustClone}}s.{{.name}}.Clone(){{else}}s.{{.name}}{{end}},
+        {{ range .Fields }}{{.name}}: {{if .Type.MustClone}}s.{{.name}}.Clone(allocators){{else}}s.{{.name}}{{end}},
         {{ end }}
 	}
 }
@@ -143,6 +154,7 @@ func (s *{{ .StructName }}) byteSize() uint {
        {{- end }}0
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copy{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}) {
 	switch src.typ {
     {{- range .Fields}}
@@ -157,6 +169,29 @@ func copy{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}) {
         {{- end}}
     {{- end}}
     case {{ $.StructName }}TypeNone: dst.SetType(src.typ)
+    default: panic("copy{{.StructName}}: unexpected type: " + fmt.Sprint(src.typ))
+    }
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNew{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}, allocators *Allocators) {
+    dst.typ = src.typ
+	switch src.typ {
+    {{- range .Fields}}
+    case {{ $.StructName }}Type{{.Name}}:
+        {{- if .Type.MustClone}}
+        {{- if .Type.Flags.StoreByPtr}}
+        dst.{{.name}} = allocators.{{ .Type.Storage }}.Alloc()
+        dst.{{.name}}.init(dst.parentModifiedFields, dst.parentModifiedBit)
+        {{- end}}
+        copyToNew{{.Type.TypeName}}(
+            {{- if .Type.Flags.TakePtr}}&{{end}}dst.{{.name }},
+            {{- if .Type.Flags.TakePtr}}&{{end}}src.{{.name}}, allocators)
+        {{- else}}
+        dst.{{.name}} = src.{{.name}}
+        {{- end}}
+    {{- end}}
+    case {{ $.StructName }}TypeNone:
     default: panic("copy{{.StructName}}: unexpected type: " + fmt.Sprint(src.typ))
     }
 }
@@ -445,6 +480,7 @@ type {{ .StructName }}Decoder struct {
     {{if .DictName}}
     dict *{{ .StructName }}DecoderDict
     {{end}}
+    allocators *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -455,6 +491,8 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     }
     state.{{.StructName}}Decoder = d
     defer func() { state.{{.StructName}}Decoder = nil }()
+
+    d.allocators = &state.Allocators
 
     var err error
     d.fieldCount, err = state.StructFieldCounts.{{.StructName}}FieldCount()
@@ -560,7 +598,7 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
         // Decode {{.Name}}
         {{- if .Type.Flags.StoreByPtr}}
         if dst.{{.name}} == nil {
-            dst.{{.name}} = &{{ .Type.Storage }}{}
+            dst.{{.name}} = d.allocators.{{ .Type.Storage }}.Alloc()
             dst.{{.name}}.init(dst.parentModifiedFields, dst.parentModifiedBit)
         }
         {{end}}
@@ -584,3 +622,34 @@ func (d* {{ .StructName }}DecoderDict) Init() {
     d.dict = append(d.dict, nil) // nil {{.StructName}} is RefNum 0
 }
 {{end}}
+
+// {{.StructName}}Allocator implements a custom allocator for {{.StructName}}.
+// It maintains a pool of pre-allocated {{.StructName}} and grows the pool
+// dynamically as needed, up to a maximum size of 64 elements.
+type {{.StructName}}Allocator struct {
+    pool []{{.StructName}}
+    ofs int
+}
+
+// Alloc returns the next available {{.StructName}} from the pool.
+// If the pool is exhausted, it grows the pool by doubling its size
+// up to a maximum of 64 elements.
+func (a *{{.StructName}}Allocator) Alloc() *{{.StructName}} {
+    if a.ofs < len(a.pool) {
+        // Get the next available {{.StructName}} from the pool
+        a.ofs++
+        return &a.pool[a.ofs-1]
+    }
+    // We've exhausted the current pool, prealloc a new pool.
+    return a.prealloc()
+}
+
+//go:noinline
+func (a *{{.StructName}}Allocator) prealloc() *{{.StructName}} {
+    // prealloc expands the pool by doubling its size, up to a maximum of 64 elements.
+    // If the pool is empty, it starts with 1 element.
+    newLen := min(max(len(a.pool)*2, 1), 64)
+    a.pool = make([]{{.StructName}}, newLen)
+    a.ofs = 1
+    return &a.pool[0]
+}

--- a/stefgen/templates/go/struct.go.tmpl
+++ b/stefgen/templates/go/struct.go.tmpl
@@ -84,6 +84,24 @@ func (s *{{ $.StructName }}) init(parentModifiedFields *modifiedFields, parentMo
     {{- end -}}
 }
 
+func (s *{{ $.StructName }}) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit uint64, allocators *Allocators) {
+    s.modifiedFields.parent = parentModifiedFields
+    s.modifiedFields.parentBit = parentModifiedBit
+
+    {{ range .Fields }}
+    {{- if not .Type.IsPrimitive }}
+    {{- if .Type.Flags.StoreByPtr}}
+    {{- if not .Optional}}
+    s.{{.name}} = allocators.{{ .Type.Storage }}.Alloc()
+    s.{{.name}}.initAlloc(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}}, allocators)
+    {{- end}}
+    {{- else }}
+    s.{{.name}}.initAlloc(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}}, allocators)
+    {{- end }}
+    {{- end -}}
+    {{- end -}}
+}
+
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *{{ $.StructName }}) reset() {
@@ -186,11 +204,17 @@ func (s *{{ $.StructName }}) markUnmodifiedRecursively() {
     s.modifiedFields.mask = 0
 }
 
-func (s *{{ .StructName }}) Clone() {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
-	return {{if .Type.Flags.StoreByPtr}}&{{end}}{{ .StructName }}{
-        {{ range .Fields }}{{.name}}: {{if .Type.MustClone}}s.{{.name}}.Clone(){{else}}s.{{.name}}{{end}},
+func (s *{{ .StructName }}) Clone(allocators *Allocators) {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
+{{if .Type.Flags.StoreByPtr}}
+    c := allocators.{{.StructName}}.Alloc()
+    *c = {{.StructName}}{
+{{else}}
+    c := {{.StructName}}{
+{{end}}
+        {{ range .Fields }}{{.name}}: {{if .Type.MustClone}}s.{{.name}}.Clone(allocators){{else}}s.{{.name}}{{end}},
         {{ end }}
 	}
+    return c
 }
 
 // ByteSize returns approximate memory usage in bytes. Used to calculate
@@ -202,6 +226,7 @@ func (s *{{ .StructName }}) byteSize() uint {
        {{- end }}0
 }
 
+// Copy from src to dst, overwriting existing data in dst.
 func copy{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}) {
     {{- range .Fields -}}
     {{- if .Type.MustClone}}
@@ -232,6 +257,41 @@ func copy{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}) {
 	}
 	{{else}}
     dst.Set{{.Name}}({{.Type.ToExported (print "src." .name)}})
+    {{- end}}
+    {{- end}}
+    {{- end}}
+    {{- if .OptionalFieldCount}}
+    dst.optionalFieldsPresent = src.optionalFieldsPresent
+    {{- end}}
+}
+
+// Copy from src to dst. dst is assumed to be just inited.
+func copyToNew{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}, allocators *Allocators) {
+    {{- range .Fields -}}
+    {{- if .Type.MustClone}}
+    {{- if .Optional}}
+    if src.Has{{.Name}}() {
+        dst.mark{{.Name}}Modified()
+    }
+    {{- end}}
+    {{- if .Type.Flags.StoreByPtr}}
+    if src.{{.name}} != nil {
+        dst.{{.name}} = allocators.{{ .Type.Storage }}.Alloc()
+        dst.{{.name}}.init(&dst.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+    {{- end}}
+        copyToNew{{.Type.TypeName}}(
+            {{- if .Type.Flags.TakePtr}}&{{end}}dst.{{.name }},
+            {{- if .Type.Flags.TakePtr}}&{{end}}src.{{.name}}, allocators)
+    {{- if .Type.Flags.StoreByPtr}}
+    }
+    {{- end}}
+    {{- else}}
+	{{- if .Optional}}
+	if src.Has{{.Name}}() {
+		dst.Set{{.Name}}({{.Type.ToExported (print "src." .name)}})
+	}
+	{{else}}
+    dst.{{.name}} = src.{{.name}}
     {{- end}}
     {{- end}}
     {{- end}}
@@ -375,6 +435,7 @@ type {{ .StructName }}Encoder struct {
     {{- end }}
     {{if .DictName}}
 	dict *{{ .StructName }}EncoderDict{{end}}
+    allocators *Allocators
 
     keepFieldMask uint64
     fieldCount uint
@@ -416,6 +477,7 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
     {{- if .DictName}}
 	e.dict = &state.{{.DictName}}
     {{- end}}
+    e.allocators = &state.Allocators
 
     // Number of fields in the output data schema.
     var err error
@@ -495,7 +557,7 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
 	}
 
 	// The {{ .StructName }} does not exist in the dictionary. Add it to the dictionary.
-	valInDict := val.Clone()
+	valInDict := val.Clone(e.allocators)
 	entry = {{ .StructName }}Entry{refNum: uint64(e.dict.dict.Len()), val: valInDict}
 	e.dict.dict.Set(valInDict, entry)
     e.dict.limiter.AddDictElemSize(valInDict.byteSize())
@@ -585,6 +647,7 @@ type {{ .StructName }}Decoder struct {
     {{if .DictName}}
     dict *{{ .StructName }}DecoderDict
     {{end}}
+    allocators *Allocators
 }
 
 // Init is called once in the lifetime of the stream.
@@ -595,6 +658,8 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     }
     state.{{.StructName}}Decoder = d
     defer func() { state.{{.StructName}}Decoder = nil }()
+
+    d.allocators = &state.Allocators
 
     // Number of fields in the input data schema.
     var err error
@@ -687,7 +752,7 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
 
 	// *dstPtr is pointing to a element in the dictionary. We are not allowed
 	// to modify it. Make a clone of it and decode into the clone.
-	val := (*dstPtr).Clone()
+	val := (*dstPtr).Clone(d.allocators)
     *dstPtr = val
 	{{- else}}
     val := dstPtr
@@ -712,7 +777,7 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
 		// Field is changed and is present, decode it.
         {{- if .Type.Flags.StoreByPtr}}
         if val.{{.name}} == nil {
-            val.{{.name}} = &{{ .Type.Storage }}{}
+            val.{{.name}} = d.allocators.{{ .Type.Storage }}.Alloc()
             val.{{.name}}.init(&val.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
         }
         {{end}}
@@ -747,6 +812,37 @@ func (d* {{ .StructName }}DecoderDict) Reset() {
     d.Init()
 }
 {{end}}
+
+// {{.StructName}}Allocator implements a custom allocator for {{.StructName}}.
+// It maintains a pool of pre-allocated {{.StructName}} and grows the pool
+// dynamically as needed, up to a maximum size of 64 elements.
+type {{.StructName}}Allocator struct {
+    pool []{{.StructName}}
+    ofs int
+}
+
+// Alloc returns the next available {{.StructName}} from the pool.
+// If the pool is exhausted, it grows the pool by doubling its size
+// up to a maximum of 64 elements.
+func (a *{{.StructName}}Allocator) Alloc() *{{.StructName}} {
+    if a.ofs < len(a.pool) {
+        // Get the next available {{.StructName}} from the pool
+        a.ofs++
+        return &a.pool[a.ofs-1]
+    }
+    // We've exhausted the current pool, prealloc a new pool.
+    return a.prealloc()
+}
+
+//go:noinline
+func (a *{{.StructName}}Allocator) prealloc() *{{.StructName}} {
+    // prealloc expands the pool by doubling its size, up to a maximum of 64 elements.
+    // If the pool is empty, it starts with 1 element.
+    newLen := min(max(len(a.pool)*2, 1), 64)
+    a.pool = make([]{{.StructName}}, newLen)
+    a.ofs = 1
+    return &a.pool[0]
+}
 
 {{if .IsMainStruct}}
 var wireSchema{{.StructName}} = []byte{ {{printf .Schema}} }

--- a/stefgen/templates/go/tools_test.go.tmpl
+++ b/stefgen/templates/go/tools_test.go.tmpl
@@ -251,8 +251,8 @@ func generateData(rootStruct, outFileName string, randSeed uint64, recordCount u
 
 		if randSeed == 0 {
 			randSeed = uint64(time.Now().UnixNano())
-			fmt.Printf("Using random seed: %d\n", randSeed)
 		}
+		fmt.Printf("Using random seed: %d\n", randSeed)
 		random := rand.New(rand.NewPCG(randSeed, 0))
 
 		opts := pkg.WriterOptions{}


### PR DESCRIPTION
Custom allocators batch allocation requests of structs and oneofs.
The CPU improvement for array- and dict-heavy schemas is around 7-25%:

```
                                                       │ bench_main.txt │         bench_current.txt          │
                                                       │     sec/op     │   sec/op     vs base               │
Deserialization/file=deser_stef.prof/format=stef-10         698.4µ ± 1%   521.2µ ± 1%  -25.37% (p=0.000 n=9)
Deserialization/file=otelcol_otlp.prof/format=stef-10       163.5µ ± 1%   132.3µ ± 1%  -19.09% (p=0.000 n=9)
Deserialization/file=wsstreamasync.prof/format=stef-10     1052.9µ ± 0%   976.0µ ± 1%   -7.30% (p=0.000 n=9)
geomean                                                     493.6µ        406.8µ       -17.59%

                                                       │ bench_main.txt │          bench_current.txt          │
                                                       │      B/op      │     B/op      vs base               │
Deserialization/file=deser_stef.prof/format=stef-10        1.081Mi ± 0%   1.205Mi ± 0%  +11.50% (p=0.000 n=9)
Deserialization/file=otelcol_otlp.prof/format=stef-10      385.1Ki ± 0%   424.8Ki ± 0%  +10.32% (p=0.000 n=9)
Deserialization/file=wsstreamasync.prof/format=stef-10     1.516Mi ± 0%   1.619Mi ± 0%   +6.84% (p=0.000 n=9)
geomean                                                    871.3Ki        954.4Ki        +9.54%

                                                       │ bench_main.txt │         bench_current.txt          │
                                                       │   allocs/op    │  allocs/op   vs base               │
Deserialization/file=deser_stef.prof/format=stef-10        11.932k ± 0%   2.610k ± 0%  -78.13% (p=0.000 n=9)
Deserialization/file=otelcol_otlp.prof/format=stef-10       3.598k ± 0%   1.270k ± 0%  -64.70% (p=0.000 n=9)
Deserialization/file=wsstreamasync.prof/format=stef-10     15.915k ± 0%   2.253k ± 0%  -85.84% (p=0.000 n=9)
geomean                                                     8.808k        1.955k       -77.81%
```

There is an increase in memory usage, which is an acceptable tradeoff for speed
improvements and reduction in allocation counts resulting in less GC work.