### PR TITLE
[Breaking] Use non-delta codec for oneof type

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -85,7 +85,7 @@ jobs:
           HEAD=$(git rev-parse HEAD)
           git reset --hard ${{ github.event.pull_request.base.sha }}
           export REF_NAME=main
-          cd benchmarks && make bench-run bench-stat
+          cd benchmarks && make gentestfiles bench-run bench-stat
           git reset --hard $HEAD
 
       - name: Benchmark stats

--- a/benchmarks/scripts/genoldtestfiles.sh
+++ b/benchmarks/scripts/genoldtestfiles.sh
@@ -14,7 +14,7 @@ TMPDIR=$(mktemp -d)
 cp ./gentestfiles.sh "$TMPDIR/"
 
 # Checkout the base branch to compare to
-BASE_BRANCH=21f498a293dbdf6e29c75385ba0043dc0f5e4009
+BASE_BRANCH=tigran/oneofcodec # Change this to the main branch commit after tigran/oneofcodec is merged.
 git -c advice.detachedHead=false checkout $BASE_BRANCH
 
 # Convert/generate the files.

--- a/go/otel/oteltef/anyvalue.go
+++ b/go/otel/oteltef/anyvalue.go
@@ -3,6 +3,7 @@ package oteltef
 
 import (
 	"fmt"
+	"math/bits"
 	"math/rand/v2"
 	"strings"
 	"unsafe"
@@ -478,10 +479,13 @@ func (s *AnyValue) mutateRandom(random *rand.Rand, schem *schema.Schema) {
 
 // AnyValueEncoder implements encoding of AnyValue
 type AnyValueEncoder struct {
-	buf        pkg.BitsWriter
-	limiter    *pkg.SizeLimiter
-	prevType   AnyValueType
+	buf     pkg.BitsWriter
+	limiter *pkg.SizeLimiter
+
+	// fieldCount is the number of fields, i.e. the number of types in this oneof.
 	fieldCount uint
+	// Number of bits needed to encode the type (including None type).
+	typeBitCount uint
 
 	// Field encoders.
 	stringEncoder encoders.StringDictEncoder
@@ -516,6 +520,7 @@ func (e *AnyValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	if err != nil {
 		return fmt.Errorf("cannot find struct %s in override schema: %v", "AnyValue", err)
 	}
+	e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount) + 1))
 
 	// Init encoder for String field.
 	if e.fieldCount <= 0 {
@@ -605,7 +610,6 @@ func (e *AnyValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 }
 
 func (e *AnyValueEncoder) Reset() {
-	e.prevType = 0
 
 	if e.fieldCount <= 0 {
 		return // String and all subsequent fields are skipped.
@@ -653,13 +657,10 @@ func (e *AnyValueEncoder) Encode(val *AnyValue) {
 		typ = AnyValueTypeNone
 	}
 
-	// Compute type delta. 0 means the type is the same as the last time.
-	typDelta := int(typ) - int(e.prevType)
-	e.prevType = typ
-	bitCount := e.buf.WriteVarintCompact(int64(typDelta))
+	e.buf.WriteBits(uint64(typ), e.typeBitCount)
 
 	// Account written bits in the limiter.
-	e.limiter.AddFrameBits(bitCount)
+	e.limiter.AddFrameBits(e.typeBitCount)
 
 	// Encode currently selected field.
 	switch typ {
@@ -757,9 +758,11 @@ type AnyValueDecoder struct {
 	column     *pkg.ReadableColumn
 	lastValPtr *AnyValue
 	lastVal    AnyValue
-	fieldCount uint
 
-	prevType AnyValueType
+	// fieldCount is the number of fields, i.e. the number of types in this oneof.
+	fieldCount uint
+	// Number of bits needed to encode the type (including None type).
+	typeBitCount uint
 
 	// Field decoders.
 
@@ -803,6 +806,8 @@ func (d *AnyValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 
 	d.lastVal.init(nil, 0)
 	d.lastValPtr = &d.lastVal
+
+	d.typeBitCount = uint(bits.Len64(uint64(d.fieldCount) + 1))
 	if d.fieldCount <= 0 {
 		return nil // String and subsequent fields are skipped.
 	}
@@ -922,7 +927,6 @@ func (d *AnyValueDecoder) Continue() {
 }
 
 func (d *AnyValueDecoder) Reset() {
-	d.prevType = 0
 
 	if d.fieldCount <= 0 {
 		return // String and all subsequent fields are skipped.
@@ -963,21 +967,20 @@ func (d *AnyValueDecoder) Reset() {
 }
 
 func (d *AnyValueDecoder) Decode(dstPtr *AnyValue) error {
-	// Read Type delta
-	typeDelta := d.buf.ReadVarintCompact()
-
-	// Calculate and validate the new Type
-	typ := int(d.prevType) + int(typeDelta)
-	if typ < 0 || typ >= int(AnyValueTypeCount) {
+	// Read the type and validate it
+	typ := uint(d.buf.ReadBits(d.typeBitCount))
+	if typ >= uint(d.fieldCount+1) {
 		return pkg.ErrInvalidOneOfType
 	}
 
 	dst := dstPtr
 	if dst.typ != AnyValueType(typ) {
 		dst.typ = AnyValueType(typ)
+		// The type changed, we need to reset the contained value so that
+		// it does not contain carry-over data from a previous record that
+		// was of this same type.
 		dst.resetContained()
 	}
-	d.prevType = AnyValueType(dst.typ)
 
 	// Decode selected field
 	switch dst.typ {

--- a/java/src/main/java/com/example/oteltef/AnyValueEncoder.java
+++ b/java/src/main/java/com/example/oteltef/AnyValueEncoder.java
@@ -12,8 +12,10 @@ import java.io.IOException;
 class AnyValueEncoder {
     private BitsWriter buf = new BitsWriter();
     private SizeLimiter limiter;
-    private AnyValue.Type prevType;
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
     private int fieldCount;
+    // Number of bits needed to encode the type (including None type).
+    private int typeBitCount;
 
     // Field encoders.
     
@@ -41,10 +43,10 @@ class AnyValueEncoder {
         state.AnyValueEncoder = this;
 
         try {
-            prevType = AnyValue.Type.TypeNone;
             this.limiter = state.getLimiter();
 
             this.fieldCount = state.getStructFieldCounts().getAnyValueFieldCount();
+            this.typeBitCount = Integer.SIZE - Integer.numberOfLeadingZeros(this.fieldCount+1);
             
             // Init encoder for String field.
             if (this.fieldCount <= 0) {
@@ -106,7 +108,6 @@ class AnyValueEncoder {
     }
 
     public void reset() {
-        prevType = AnyValue.Type.TypeNone;
         
         if (fieldCount <= 0) {
             return; // String and all subsequent fields are skipped.
@@ -148,8 +149,6 @@ class AnyValueEncoder {
 
     // Encode encodes val into buf
     public void encode(AnyValue val) throws IOException {
-        int oldLen = buf.bitCount();
-
         AnyValue.Type typ = val.typ;
         if (typ.getValue() > fieldCount) {
             // The current field type is not supported in target schema. Encode the type as None.
@@ -157,13 +156,10 @@ class AnyValueEncoder {
         }
 
         // Compute type delta. 0 means the type is the same as the last time.
-        int typDelta = typ.getValue() - prevType.getValue();
-        prevType = typ;
-        buf.writeVarintCompact(typDelta);
+        buf.writeBits(typ.getValue(), typeBitCount);
 
         // Account written bits in the limiter.
-        int newLen = buf.bitCount();
-        limiter.addFrameBits(newLen-oldLen);
+        limiter.addFrameBits(typeBitCount);
 
         // Encode currently selected field.
         switch (typ) {

--- a/java/src/main/java/com/example/oteltef/ExemplarValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarValueDecoder.java
@@ -12,10 +12,10 @@ import java.io.IOException;
 class ExemplarValueDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
-    private ExemplarValue lastValPtr;
-    private ExemplarValue lastVal = new ExemplarValue();
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
     private int fieldCount;
-    private ExemplarValue.Type prevType;
+    // Number of bits needed to encode the type (including None type).
+    private int typeBitCount;
 
     // Field decoders.
     
@@ -34,11 +34,9 @@ class ExemplarValueDecoder {
         state.ExemplarValueDecoder = this;
 
         try {
-            prevType = ExemplarValue.Type.TypeNone;
             this.fieldCount = state.getStructFieldCounts().getExemplarValueFieldCount();
+            this.typeBitCount = Integer.SIZE - Integer.numberOfLeadingZeros(this.fieldCount+1);
             this.column = columns.getColumn();
-            this.lastVal.init(null, 0);
-            this.lastValPtr = this.lastVal;
             Exception err = null;
             
             if (this.fieldCount <= 0) {
@@ -75,7 +73,6 @@ class ExemplarValueDecoder {
     }
 
     public void reset() {
-        prevType = ExemplarValue.Type.TypeNone;
         
         if (fieldCount <= 0) {
             return; // Int64 and all subsequent fields are skipped.
@@ -90,18 +87,18 @@ class ExemplarValueDecoder {
     // Decode decodes a value from the buffer into dst.
     public ExemplarValue decode(ExemplarValue dst) throws IOException {
         // Read type delta
-        long typeDelta = this.buf.readVarintCompact();
-        long typ = prevType.getValue() + typeDelta;
+        long typ = this.buf.readBits(typeBitCount);
         if (typ < 0 || typ >= ExemplarValue.Type.values().length) {
             throw new IOException("Invalid oneof type");
         }
         ExemplarValue.Type newType = ExemplarValue.Type.values()[(int)typ];
         if (dst.typ != newType) {
             dst.typ = newType;
+            // The type changed, we need to reset the contained value so that
+            // it does not contain carry-over data from a previous record that
+            // was of this same type.
             dst.resetContained();
         }
-        prevType = dst.typ;
-        this.lastValPtr = dst;
         // Decode selected field
         switch (dst.typ) {
         case TypeInt64:

--- a/java/src/main/java/com/example/oteltef/ExemplarValueEncoder.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarValueEncoder.java
@@ -12,8 +12,10 @@ import java.io.IOException;
 class ExemplarValueEncoder {
     private BitsWriter buf = new BitsWriter();
     private SizeLimiter limiter;
-    private ExemplarValue.Type prevType;
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
     private int fieldCount;
+    // Number of bits needed to encode the type (including None type).
+    private int typeBitCount;
 
     // Field encoders.
     
@@ -31,10 +33,10 @@ class ExemplarValueEncoder {
         state.ExemplarValueEncoder = this;
 
         try {
-            prevType = ExemplarValue.Type.TypeNone;
             this.limiter = state.getLimiter();
 
             this.fieldCount = state.getStructFieldCounts().getExemplarValueFieldCount();
+            this.typeBitCount = Integer.SIZE - Integer.numberOfLeadingZeros(this.fieldCount+1);
             
             // Init encoder for Int64 field.
             if (this.fieldCount <= 0) {
@@ -54,7 +56,6 @@ class ExemplarValueEncoder {
     }
 
     public void reset() {
-        prevType = ExemplarValue.Type.TypeNone;
         
         if (fieldCount <= 0) {
             return; // Int64 and all subsequent fields are skipped.
@@ -68,8 +69,6 @@ class ExemplarValueEncoder {
 
     // Encode encodes val into buf
     public void encode(ExemplarValue val) throws IOException {
-        int oldLen = buf.bitCount();
-
         ExemplarValue.Type typ = val.typ;
         if (typ.getValue() > fieldCount) {
             // The current field type is not supported in target schema. Encode the type as None.
@@ -77,13 +76,10 @@ class ExemplarValueEncoder {
         }
 
         // Compute type delta. 0 means the type is the same as the last time.
-        int typDelta = typ.getValue() - prevType.getValue();
-        prevType = typ;
-        buf.writeVarintCompact(typDelta);
+        buf.writeBits(typ.getValue(), typeBitCount);
 
         // Account written bits in the limiter.
-        int newLen = buf.bitCount();
-        limiter.addFrameBits(newLen-oldLen);
+        limiter.addFrameBits(typeBitCount);
 
         // Encode currently selected field.
         switch (typ) {

--- a/stef-spec/specification.md
+++ b/stef-spec/specification.md
@@ -732,7 +732,7 @@ follows. `RefNum` will be set to the number of the found entry in the dictionary
 
 ```
 OneOf {
-    ChoiceDelta: SC
+    Choice: 1..6
 }
 ```
 
@@ -740,14 +740,12 @@ Fields declared in oneof are numbered, starting from number 1 and assigned
 incrementing numbers in the order of declaration. This assigned number is called the 
 "oneof choice number". Choice number 0 corresponds to "None" choice.
 
-OneOf codec encodes choice number in the column in delta encoding:
-- If this is the first oneof value since encoder was started ChoiceDelta is equal to the 
-  choice number.
-- For subsequent oneof values ChoiceDelta is the delta between this oneof instance's 
-  choice number and the previous oneof instance's choice number.
+OneOf codec encodes choice number in the column using as many bits as are necessary to
+encode the highest field number (at least one bit is always used, even if the oneof
+has no fields, so that a value of 0 can be encoded to represent the "None" choice).
 
 The chosen field's value is encoded in the child column using field's codec.
-After the ChoiceDelta is encoded the OneOf encoder will call the encoders for the 
+After the Choice is encoded the OneOf encoder will call the encoders for the 
 currently chosen field, that will then encode the chosen field's values in its 
 corresponding column. Note that all other fields of the oneof (other than the current 
 chosen field) will have nothing appended to their columns.
@@ -756,7 +754,7 @@ chosen field) will have nothing appended to their columns.
 
 ```
 Array {
-    Length: SC
+    Length: UC
 }
 ```
 

--- a/stefgen/templates/go/oneof.go.tmpl
+++ b/stefgen/templates/go/oneof.go.tmpl
@@ -2,6 +2,7 @@ package {{ .PackageName }}
 
 import (
     "fmt"
+	"math/bits"
     "math/rand/v2"
     "strings"
 	"unsafe"
@@ -384,8 +385,11 @@ typeChanged := false
 type {{ .StructName }}Encoder struct {
     buf pkg.BitsWriter
 	limiter *pkg.SizeLimiter
-    prevType {{.StructName}}Type
+
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
     fieldCount uint
+    // Number of bits needed to encode the type (including None type).
+    typeBitCount uint
 
     // Field encoders.
     {{- range .Fields }}
@@ -440,6 +444,7 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
     if err != nil {
         return fmt.Errorf("cannot find struct %s in override schema: %v", {{printf "%q" .StructName}}, err)
     }
+    e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount)+1))
 
     {{ range $i, $e := .Fields }}
     // Init encoder for {{.Name}} field.
@@ -471,7 +476,6 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
 }
 
 func (e *{{ .StructName }}Encoder) Reset() {
-    e.prevType = 0
     {{ range $i, $e := .Fields }}
     if e.fieldCount <= {{$i}} {
         return // {{.Name}} and all subsequent fields are skipped.
@@ -492,13 +496,10 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
         typ = {{ $.StructName }}TypeNone
     }
 
-	// Compute type delta. 0 means the type is the same as the last time.
-	typDelta := int(typ) - int(e.prevType)
-    e.prevType = typ
-	bitCount := e.buf.WriteVarintCompact(int64(typDelta))
+	e.buf.WriteBits(uint64(typ), e.typeBitCount)
 
     // Account written bits in the limiter.
-    e.limiter.AddFrameBits(bitCount)
+    e.limiter.AddFrameBits(e.typeBitCount)
 
     // Encode currently selected field.
 	switch typ {
@@ -537,9 +538,11 @@ type {{ .StructName }}Decoder struct {
     column *pkg.ReadableColumn
     lastValPtr *{{.StructName}}
     lastVal {{.StructName}}
-    fieldCount uint
 
-    prevType {{.StructName}}Type
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
+    fieldCount uint
+    // Number of bits needed to encode the type (including None type).
+    typeBitCount uint
 
     // Field decoders.
     {{range .Fields}}
@@ -578,6 +581,8 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     d.lastVal.init(nil,0)
     {{- end}}
     d.lastValPtr = &d.lastVal
+
+    d.typeBitCount = uint(bits.Len64(uint64(d.fieldCount)+1))
 
     {{- range $i,$e := .Fields }}
     if d.fieldCount <= {{$i}} {
@@ -632,7 +637,6 @@ func (d *{{ .StructName }}Decoder) Continue() {
 }
 
 func (d *{{ .StructName }}Decoder) Reset() {
-    d.prevType = 0
     {{ range $i, $e := .Fields }}
     if d.fieldCount <= {{$i}} {
         return // {{.Name}} and all subsequent fields are skipped.
@@ -646,21 +650,20 @@ func (d *{{ .StructName }}Decoder) Reset() {
 }
 
 func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.StructName}}) error {
-	// Read Type delta
-    typeDelta := d.buf.ReadVarintCompact()
-
-	// Calculate and validate the new Type
-	typ := int(d.prevType) + int(typeDelta)
-	if typ < 0 || typ >= int({{.StructName}}TypeCount) {
+	// Read the type and validate it
+	typ := uint(d.buf.ReadBits(d.typeBitCount))
+	if typ >= uint(d.fieldCount+1) {
 		return pkg.ErrInvalidOneOfType
     }
 
 	dst := dstPtr
 	if dst.typ != {{.StructName}}Type(typ) {
 	    dst.typ = {{.StructName}}Type(typ)
+	    // The type changed, we need to reset the contained value so that
+	    // it does not contain carry-over data from a previous record that
+	    // was of this same type.
 	    dst.resetContained()
 	}
-    d.prevType = {{.StructName}}Type(dst.typ)
 
 	// Decode selected field
 	switch dst.typ {

--- a/stefgen/templates/java/oneofDecoder.java.tmpl
+++ b/stefgen/templates/java/oneofDecoder.java.tmpl
@@ -11,10 +11,10 @@ import java.io.IOException;
 class {{ .StructName }}Decoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
-    private {{.StructName}} lastValPtr;
-    private {{.StructName}} lastVal = new {{.StructName}}();
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
     private int fieldCount;
-    private {{.StructName}}.Type prevType;
+    // Number of bits needed to encode the type (including None type).
+    private int typeBitCount;
 
     // Field decoders.
     {{range .Fields}}
@@ -34,11 +34,9 @@ class {{ .StructName }}Decoder {
         state.{{.StructName}}Decoder = this;
 
         try {
-            prevType = {{.StructName}}.Type.TypeNone;
             this.fieldCount = state.getStructFieldCounts().get{{.StructName}}FieldCount();
+            this.typeBitCount = Integer.SIZE - Integer.numberOfLeadingZeros(this.fieldCount+1);
             this.column = columns.getColumn();
-            this.lastVal.init(null, 0);
-            this.lastValPtr = this.lastVal;
             {{- if .DictName}}
             this.dict = state.get{{.DictName}}();
             {{- end}}
@@ -86,7 +84,6 @@ class {{ .StructName }}Decoder {
     }
 
     public void reset() {
-        prevType = {{.StructName}}.Type.TypeNone;
         {{ range $i, $e := .Fields }}
         if (fieldCount <= {{$i}}) {
             return; // {{.Name}} and all subsequent fields are skipped.
@@ -104,18 +101,18 @@ class {{ .StructName }}Decoder {
     // Decode decodes a value from the buffer into dst.
     public {{.StructName}} decode({{.StructName}} dst) throws IOException {
         // Read type delta
-        long typeDelta = this.buf.readVarintCompact();
-        long typ = prevType.getValue() + typeDelta;
+        long typ = this.buf.readBits(typeBitCount);
         if (typ < 0 || typ >= {{.StructName}}.Type.values().length) {
             throw new IOException("Invalid oneof type");
         }
         {{.StructName}}.Type newType = {{.StructName}}.Type.values()[(int)typ];
         if (dst.typ != newType) {
             dst.typ = newType;
+            // The type changed, we need to reset the contained value so that
+            // it does not contain carry-over data from a previous record that
+            // was of this same type.
             dst.resetContained();
         }
-        prevType = dst.typ;
-        this.lastValPtr = dst;
         // Decode selected field
         switch (dst.typ) {
         {{- range .Fields }}

--- a/stefgen/templates/java/oneofEncoder.java.tmpl
+++ b/stefgen/templates/java/oneofEncoder.java.tmpl
@@ -11,8 +11,10 @@ import java.io.IOException;
 class {{ .StructName }}Encoder {
     private BitsWriter buf = new BitsWriter();
     private SizeLimiter limiter;
-    private {{.StructName}}.Type prevType;
+    // fieldCount is the number of fields, i.e. the number of types in this oneof.
     private int fieldCount;
+    // Number of bits needed to encode the type (including None type).
+    private int typeBitCount;
 
     // Field encoders.
     {{ range .Fields }}
@@ -31,13 +33,13 @@ class {{ .StructName }}Encoder {
         state.{{.StructName}}Encoder = this;
 
         try {
-            prevType = {{.StructName}}.Type.TypeNone;
             this.limiter = state.getLimiter();
             {{- if .DictName}}
             this.dict = state.get{{.DictName}}();
             {{- end}}
 
             this.fieldCount = state.getStructFieldCounts().get{{.StructName}}FieldCount();
+            this.typeBitCount = Integer.SIZE - Integer.numberOfLeadingZeros(this.fieldCount+1);
             {{ range $i, $e := .Fields }}
             // Init encoder for {{.Name}} field.
             if (this.fieldCount <= {{$i}}) {
@@ -63,7 +65,6 @@ class {{ .StructName }}Encoder {
     }
 
     public void reset() {
-        prevType = {{ .StructName }}.Type.TypeNone;
         {{ range $i, $e := .Fields }}
         if (fieldCount <= {{$i}}) {
             return; // {{.Name}} and all subsequent fields are skipped.
@@ -78,8 +79,6 @@ class {{ .StructName }}Encoder {
 
     // Encode encodes val into buf
     public void encode({{ .StructName }} val) throws IOException {
-        int oldLen = buf.bitCount();
-
         {{ $.StructName }}.Type typ = val.typ;
         if (typ.getValue() > fieldCount) {
             // The current field type is not supported in target schema. Encode the type as None.
@@ -87,13 +86,10 @@ class {{ .StructName }}Encoder {
         }
 
         // Compute type delta. 0 means the type is the same as the last time.
-        int typDelta = typ.getValue() - prevType.getValue();
-        prevType = typ;
-        buf.writeVarintCompact(typDelta);
+        buf.writeBits(typ.getValue(), typeBitCount);
 
         // Account written bits in the limiter.
-        int newLen = buf.bitCount();
-        limiter.addFrameBits(newLen-oldLen);
+        limiter.addFrameBits(typeBitCount);
 
         // Encode currently selected field.
         switch (typ) {


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/127

This simplifies oneof codec and improves codec speed at the cost of slight increase
of uncompressed size. The zstd-compressed size is approximately the same (slightly
increased or decresed depending on the dataset).

### Benchmarks

Otel schema speed improvement:
```
                                  │ bench_base.txt │         bench_current.txt         │
                                  │   sec/point    │  sec/point   vs base              │
SerializeNative/STEF/serialize-10      64.36n ± 1%   63.10n ± 2%  -1.96% (p=0.020 n=9)
DeserializeNative/STEF/deser-10        24.06n ± 1%   22.70n ± 1%  -5.65% (p=0.000 n=9)
geomean                                39.35n        37.85n       -3.82%
```

Otel schema size before the change:
```
File                           Uncompressed   Zstd Bytes
hipstershop-otelmetrics.stefz        432716        93702
hostandcollector-otelmetrics.stefz      1258652        83009
astronomy-otelmetrics.stefz         7462303      1652082
```

After the change:
```
File                           Uncompressed   Zstd Bytes
hipstershop-otelmetrics.stefz        441558        95083
hostandcollector-otelmetrics.stefz      1266627        79835
astronomy-otelmetrics.stefz         7557122      1644464
```

Other benchmarks show similar patterns for speed and size changes.
