### PR TITLE
Fix oneof encoding bugs

### DIFF
--- a/examples/jsonl/internal/jsonstef/record.go
+++ b/examples/jsonl/internal/jsonstef/record.go
@@ -63,7 +63,9 @@ func (s *Record) initAlloc(parentModifiedFields *modifiedFields, parentModifiedB
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Record) reset() {
 
-	s.value.reset()
+	if s.value != nil {
+		s.value.reset()
+	}
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -66,6 +66,11 @@ func (s *Function) initAlloc(parentModifiedFields *modifiedFields, parentModifie
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Function) reset() {
+
+	s.name = ""
+	s.systemName = ""
+	s.filename = ""
+	s.startLine = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/line.go
+++ b/examples/profile/internal/profile/line.go
@@ -67,7 +67,11 @@ func (s *Line) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Line) reset() {
 
-	s.function.reset()
+	if s.function != nil {
+		s.function.reset()
+	}
+	s.line = 0
+	s.column = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -73,8 +73,12 @@ func (s *Location) initAlloc(parentModifiedFields *modifiedFields, parentModifie
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Location) reset() {
 
-	s.mapping.reset()
+	if s.mapping != nil {
+		s.mapping.reset()
+	}
+	s.address = 0
 	s.lines.reset()
+	s.isFolded = false
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -76,6 +76,16 @@ func (s *Mapping) initAlloc(parentModifiedFields *modifiedFields, parentModified
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Mapping) reset() {
+
+	s.memoryStart = 0
+	s.memoryLimit = 0
+	s.fileOffset = 0
+	s.filename = ""
+	s.buildId = ""
+	s.hasFunctions = false
+	s.hasFilenames = false
+	s.hasLineNumbers = false
+	s.hasInlineFrames = false
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/numvalue.go
+++ b/examples/profile/internal/profile/numvalue.go
@@ -60,6 +60,9 @@ func (s *NumValue) initAlloc(parentModifiedFields *modifiedFields, parentModifie
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *NumValue) reset() {
+
+	s.val = 0
+	s.unit = ""
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/profilemetadata.go
+++ b/examples/profile/internal/profile/profilemetadata.go
@@ -83,9 +83,18 @@ func (s *ProfileMetadata) initAlloc(parentModifiedFields *modifiedFields, parent
 // Will not reset internal fields such as parentModifiedFields.
 func (s *ProfileMetadata) reset() {
 
-	s.periodType.reset()
+	s.dropFrames = ""
+	s.keepFrames = ""
+	s.timeNanos = 0
+	s.durationNanos = 0
+	if s.periodType != nil {
+		s.periodType.reset()
+	}
+	s.period = 0
 	s.comments.reset()
-	s.defaultSampleType.reset()
+	if s.defaultSampleType != nil {
+		s.defaultSampleType.reset()
+	}
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/samplevalue.go
+++ b/examples/profile/internal/profile/samplevalue.go
@@ -65,7 +65,10 @@ func (s *SampleValue) initAlloc(parentModifiedFields *modifiedFields, parentModi
 // Will not reset internal fields such as parentModifiedFields.
 func (s *SampleValue) reset() {
 
-	s.type_.reset()
+	s.val = 0
+	if s.type_ != nil {
+		s.type_.reset()
+	}
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -62,6 +62,9 @@ func (s *SampleValueType) initAlloc(parentModifiedFields *modifiedFields, parent
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *SampleValueType) reset() {
+
+	s.type_ = ""
+	s.unit = ""
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/event.go
+++ b/go/otel/oteltef/event.go
@@ -67,7 +67,10 @@ func (s *Event) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBi
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Event) reset() {
 
+	s.name = ""
+	s.timeUnixNano = 0
 	s.attributes.reset()
+	s.droppedAttributesCount = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/exemplar.go
+++ b/go/otel/oteltef/exemplar.go
@@ -71,7 +71,10 @@ func (s *Exemplar) initAlloc(parentModifiedFields *modifiedFields, parentModifie
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Exemplar) reset() {
 
+	s.timestamp = 0
 	s.value.reset()
+	s.spanID = pkg.EmptyBytes
+	s.traceID = pkg.EmptyBytes
 	s.filteredAttributes.reset()
 }
 

--- a/go/otel/oteltef/exemplarvalue.go
+++ b/go/otel/oteltef/exemplarvalue.go
@@ -50,6 +50,8 @@ func (s *ExemplarValue) initAlloc(parentModifiedFields *modifiedFields, parentMo
 // Will not reset internal fields such as parentModifiedFields.
 func (s *ExemplarValue) reset() {
 	s.typ = ExemplarValueTypeNone
+	// We don't need to reset the state of the field since that will be done
+	// when the type is changed, see SetType().
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.
@@ -74,10 +76,19 @@ func (s *ExemplarValue) Type() ExemplarValueType {
 	return s.typ
 }
 
+// resetContained resets the currently contained value, if any.
+// Normally used after switching to a different type to make sure
+// the value contained is in blank state.
+func (s *ExemplarValue) resetContained() {
+	switch s.typ {
+	}
+}
+
 // SetType sets the type of the value currently contained in ExemplarValue.
 func (s *ExemplarValue) SetType(typ ExemplarValueType) {
 	if s.typ != typ {
 		s.typ = typ
+		s.resetContained()
 		switch typ {
 		}
 		s.markParentModified()
@@ -472,7 +483,10 @@ func (d *ExemplarValueDecoder) Decode(dstPtr *ExemplarValue) error {
 	}
 
 	dst := dstPtr
-	dst.typ = ExemplarValueType(typ)
+	if dst.typ != ExemplarValueType(typ) {
+		dst.typ = ExemplarValueType(typ)
+		dst.resetContained()
+	}
 	d.prevType = ExemplarValueType(dst.typ)
 
 	// Decode selected field

--- a/go/otel/oteltef/exphistogrambuckets.go
+++ b/go/otel/oteltef/exphistogrambuckets.go
@@ -63,6 +63,7 @@ func (s *ExpHistogramBuckets) initAlloc(parentModifiedFields *modifiedFields, pa
 // Will not reset internal fields such as parentModifiedFields.
 func (s *ExpHistogramBuckets) reset() {
 
+	s.offset = 0
 	s.bucketCounts.reset()
 }
 

--- a/go/otel/oteltef/exphistogramvalue.go
+++ b/go/otel/oteltef/exphistogramvalue.go
@@ -90,8 +90,15 @@ func (s *ExpHistogramValue) initAlloc(parentModifiedFields *modifiedFields, pare
 // Will not reset internal fields such as parentModifiedFields.
 func (s *ExpHistogramValue) reset() {
 
+	s.count = 0
+	s.sum = 0.0
+	s.min = 0.0
+	s.max = 0.0
+	s.scale = 0
+	s.zeroCount = 0
 	s.positiveBuckets.reset()
 	s.negativeBuckets.reset()
+	s.zeroThreshold = 0.0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/histogramvalue.go
+++ b/go/otel/oteltef/histogramvalue.go
@@ -80,6 +80,10 @@ func (s *HistogramValue) initAlloc(parentModifiedFields *modifiedFields, parentM
 // Will not reset internal fields such as parentModifiedFields.
 func (s *HistogramValue) reset() {
 
+	s.count = 0
+	s.sum = 0.0
+	s.min = 0.0
+	s.max = 0.0
 	s.bucketCounts.reset()
 }
 

--- a/go/otel/oteltef/link.go
+++ b/go/otel/oteltef/link.go
@@ -71,7 +71,12 @@ func (s *Link) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Link) reset() {
 
+	s.traceID = pkg.EmptyBytes
+	s.spanID = pkg.EmptyBytes
+	s.traceState = ""
+	s.flags = 0
 	s.attributes.reset()
+	s.droppedAttributesCount = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/metric.go
+++ b/go/otel/oteltef/metric.go
@@ -79,8 +79,14 @@ func (s *Metric) initAlloc(parentModifiedFields *modifiedFields, parentModifiedB
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Metric) reset() {
 
+	s.name = ""
+	s.description = ""
+	s.unit = ""
+	s.type_ = 0
 	s.metadata.reset()
 	s.histogramBounds.reset()
+	s.aggregationTemporality = 0
+	s.monotonic = false
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/metrics.go
+++ b/go/otel/oteltef/metrics.go
@@ -88,9 +88,15 @@ func (s *Metrics) initAlloc(parentModifiedFields *modifiedFields, parentModified
 func (s *Metrics) reset() {
 
 	s.envelope.reset()
-	s.metric.reset()
-	s.resource.reset()
-	s.scope.reset()
+	if s.metric != nil {
+		s.metric.reset()
+	}
+	if s.resource != nil {
+		s.resource.reset()
+	}
+	if s.scope != nil {
+		s.scope.reset()
+	}
 	s.attributes.reset()
 	s.point.reset()
 }

--- a/go/otel/oteltef/point.go
+++ b/go/otel/oteltef/point.go
@@ -69,6 +69,8 @@ func (s *Point) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBi
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Point) reset() {
 
+	s.startTimestamp = 0
+	s.timestamp = 0
 	s.value.reset()
 	s.exemplars.reset()
 }

--- a/go/otel/oteltef/quantilevalue.go
+++ b/go/otel/oteltef/quantilevalue.go
@@ -60,6 +60,9 @@ func (s *QuantileValue) initAlloc(parentModifiedFields *modifiedFields, parentMo
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *QuantileValue) reset() {
+
+	s.quantile = 0.0
+	s.value = 0.0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/resource.go
+++ b/go/otel/oteltef/resource.go
@@ -67,7 +67,9 @@ func (s *Resource) initAlloc(parentModifiedFields *modifiedFields, parentModifie
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Resource) reset() {
 
+	s.schemaURL = ""
 	s.attributes.reset()
+	s.droppedAttributesCount = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/scope.go
+++ b/go/otel/oteltef/scope.go
@@ -71,7 +71,11 @@ func (s *Scope) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBi
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Scope) reset() {
 
+	s.name = ""
+	s.version = ""
+	s.schemaURL = ""
 	s.attributes.reset()
+	s.droppedAttributesCount = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/span.go
+++ b/go/otel/oteltef/span.go
@@ -93,7 +93,17 @@ func (s *Span) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBit
 // Will not reset internal fields such as parentModifiedFields.
 func (s *Span) reset() {
 
+	s.traceID = pkg.EmptyBytes
+	s.spanID = pkg.EmptyBytes
+	s.traceState = ""
+	s.parentSpanID = pkg.EmptyBytes
+	s.flags = 0
+	s.name = ""
+	s.kind = 0
+	s.startTimeUnixNano = 0
+	s.endTimeUnixNano = 0
 	s.attributes.reset()
+	s.droppedAttributesCount = 0
 	s.events.reset()
 	s.links.reset()
 	s.status.reset()

--- a/go/otel/oteltef/spans.go
+++ b/go/otel/oteltef/spans.go
@@ -78,8 +78,12 @@ func (s *Spans) initAlloc(parentModifiedFields *modifiedFields, parentModifiedBi
 func (s *Spans) reset() {
 
 	s.envelope.reset()
-	s.resource.reset()
-	s.scope.reset()
+	if s.resource != nil {
+		s.resource.reset()
+	}
+	if s.scope != nil {
+		s.scope.reset()
+	}
 	s.span.reset()
 }
 

--- a/go/otel/oteltef/spanstatus.go
+++ b/go/otel/oteltef/spanstatus.go
@@ -60,6 +60,9 @@ func (s *SpanStatus) initAlloc(parentModifiedFields *modifiedFields, parentModif
 // reset the struct to its initial state, as if init() was just called.
 // Will not reset internal fields such as parentModifiedFields.
 func (s *SpanStatus) reset() {
+
+	s.message = ""
+	s.code = 0
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.

--- a/go/otel/oteltef/summaryvalue.go
+++ b/go/otel/oteltef/summaryvalue.go
@@ -65,6 +65,8 @@ func (s *SummaryValue) initAlloc(parentModifiedFields *modifiedFields, parentMod
 // Will not reset internal fields such as parentModifiedFields.
 func (s *SummaryValue) reset() {
 
+	s.count = 0
+	s.sum = 0.0
 	s.quantileValues.reset()
 }
 

--- a/go/pkg/types.go
+++ b/go/pkg/types.go
@@ -9,6 +9,8 @@ import (
 // Bytes is a sequence of immutable bytes.
 type Bytes string
 
+const EmptyBytes = Bytes("")
+
 func Uint64Compare(left, right uint64) int {
 	if left > right {
 		return 1

--- a/java/src/main/java/com/example/oteltef/AnyValue.java
+++ b/java/src/main/java/com/example/oteltef/AnyValue.java
@@ -38,26 +38,18 @@ public class AnyValue {
         this.parentModifiedBit = parentModifiedBit;
         
         string = StringValue.empty;
-        
-        
-        
+        bool = false;
+        int64 = 0;
+        float64 = 0.0;
         bytes = Types.emptyBytes;
     }
 
+    // reset the struct to its initial state, as if init() was just called.
+    // Will not reset internal fields such as parentModifiedFields.
     void reset() {
         typ = Type.TypeNone;
-        
-        string = StringValue.empty;
-        
-        
-        
-        if (array != null) {
-            array.reset();
-        }
-        if (kVList != null) {
-            kVList.reset();
-        }
-        bytes = Types.emptyBytes;
+        // We don't need to reset the state of the field since that will be done
+        // when the type is changed, see SetType().
     }
 
     // Type enum for oneof
@@ -88,10 +80,29 @@ public class AnyValue {
         return typ;
     }
 
+    // resetContained resets the currently contained value, if any.
+    // Normally used after switching to a different type to make sure
+    // the value contained is in blank state.
+    void resetContained() {
+        switch (typ) {
+        case TypeArray:
+            if (array != null) {
+                array.reset();
+            }
+            break;
+        case TypeKVList:
+            if (kVList != null) {
+                kVList.reset();
+            }
+            break;
+        }
+    }
+
     // setType sets the type of the value currently contained in AnyValue.
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            resetContained();
             switch (typ) {
             case TypeArray:
                 if (array == null) {

--- a/java/src/main/java/com/example/oteltef/AnyValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/AnyValueDecoder.java
@@ -194,7 +194,11 @@ class AnyValueDecoder {
         if (typ < 0 || typ >= AnyValue.Type.values().length) {
             throw new IOException("Invalid oneof type");
         }
-        dst.typ = AnyValue.Type.values()[(int)typ];
+        AnyValue.Type newType = AnyValue.Type.values()[(int)typ];
+        if (dst.typ != newType) {
+            dst.typ = newType;
+            dst.resetContained();
+        }
         prevType = dst.typ;
         this.lastValPtr = dst;
         // Decode selected field

--- a/java/src/main/java/com/example/oteltef/Envelope.java
+++ b/java/src/main/java/com/example/oteltef/Envelope.java
@@ -43,7 +43,9 @@ public class Envelope {
 
     void reset() {
         
-        attributes.reset();
+        if (attributes != null) {
+            attributes.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Event.java
+++ b/java/src/main/java/com/example/oteltef/Event.java
@@ -45,17 +45,19 @@ public class Event {
         modifiedFields.parentBit = parentModifiedBit;
         
         name = StringValue.empty;
-        
+        timeUnixNano = 0;
         attributes = new Attributes(modifiedFields, fieldModifiedAttributes);
-        
+        droppedAttributesCount = 0;
     }
 
     void reset() {
         
         name = StringValue.empty;
-        
-        attributes.reset();
-        
+        timeUnixNano = 0;
+        if (attributes != null) {
+            attributes.reset();
+        }
+        droppedAttributesCount = 0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Exemplar.java
+++ b/java/src/main/java/com/example/oteltef/Exemplar.java
@@ -46,7 +46,7 @@ public class Exemplar {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
+        timestamp = 0;
         value = new ExemplarValue(modifiedFields, fieldModifiedValue);
         spanID = Types.emptyBytes;
         traceID = Types.emptyBytes;
@@ -55,11 +55,15 @@ public class Exemplar {
 
     void reset() {
         
-        
-        value.reset();
+        timestamp = 0;
+        if (value != null) {
+            value.reset();
+        }
         spanID = Types.emptyBytes;
         traceID = Types.emptyBytes;
-        filteredAttributes.reset();
+        if (filteredAttributes != null) {
+            filteredAttributes.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/ExemplarValue.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarValue.java
@@ -32,15 +32,16 @@ public class ExemplarValue {
         this.parentModifiedFields = parentModifiedFields;
         this.parentModifiedBit = parentModifiedBit;
         
-        
-        
+        int64 = 0;
+        float64 = 0.0;
     }
 
+    // reset the struct to its initial state, as if init() was just called.
+    // Will not reset internal fields such as parentModifiedFields.
     void reset() {
         typ = Type.TypeNone;
-        
-        
-        
+        // We don't need to reset the state of the field since that will be done
+        // when the type is changed, see SetType().
     }
 
     // Type enum for oneof
@@ -66,10 +67,19 @@ public class ExemplarValue {
         return typ;
     }
 
+    // resetContained resets the currently contained value, if any.
+    // Normally used after switching to a different type to make sure
+    // the value contained is in blank state.
+    void resetContained() {
+        switch (typ) {
+        }
+    }
+
     // setType sets the type of the value currently contained in ExemplarValue.
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            resetContained();
             switch (typ) {
             }
             this.markParentModified();

--- a/java/src/main/java/com/example/oteltef/ExemplarValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarValueDecoder.java
@@ -95,7 +95,11 @@ class ExemplarValueDecoder {
         if (typ < 0 || typ >= ExemplarValue.Type.values().length) {
             throw new IOException("Invalid oneof type");
         }
-        dst.typ = ExemplarValue.Type.values()[(int)typ];
+        ExemplarValue.Type newType = ExemplarValue.Type.values()[(int)typ];
+        if (dst.typ != newType) {
+            dst.typ = newType;
+            dst.resetContained();
+        }
         prevType = dst.typ;
         this.lastValPtr = dst;
         // Decode selected field

--- a/java/src/main/java/com/example/oteltef/ExpHistogramBuckets.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramBuckets.java
@@ -40,14 +40,16 @@ public class ExpHistogramBuckets {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
+        offset = 0;
         bucketCounts = new Uint64Array(modifiedFields, fieldModifiedBucketCounts);
     }
 
     void reset() {
         
-        
-        bucketCounts.reset();
+        offset = 0;
+        if (bucketCounts != null) {
+            bucketCounts.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/ExpHistogramValue.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramValue.java
@@ -63,28 +63,32 @@ public class ExpHistogramValue {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
-        
-        
-        
-        
-        
+        count = 0;
+        sum = 0.0;
+        min = 0.0;
+        max = 0.0;
+        scale = 0;
+        zeroCount = 0;
         positiveBuckets = new ExpHistogramBuckets(modifiedFields, fieldModifiedPositiveBuckets);
         negativeBuckets = new ExpHistogramBuckets(modifiedFields, fieldModifiedNegativeBuckets);
-        
+        zeroThreshold = 0.0;
     }
 
     void reset() {
         
-        
-        
-        
-        
-        
-        
-        positiveBuckets.reset();
-        negativeBuckets.reset();
-        
+        count = 0;
+        sum = 0.0;
+        min = 0.0;
+        max = 0.0;
+        scale = 0;
+        zeroCount = 0;
+        if (positiveBuckets != null) {
+            positiveBuckets.reset();
+        }
+        if (negativeBuckets != null) {
+            negativeBuckets.reset();
+        }
+        zeroThreshold = 0.0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Float64Array.java
+++ b/java/src/main/java/com/example/oteltef/Float64Array.java
@@ -153,7 +153,7 @@ public class Float64Array {
             markModified();
             // Initialize newly added elements.
             for (int i = oldLen; i < newLen; i++) {
-                
+                elems[i] = 0.0;
             }
         } else if (oldLen > newLen) {
             // Shrink it

--- a/java/src/main/java/com/example/oteltef/HistogramValue.java
+++ b/java/src/main/java/com/example/oteltef/HistogramValue.java
@@ -55,20 +55,22 @@ public class HistogramValue {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
-        
-        
-        
+        count = 0;
+        sum = 0.0;
+        min = 0.0;
+        max = 0.0;
         bucketCounts = new Int64Array(modifiedFields, fieldModifiedBucketCounts);
     }
 
     void reset() {
         
-        
-        
-        
-        
-        bucketCounts.reset();
+        count = 0;
+        sum = 0.0;
+        min = 0.0;
+        max = 0.0;
+        if (bucketCounts != null) {
+            bucketCounts.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Int64Array.java
+++ b/java/src/main/java/com/example/oteltef/Int64Array.java
@@ -153,7 +153,7 @@ public class Int64Array {
             markModified();
             // Initialize newly added elements.
             for (int i = oldLen; i < newLen; i++) {
-                
+                elems[i] = 0;
             }
         } else if (oldLen > newLen) {
             // Shrink it

--- a/java/src/main/java/com/example/oteltef/Link.java
+++ b/java/src/main/java/com/example/oteltef/Link.java
@@ -51,9 +51,9 @@ public class Link {
         traceID = Types.emptyBytes;
         spanID = Types.emptyBytes;
         traceState = StringValue.empty;
-        
+        flags = 0;
         attributes = new Attributes(modifiedFields, fieldModifiedAttributes);
-        
+        droppedAttributesCount = 0;
     }
 
     void reset() {
@@ -61,9 +61,11 @@ public class Link {
         traceID = Types.emptyBytes;
         spanID = Types.emptyBytes;
         traceState = StringValue.empty;
-        
-        attributes.reset();
-        
+        flags = 0;
+        if (attributes != null) {
+            attributes.reset();
+        }
+        droppedAttributesCount = 0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Metric.java
+++ b/java/src/main/java/com/example/oteltef/Metric.java
@@ -55,11 +55,11 @@ public class Metric {
         name = StringValue.empty;
         description = StringValue.empty;
         unit = StringValue.empty;
-        
+        type_ = 0;
         metadata = new Attributes(modifiedFields, fieldModifiedMetadata);
         histogramBounds = new Float64Array(modifiedFields, fieldModifiedHistogramBounds);
-        
-        
+        aggregationTemporality = 0;
+        monotonic = false;
     }
 
     void reset() {
@@ -67,11 +67,15 @@ public class Metric {
         name = StringValue.empty;
         description = StringValue.empty;
         unit = StringValue.empty;
-        
-        metadata.reset();
-        histogramBounds.reset();
-        
-        
+        type_ = 0;
+        if (metadata != null) {
+            metadata.reset();
+        }
+        if (histogramBounds != null) {
+            histogramBounds.reset();
+        }
+        aggregationTemporality = 0;
+        monotonic = false;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Metrics.java
+++ b/java/src/main/java/com/example/oteltef/Metrics.java
@@ -58,12 +58,24 @@ public class Metrics {
 
     void reset() {
         
-        envelope.reset();
-        metric.reset();
-        resource.reset();
-        scope.reset();
-        attributes.reset();
-        point.reset();
+        if (envelope != null) {
+            envelope.reset();
+        }
+        if (metric != null) {
+            metric.reset();
+        }
+        if (resource != null) {
+            resource.reset();
+        }
+        if (scope != null) {
+            scope.reset();
+        }
+        if (attributes != null) {
+            attributes.reset();
+        }
+        if (point != null) {
+            point.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Point.java
+++ b/java/src/main/java/com/example/oteltef/Point.java
@@ -44,18 +44,22 @@ public class Point {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
-        
+        startTimestamp = 0;
+        timestamp = 0;
         value = new PointValue(modifiedFields, fieldModifiedValue);
         exemplars = new ExemplarArray(modifiedFields, fieldModifiedExemplars);
     }
 
     void reset() {
         
-        
-        
-        value.reset();
-        exemplars.reset();
+        startTimestamp = 0;
+        timestamp = 0;
+        if (value != null) {
+            value.reset();
+        }
+        if (exemplars != null) {
+            exemplars.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/PointValue.java
+++ b/java/src/main/java/com/example/oteltef/PointValue.java
@@ -35,24 +35,16 @@ public class PointValue {
         this.parentModifiedFields = parentModifiedFields;
         this.parentModifiedBit = parentModifiedBit;
         
-        
-        
+        int64 = 0;
+        float64 = 0.0;
     }
 
+    // reset the struct to its initial state, as if init() was just called.
+    // Will not reset internal fields such as parentModifiedFields.
     void reset() {
         typ = Type.TypeNone;
-        
-        
-        
-        if (histogram != null) {
-            histogram.reset();
-        }
-        if (expHistogram != null) {
-            expHistogram.reset();
-        }
-        if (summary != null) {
-            summary.reset();
-        }
+        // We don't need to reset the state of the field since that will be done
+        // when the type is changed, see SetType().
     }
 
     // Type enum for oneof
@@ -81,10 +73,34 @@ public class PointValue {
         return typ;
     }
 
+    // resetContained resets the currently contained value, if any.
+    // Normally used after switching to a different type to make sure
+    // the value contained is in blank state.
+    void resetContained() {
+        switch (typ) {
+        case TypeHistogram:
+            if (histogram != null) {
+                histogram.reset();
+            }
+            break;
+        case TypeExpHistogram:
+            if (expHistogram != null) {
+                expHistogram.reset();
+            }
+            break;
+        case TypeSummary:
+            if (summary != null) {
+                summary.reset();
+            }
+            break;
+        }
+    }
+
     // setType sets the type of the value currently contained in PointValue.
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            resetContained();
             switch (typ) {
             case TypeHistogram:
                 if (histogram == null) {

--- a/java/src/main/java/com/example/oteltef/PointValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/PointValueDecoder.java
@@ -176,7 +176,11 @@ class PointValueDecoder {
         if (typ < 0 || typ >= PointValue.Type.values().length) {
             throw new IOException("Invalid oneof type");
         }
-        dst.typ = PointValue.Type.values()[(int)typ];
+        PointValue.Type newType = PointValue.Type.values()[(int)typ];
+        if (dst.typ != newType) {
+            dst.typ = newType;
+            dst.resetContained();
+        }
         prevType = dst.typ;
         this.lastValPtr = dst;
         // Decode selected field

--- a/java/src/main/java/com/example/oteltef/QuantileValue.java
+++ b/java/src/main/java/com/example/oteltef/QuantileValue.java
@@ -40,14 +40,14 @@ public class QuantileValue {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
-        
+        quantile = 0.0;
+        value = 0.0;
     }
 
     void reset() {
         
-        
-        
+        quantile = 0.0;
+        value = 0.0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Resource.java
+++ b/java/src/main/java/com/example/oteltef/Resource.java
@@ -44,14 +44,16 @@ public class Resource {
         
         schemaURL = StringValue.empty;
         attributes = new Attributes(modifiedFields, fieldModifiedAttributes);
-        
+        droppedAttributesCount = 0;
     }
 
     void reset() {
         
         schemaURL = StringValue.empty;
-        attributes.reset();
-        
+        if (attributes != null) {
+            attributes.reset();
+        }
+        droppedAttributesCount = 0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Scope.java
+++ b/java/src/main/java/com/example/oteltef/Scope.java
@@ -50,7 +50,7 @@ public class Scope {
         version = StringValue.empty;
         schemaURL = StringValue.empty;
         attributes = new Attributes(modifiedFields, fieldModifiedAttributes);
-        
+        droppedAttributesCount = 0;
     }
 
     void reset() {
@@ -58,8 +58,10 @@ public class Scope {
         name = StringValue.empty;
         version = StringValue.empty;
         schemaURL = StringValue.empty;
-        attributes.reset();
-        
+        if (attributes != null) {
+            attributes.reset();
+        }
+        droppedAttributesCount = 0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Span.java
+++ b/java/src/main/java/com/example/oteltef/Span.java
@@ -68,13 +68,13 @@ public class Span {
         spanID = Types.emptyBytes;
         traceState = StringValue.empty;
         parentSpanID = Types.emptyBytes;
-        
+        flags = 0;
         name = StringValue.empty;
-        
-        
-        
+        kind = 0;
+        startTimeUnixNano = 0;
+        endTimeUnixNano = 0;
         attributes = new Attributes(modifiedFields, fieldModifiedAttributes);
-        
+        droppedAttributesCount = 0;
         events = new EventArray(modifiedFields, fieldModifiedEvents);
         links = new LinkArray(modifiedFields, fieldModifiedLinks);
         status = new SpanStatus(modifiedFields, fieldModifiedStatus);
@@ -86,16 +86,24 @@ public class Span {
         spanID = Types.emptyBytes;
         traceState = StringValue.empty;
         parentSpanID = Types.emptyBytes;
-        
+        flags = 0;
         name = StringValue.empty;
-        
-        
-        
-        attributes.reset();
-        
-        events.reset();
-        links.reset();
-        status.reset();
+        kind = 0;
+        startTimeUnixNano = 0;
+        endTimeUnixNano = 0;
+        if (attributes != null) {
+            attributes.reset();
+        }
+        droppedAttributesCount = 0;
+        if (events != null) {
+            events.reset();
+        }
+        if (links != null) {
+            links.reset();
+        }
+        if (status != null) {
+            status.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/SpanStatus.java
+++ b/java/src/main/java/com/example/oteltef/SpanStatus.java
@@ -41,13 +41,13 @@ public class SpanStatus {
         modifiedFields.parentBit = parentModifiedBit;
         
         message = StringValue.empty;
-        
+        code = 0;
     }
 
     void reset() {
         
         message = StringValue.empty;
-        
+        code = 0;
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Spans.java
+++ b/java/src/main/java/com/example/oteltef/Spans.java
@@ -52,10 +52,18 @@ public class Spans {
 
     void reset() {
         
-        envelope.reset();
-        resource.reset();
-        scope.reset();
-        span.reset();
+        if (envelope != null) {
+            envelope.reset();
+        }
+        if (resource != null) {
+            resource.reset();
+        }
+        if (scope != null) {
+            scope.reset();
+        }
+        if (span != null) {
+            span.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/SummaryValue.java
+++ b/java/src/main/java/com/example/oteltef/SummaryValue.java
@@ -42,16 +42,18 @@ public class SummaryValue {
         modifiedFields.parent = parentModifiedFields;
         modifiedFields.parentBit = parentModifiedBit;
         
-        
-        
+        count = 0;
+        sum = 0.0;
         quantileValues = new QuantileValueArray(modifiedFields, fieldModifiedQuantileValues);
     }
 
     void reset() {
         
-        
-        
-        quantileValues.reset();
+        count = 0;
+        sum = 0.0;
+        if (quantileValues != null) {
+            quantileValues.reset();
+        }
     }
 
     

--- a/java/src/main/java/com/example/oteltef/Uint64Array.java
+++ b/java/src/main/java/com/example/oteltef/Uint64Array.java
@@ -153,7 +153,7 @@ public class Uint64Array {
             markModified();
             // Initialize newly added elements.
             for (int i = oldLen; i < newLen; i++) {
-                
+                elems[i] = 0;
             }
         } else if (oldLen > newLen) {
             // Shrink it

--- a/stefgen/generator/genschema.go
+++ b/stefgen/generator/genschema.go
@@ -180,20 +180,35 @@ func (r *genPrimitiveTypeRef) Storage() string {
 // Return empty string if there is no need to assign an initial value
 // since the default initial value is good enough.
 func (r *genPrimitiveTypeRef) InitVal() string {
-	switch r.Lang {
-	case LangGo:
-		return "" // Go does not need initial values for primitive types.
-	case LangJava:
-		switch r.Type {
-		case schema.PrimitiveTypeString:
+	switch r.Type {
+	case schema.PrimitiveTypeInt64:
+		return "0"
+	case schema.PrimitiveTypeUint64:
+		return "0"
+	case schema.PrimitiveTypeFloat64:
+		return "0.0"
+	case schema.PrimitiveTypeBool:
+		return "false"
+	case schema.PrimitiveTypeString:
+		switch r.Lang {
+		case LangGo:
+			return `""`
+		case LangJava:
 			return "StringValue.empty"
-		case schema.PrimitiveTypeBytes:
+		default:
+			panic("unknown language")
+		}
+	case schema.PrimitiveTypeBytes:
+		switch r.Lang {
+		case LangGo:
+			return "pkg.EmptyBytes"
+		case LangJava:
 			return "Types.emptyBytes"
 		default:
-			return ""
+			panic("unknown language")
 		}
 	default:
-		panic(fmt.Sprintf("unknown language %v", r.Lang))
+		panic("unknown type")
 	}
 }
 

--- a/stefgen/templates/go/oneof.go.tmpl
+++ b/stefgen/templates/go/oneof.go.tmpl
@@ -62,11 +62,8 @@ func (s *{{ $.StructName }}) initAlloc(parentModifiedFields *modifiedFields, par
 // Will not reset internal fields such as parentModifiedFields.
 func (s *{{ $.StructName }}) reset() {
     s.typ = {{$.StructName }}TypeNone
-    {{ range .Fields }}
-	{{- if not .Type.IsPrimitive }}
-    s.{{.name}}.reset()
-    {{- end -}}
-    {{- end -}}
+    // We don't need to reset the state of the field since that will be done
+    // when the type is changed, see SetType().
 }
 
 // fixParent sets the parentModifiedFields pointer to the supplied value.
@@ -96,10 +93,31 @@ func (s *{{ $.StructName }}) Type() {{$.StructName }}Type {
     return s.typ
 }
 
+// resetContained resets the currently contained value, if any.
+// Normally used after switching to a different type to make sure
+// the value contained is in blank state.
+func (s *{{ $.StructName }}) resetContained() {
+    switch s.typ {
+    {{- range .Fields }}
+    {{- if not .Type.IsPrimitive}}
+    case {{ $.StructName }}Type{{.Name}}:
+        {{- if .Type.Flags.StoreByPtr}}
+        if s.{{.name}} != nil {
+            s.{{.name}}.reset()
+        }
+        {{- else}}
+        s.{{.name}}.reset()
+        {{- end -}}
+    {{- end -}}
+    {{- end }}
+    }
+}
+
 // SetType sets the type of the value currently contained in {{ $.StructName }}.
 func (s *{{ $.StructName }}) SetType(typ {{$.StructName }}Type) {
-	if s.typ!=typ {
-        s.typ=typ
+	if s.typ != typ {
+        s.typ = typ
+        s.resetContained()
         switch typ {
         {{- range .Fields }}
         {{- if .Type.Flags.StoreByPtr}}
@@ -588,7 +606,10 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
     }
 
 	dst := dstPtr
-	dst.typ = {{.StructName}}Type(typ)
+	if dst.typ != {{.StructName}}Type(typ) {
+	    dst.typ = {{.StructName}}Type(typ)
+	    dst.resetContained()
+	}
     d.prevType = {{.StructName}}Type(dst.typ)
 
 	// Decode selected field

--- a/stefgen/templates/go/struct.go.tmpl
+++ b/stefgen/templates/go/struct.go.tmpl
@@ -106,8 +106,16 @@ func (s *{{ $.StructName }}) initAlloc(parentModifiedFields *modifiedFields, par
 // Will not reset internal fields such as parentModifiedFields.
 func (s *{{ $.StructName }}) reset() {
     {{ range .Fields }}
-	{{- if not .Type.IsPrimitive }}
+	{{- if .Type.IsPrimitive }}
+	{{if .Type.InitVal}}s.{{.name}} = {{.Type.InitVal}};{{end}}
+	{{- else}}
+	{{- if .Type.Flags.StoreByPtr}}
+    if s.{{.name}} != nil {
+        s.{{.name}}.reset()
+    }
+    {{- else}}
     s.{{.name}}.reset()
+    {{- end -}}
     {{- end -}}
     {{- end -}}
 }

--- a/stefgen/templates/java/oneof.java.tmpl
+++ b/stefgen/templates/java/oneof.java.tmpl
@@ -37,17 +37,12 @@ public class {{ .StructName }} {
         {{- end }}
     }
 
+    // reset the struct to its initial state, as if init() was just called.
+    // Will not reset internal fields such as parentModifiedFields.
     void reset() {
         typ = Type.TypeNone;
-        {{ range .Fields }}
-        {{- if .Type.IsPrimitive }}
-        {{if .Type.InitVal}}{{.name}} = {{.Type.InitVal}};{{end}}
-        {{- else}}
-        if ({{.name}} != null) {
-            {{.name}}.reset();
-        }
-        {{- end }}
-        {{- end }}
+        // We don't need to reset the state of the field since that will be done
+        // when the type is changed, see SetType().
     }
 
     // Type enum for oneof
@@ -74,10 +69,28 @@ public class {{ .StructName }} {
         return typ;
     }
 
+    // resetContained resets the currently contained value, if any.
+    // Normally used after switching to a different type to make sure
+    // the value contained is in blank state.
+    void resetContained() {
+        switch (typ) {
+        {{- range .Fields }}
+        {{- if not .Type.IsPrimitive}}
+        case Type{{.Name}}:
+            if ({{.name}} != null) {
+                {{.name}}.reset();
+            }
+            break;
+        {{- end -}}
+        {{- end }}
+        }
+    }
+
     // setType sets the type of the value currently contained in {{ $.StructName }}.
     public void setType(Type typ) {
         if (this.typ != typ) {
             this.typ = typ;
+            resetContained();
             switch (typ) {
             {{- range .Fields }}
             {{- if not .Type.IsPrimitive}}

--- a/stefgen/templates/java/oneofDecoder.java.tmpl
+++ b/stefgen/templates/java/oneofDecoder.java.tmpl
@@ -115,7 +115,11 @@ class {{ .StructName }}Decoder {
         if (typ < 0 || typ >= {{.StructName}}.Type.values().length) {
             throw new IOException("Invalid oneof type");
         }
-        dst.typ = {{.StructName}}.Type.values()[(int)typ];
+        {{.StructName}}.Type newType = {{.StructName}}.Type.values()[(int)typ];
+        if (dst.typ != newType) {
+            dst.typ = newType;
+            dst.resetContained();
+        }
         prevType = dst.typ;
         this.lastValPtr = dst;
         // Decode selected field

--- a/stefgen/templates/java/struct.java.tmpl
+++ b/stefgen/templates/java/struct.java.tmpl
@@ -67,7 +67,9 @@ public class {{ .StructName }} {
         {{- if .Type.IsPrimitive }}
         {{if .Type.InitVal}}{{.name}} = {{.Type.InitVal}};{{end}}
         {{- else}}
-        {{.name}}.reset();
+        if ({{.name}} != null) {
+            {{.name}}.reset();
+        }
         {{- end }}
         {{- end }}
     }


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/129
Fixes https://github.com/splunk/stef/issues/130

The problem was that oneof reset was not fully resetting
the state of the oneof and when the type of the oneof was
switched back it would appear in incorrect state.

This is now fixed by fixing the reset() and setType() methods.

This is stacked on top of https://github.com/splunk/stef/pull/128 which needs to be merged first.