### PR TITLE
Improve benchmark outputs to make zstd time/size more prominent

### DIFF
--- a/benchmarks/size_test.go
+++ b/benchmarks/size_test.go
@@ -230,13 +230,17 @@ func TestMetricsSize(t *testing.T) {
 			)
 
 			if wantChart {
-				chart.Record(nil, encoding.LongName(), float64(zstdedSize))
+				chart.Record(
+					nil, encoding.LongName(),
+					"Compressed size in bytes (zstd)",
+					float64(zstdedSize),
+				)
 			}
 		}
 
 		if wantChart {
 			chart.EndChart(
-				"Bytes", "Compressed size in bytes (zstd)",
+				"Bytes",
 				charts.WithColorsOpts(opts.Colors{"#92C5F9"}),
 			)
 		}
@@ -306,11 +310,14 @@ func TestMetricsMultipart(t *testing.T) {
 					firstSize = curSize
 				}
 
-				chart.Record(nil, encoding.LongName(), float64(curSize))
+				chart.Record(
+					nil, encoding.LongName(), "Size in bytes, compression="+compression,
+					float64(curSize),
+				)
 			}
 
 			chart.EndChart(
-				"Bytes", "Size in bytes, compression="+compression,
+				"Bytes",
 				charts.WithColorsOpts(opts.Colors{"#87BB62"}),
 			)
 		}

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -9,137 +9,137 @@
 <body>
 <div/><h2>Size Benchmarks - One Large Batch</h2>
 <div class="container">
-    <div class="item" id="mJYhGkwRaHSo" style="width:900px;height:500px;"></div>
+    <div class="item" id="WSASQLlLoAyV" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_mJYhGkwRaHSo = echarts.init(document.getElementById('mJYhGkwRaHSo'), "white", { renderer: "canvas" });
-    let option_mJYhGkwRaHSo = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":236734,"label":{"show":true}},{"value":211051,"label":{"show":true}},{"value":549012,"label":{"show":true}},{"value":93235,"label":{"show":true}},{"value":262005,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_WSASQLlLoAyV = echarts.init(document.getElementById('WSASQLlLoAyV'), "white", { renderer: "canvas" });
+    let option_WSASQLlLoAyV = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","stack":"stack","data":[{"value":1617878,"label":{"show":true}},{"value":6304039,"label":{"show":true}},{"value":1646140,"label":{"show":true}},{"value":3690963,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_mJYhGkwRaHSo.setOption(option_mJYhGkwRaHSo);
+    goecharts_WSASQLlLoAyV.setOption(option_WSASQLlLoAyV);
 </script>
 <div class="container">
-    <div class="item" id="QXxJVEdgMuGz" style="width:900px;height:500px;"></div>
+    <div class="item" id="YHNdkdXXBPXp" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_QXxJVEdgMuGz = echarts.init(document.getElementById('QXxJVEdgMuGz'), "white", { renderer: "canvas" });
-    let option_QXxJVEdgMuGz = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":205821,"label":{"show":true}},{"value":134558,"label":{"show":true}},{"value":846035,"label":{"show":true}},{"value":83006,"label":{"show":true}},{"value":293520,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_YHNdkdXXBPXp = echarts.init(document.getElementById('YHNdkdXXBPXp'), "white", { renderer: "canvas" });
+    let option_YHNdkdXXBPXp = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","stack":"stack","data":[{"value":237375,"label":{"show":true}},{"value":211051,"label":{"show":true}},{"value":549012,"label":{"show":true}},{"value":92568,"label":{"show":true}},{"value":264167,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_QXxJVEdgMuGz.setOption(option_QXxJVEdgMuGz);
+    goecharts_YHNdkdXXBPXp.setOption(option_YHNdkdXXBPXp);
 </script>
 <div class="container">
-    <div class="item" id="PNBSLlJQWHHG" style="width:900px;height:500px;"></div>
+    <div class="item" id="xKgMWtoRKMLN" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_PNBSLlJQWHHG = echarts.init(document.getElementById('PNBSLlJQWHHG'), "white", { renderer: "canvas" });
-    let option_PNBSLlJQWHHG = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","data":[{"value":1617878,"label":{"show":true}},{"value":6304039,"label":{"show":true}},{"value":1646707,"label":{"show":true}},{"value":3673787,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_xKgMWtoRKMLN = echarts.init(document.getElementById('xKgMWtoRKMLN'), "white", { renderer: "canvas" });
+    let option_xKgMWtoRKMLN = {"animation":false,"color":["#92C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","stack":"stack","data":[{"value":205790,"label":{"show":true}},{"value":134558,"label":{"show":true}},{"value":846035,"label":{"show":true}},{"value":83011,"label":{"show":true}},{"value":293562,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_PNBSLlJQWHHG.setOption(option_PNBSLlJQWHHG);
+    goecharts_xKgMWtoRKMLN.setOption(option_xKgMWtoRKMLN);
 </script>
 <div/><h2>Size Benchmarks - Many Batches, Multipart</h2>
 <div class="container">
-    <div class="item" id="DhqaKVgfyWUy" style="width:900px;height:500px;"></div>
+    <div class="item" id="GCpAaAJNtqBW" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_DhqaKVgfyWUy = echarts.init(document.getElementById('DhqaKVgfyWUy'), "white", { renderer: "canvas" });
-    let option_DhqaKVgfyWUy = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","data":[{"value":13662327,"label":{"show":true}},{"value":22219873,"label":{"show":true}},{"value":1352774,"label":{"show":true}},{"value":1417021,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_GCpAaAJNtqBW = echarts.init(document.getElementById('GCpAaAJNtqBW'), "white", { renderer: "canvas" });
+    let option_GCpAaAJNtqBW = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","stack":"stack","data":[{"value":13662327,"label":{"show":true}},{"value":22219873,"label":{"show":true}},{"value":1352844,"label":{"show":true}},{"value":1417113,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_DhqaKVgfyWUy.setOption(option_DhqaKVgfyWUy);
+    goecharts_GCpAaAJNtqBW.setOption(option_GCpAaAJNtqBW);
 </script>
 <div class="container">
-    <div class="item" id="YpJcAXFAIvTY" style="width:900px;height:500px;"></div>
+    <div class="item" id="heHUNPQZzSNS" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_YpJcAXFAIvTY = echarts.init(document.getElementById('YpJcAXFAIvTY'), "white", { renderer: "canvas" });
-    let option_YpJcAXFAIvTY = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","data":[{"value":92143355,"label":{"show":true}},{"value":145844039,"label":{"show":true}},{"value":9921423,"label":{"show":true}},{"value":10385686,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_heHUNPQZzSNS = echarts.init(document.getElementById('heHUNPQZzSNS'), "white", { renderer: "canvas" });
+    let option_heHUNPQZzSNS = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","stack":"stack","data":[{"value":92143355,"label":{"show":true}},{"value":145844039,"label":{"show":true}},{"value":9970952,"label":{"show":true}},{"value":10435308,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_YpJcAXFAIvTY.setOption(option_YpJcAXFAIvTY);
+    goecharts_heHUNPQZzSNS.setOption(option_heHUNPQZzSNS);
 </script>
 <div class="container">
-    <div class="item" id="CaapJBlwGARK" style="width:900px;height:500px;"></div>
+    <div class="item" id="rgAQHVSYwXKr" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_CaapJBlwGARK = echarts.init(document.getElementById('CaapJBlwGARK'), "white", { renderer: "canvas" });
-    let option_CaapJBlwGARK = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","data":[{"value":4428191,"label":{"show":true}},{"value":2750908,"label":{"show":true}},{"value":245977,"label":{"show":true}},{"value":368842,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_rgAQHVSYwXKr = echarts.init(document.getElementById('rgAQHVSYwXKr'), "white", { renderer: "canvas" });
+    let option_rgAQHVSYwXKr = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","stack":"stack","data":[{"value":4428191,"label":{"show":true}},{"value":2750908,"label":{"show":true}},{"value":245986,"label":{"show":true}},{"value":369040,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_CaapJBlwGARK.setOption(option_CaapJBlwGARK);
+    goecharts_rgAQHVSYwXKr.setOption(option_rgAQHVSYwXKr);
 </script>
 <div class="container">
-    <div class="item" id="WzklSgkjlAPf" style="width:900px;height:500px;"></div>
+    <div class="item" id="CjAJrmlwRYZL" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_WzklSgkjlAPf = echarts.init(document.getElementById('WzklSgkjlAPf'), "white", { renderer: "canvas" });
-    let option_WzklSgkjlAPf = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","data":[{"value":40924021,"label":{"show":true}},{"value":19855253,"label":{"show":true}},{"value":3376374,"label":{"show":true}},{"value":4167995,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_CjAJrmlwRYZL = echarts.init(document.getElementById('CjAJrmlwRYZL'), "white", { renderer: "canvas" });
+    let option_CjAJrmlwRYZL = {"animation":false,"color":["#87BB62","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","stack":"stack","data":[{"value":40924021,"label":{"show":true}},{"value":19855253,"label":{"show":true}},{"value":3373308,"label":{"show":true}},{"value":4166740,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
 
-    goecharts_WzklSgkjlAPf.setOption(option_WzklSgkjlAPf);
+    goecharts_CjAJrmlwRYZL.setOption(option_CjAJrmlwRYZL);
 </script>
 <div/><h2>Speed Benchmarks</h2>
 <div class="container">
-    <div class="item" id="kfbtncaORGFO" style="width:900px;height:500px;"></div>
+    <div class="item" id="EEXpPXJjAnzG" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_kfbtncaORGFO = echarts.init(document.getElementById('kfbtncaORGFO'), "white", { renderer: "canvas" });
-    let option_kfbtncaORGFO = {"animation":false,"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","data":[{"value":1106,"label":{"show":true}},{"value":279,"label":{"show":true}},{"value":54,"label":{"show":true}},{"value":314,"label":{"show":true}}]}],"title":{"text":"Serialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_EEXpPXJjAnzG = echarts.init(document.getElementById('EEXpPXJjAnzG'), "white", { renderer: "canvas" });
+    let option_EEXpPXJjAnzG = {"animation":false,"color":["#92C5F9","#12C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Serialize","type":"bar","stack":"stack","data":[{"value":1075,"label":{"show":true}},{"value":263,"label":{"show":true}},{"value":66,"label":{"show":true}},{"value":244,"label":{"show":true}}]},{"name":"Zstd Compress","type":"bar","stack":"stack","data":[{"value":238,"label":{"show":true}},{"value":218,"label":{"show":true}},{"value":15,"label":{"show":true}},{"value":53,"label":{"show":true}}]}],"title":{"text":"Serialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_kfbtncaORGFO.setOption(option_kfbtncaORGFO);
+    goecharts_EEXpPXJjAnzG.setOption(option_EEXpPXJjAnzG);
 </script>
 <div class="container">
-    <div class="item" id="sWrowIYXTKEn" style="width:900px;height:500px;"></div>
+    <div class="item" id="RrUNMBzgaMYd" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_sWrowIYXTKEn = echarts.init(document.getElementById('sWrowIYXTKEn'), "white", { renderer: "canvas" });
-    let option_sWrowIYXTKEn = {"animation":false,"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to deserialize one data point","type":"bar","data":[{"value":2344,"label":{"show":true}},{"value":736,"label":{"show":true}},{"value":25,"label":{"show":true}},{"value":103,"label":{"show":true}}]}],"title":{"text":"Deserialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_RrUNMBzgaMYd = echarts.init(document.getElementById('RrUNMBzgaMYd'), "white", { renderer: "canvas" });
+    let option_RrUNMBzgaMYd = {"animation":false,"color":["#92C5F9","#12C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"Deserialize","type":"bar","stack":"stack","data":[{"value":2259,"label":{"show":true}},{"value":664,"label":{"show":true}},{"value":23,"label":{"show":true}},{"value":69,"label":{"show":true}}]},{"name":"Zstd Decompress","type":"bar","stack":"stack","data":[{"value":180,"label":{"show":true}},{"value":93,"label":{"show":true}},{"value":4,"label":{"show":true}},{"value":14,"label":{"show":true}}]}],"title":{"text":"Deserialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_sWrowIYXTKEn.setOption(option_sWrowIYXTKEn);
+    goecharts_RrUNMBzgaMYd.setOption(option_RrUNMBzgaMYd);
 </script>
 <div class="container">
-    <div class="item" id="SoQaiGBTXNEZ" style="width:900px;height:500px;"></div>
+    <div class="item" id="OJJGoOrXMtuL" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_SoQaiGBTXNEZ = echarts.init(document.getElementById('SoQaiGBTXNEZ'), "white", { renderer: "canvas" });
-    let option_SoQaiGBTXNEZ = {"animation":false,"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","data":[{"value":8099,"label":{"show":true}},{"value":2796,"label":{"show":true}},{"value":277,"label":{"show":true}},{"value":1199,"label":{"show":true}},{"value":310,"label":{"show":true}}]}],"title":{"text":"Serialization From pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_OJJGoOrXMtuL = echarts.init(document.getElementById('OJJGoOrXMtuL'), "white", { renderer: "canvas" });
+    let option_OJJGoOrXMtuL = {"animation":false,"color":["#92C5F9","#12C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","stack":"stack","data":[{"value":7803,"label":{"show":true}},{"value":2657,"label":{"show":true}},{"value":262,"label":{"show":true}},{"value":1292,"label":{"show":true}},{"value":243,"label":{"show":true}}]},{"name":"Zstd Compress","type":"bar","stack":"stack","data":[{"value":82,"label":{"show":true}},{"value":242,"label":{"show":true}},{"value":218,"label":{"show":true}},{"value":15,"label":{"show":true}},{"value":54,"label":{"show":true}}]}],"title":{"text":"Serialization From pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_SoQaiGBTXNEZ.setOption(option_SoQaiGBTXNEZ);
+    goecharts_OJJGoOrXMtuL.setOption(option_OJJGoOrXMtuL);
 </script>
 <div class="container">
-    <div class="item" id="LkDWkdmfFRZQ" style="width:900px;height:500px;"></div>
+    <div class="item" id="qFVTBWZCwDTD" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_LkDWkdmfFRZQ = echarts.init(document.getElementById('LkDWkdmfFRZQ'), "white", { renderer: "canvas" });
-    let option_LkDWkdmfFRZQ = {"animation":false,"color":["#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","data":[{"value":1400,"label":{"show":true}},{"value":3194,"label":{"show":true}},{"value":775,"label":{"show":true}},{"value":305,"label":{"show":true}},{"value":479,"label":{"show":true}}]}],"title":{"text":"Deserialization To pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_qFVTBWZCwDTD = echarts.init(document.getElementById('qFVTBWZCwDTD'), "white", { renderer: "canvas" });
+    let option_qFVTBWZCwDTD = {"animation":false,"color":["#92C5F9","#12C5F9","#5470c6","#91cc75","#fac858","#ee6666","#73c0de","#3ba272","#fc8452","#9a60b4","#ea7ccc"],"legend":{},"series":[{"name":"CPU time to deserialize one data point","type":"bar","stack":"stack","data":[{"value":1248,"label":{"show":true}},{"value":2826,"label":{"show":true}},{"value":651,"label":{"show":true}},{"value":265,"label":{"show":true}},{"value":391,"label":{"show":true}}]},{"name":"Zstd Decompress","type":"bar","stack":"stack","data":[{"value":79,"label":{"show":true}},{"value":181,"label":{"show":true}},{"value":93,"label":{"show":true}},{"value":4,"label":{"show":true}},{"value":14,"label":{"show":true}}]}],"title":{"text":"Deserialization To pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_LkDWkdmfFRZQ.setOption(option_LkDWkdmfFRZQ);
+    goecharts_qFVTBWZCwDTD.setOption(option_qFVTBWZCwDTD);
 </script>
 </body></html>


### PR DESCRIPTION
This adds zstd sizes to Profile and JSONL examples:
```
File --> Size in bytes         | JSON   | Protobuf       | STEF           | JSONZ  | ProtoZ | stefz
currencies_historical          |   4197 |   4393 (1.05x) |   1082 (0.26x) |    756 |   1105 |    782
macosx_releases                |   2449 |   2604 (1.06x) |    935 (0.38x) |    523 |    766 |    596
programming_languages_keywords |  10681 |  11912 (1.12x) |   8225 (0.77x) |   3746 |   5074 |   4053

File                 | pprof  | stef   | pprofz | stefz
deser_stef.prof      |  83343 |  83768 |  33326 |  29424 (1.005x/0.883x)
otelcol_otlp.prof    |  31864 |  38859 |  13054 |   9215 (1.220x/0.706x)
wsstreamasync.prof   |  92996 | 128295 |  29093 |  28150 (1.380x/0.968x)
```

Also makes zstd CPU times visible as a stack bar chart in benchmark.html, for example:
<img width="914" height="519" alt="image" src="https://github.com/user-attachments/assets/3a713a1d-ccfb-422b-9bc5-f741d576d561" />
