### PR TITLE
STEF IDL parser now requires "package"

### DIFF
--- a/go/grpc/testdata/schema.stef
+++ b/go/grpc/testdata/schema.stef
@@ -1,3 +1,5 @@
+package test
+
 struct TestStruct root {
     F1 uint64
     F2 string

--- a/go/pkg/idl/parser.go
+++ b/go/pkg/idl/parser.go
@@ -390,25 +390,26 @@ func (p *Parser) parseMultimapField(field *schema.MultimapField) error {
 }
 
 func (p *Parser) parsePackage() error {
-	if p.lexer.Token() == tPackage {
-		p.lexer.Next() // skip "package"
-
-		// Package name is a sequence of identifiers separated by dots.
-		packageComponents := []string{}
-		for {
-			if p.lexer.Token() != tIdent {
-				return p.error("identifier expected")
-			}
-			packageComponents = append(packageComponents, p.lexer.Ident())
-			p.lexer.Next()
-
-			if p.lexer.Token() != tDot {
-				break
-			}
-			p.lexer.Next()
-		}
-		p.schema.PackageName = packageComponents
+	if err := p.eat(tPackage); err != nil {
+		return err
 	}
+
+	// Package name is a sequence of identifiers separated by dots.
+	packageComponents := []string{}
+	for {
+		if p.lexer.Token() != tIdent {
+			return p.error("identifier expected")
+		}
+		packageComponents = append(packageComponents, p.lexer.Ident())
+		p.lexer.Next()
+
+		if p.lexer.Token() != tDot {
+			break
+		}
+		p.lexer.Next()
+	}
+	p.schema.PackageName = packageComponents
+
 	return nil
 }
 

--- a/go/pkg/idl/parser_test.go
+++ b/go/pkg/idl/parser_test.go
@@ -61,6 +61,10 @@ func TestParserErrors(t *testing.T) {
 			input: "package abc enum Enum { Value = }",
 			err:   "test.stef:1:33: enum field value expected",
 		},
+		{
+			input: "struct Root root {}",
+			err:   "test.stef:1:2: expected package but got struct",
+		},
 	}
 
 	for _, test := range tests {

--- a/go/pkg/idl/testdata/example.stef
+++ b/go/pkg/idl/testdata/example.stef
@@ -1,3 +1,5 @@
+package books
+
 // Records of events that happened with books. This is the main record struct.
 struct BookRecords root {
     Book Book       // Which book the event is about.


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/138

Previously if "package" was missing it did not error which resulted in failure later when trying to generate the code.