### PR TITLE
Don't clone frozen struct when encoding

### DIFF
--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -434,10 +434,15 @@ func (d *FunctionEncoderDict) Add(val *Function) {
 	val.modifiedFields.refNum = refNum // Cache the refNum
 	d.slice = append(d.slice, val)     // Remember the value by refNum.
 
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
 	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
 	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
 	d.dict.Set(clone, refNum)
-	d.limiter.AddDictElemSize(val.byteSize())
 }
 
 func (d *FunctionEncoderDict) Reset() {

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -481,10 +481,15 @@ func (d *LocationEncoderDict) Add(val *Location) {
 	val.modifiedFields.refNum = refNum // Cache the refNum
 	d.slice = append(d.slice, val)     // Remember the value by refNum.
 
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
 	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
 	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
 	d.dict.Set(clone, refNum)
-	d.limiter.AddDictElemSize(val.byteSize())
 }
 
 func (d *LocationEncoderDict) Reset() {

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -694,10 +694,15 @@ func (d *MappingEncoderDict) Add(val *Mapping) {
 	val.modifiedFields.refNum = refNum // Cache the refNum
 	d.slice = append(d.slice, val)     // Remember the value by refNum.
 
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
 	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
 	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
 	d.dict.Set(clone, refNum)
-	d.limiter.AddDictElemSize(val.byteSize())
 }
 
 func (d *MappingEncoderDict) Reset() {

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -330,10 +330,15 @@ func (d *SampleValueTypeEncoderDict) Add(val *SampleValueType) {
 	val.modifiedFields.refNum = refNum // Cache the refNum
 	d.slice = append(d.slice, val)     // Remember the value by refNum.
 
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
 	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
 	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
 	d.dict.Set(clone, refNum)
-	d.limiter.AddDictElemSize(val.byteSize())
 }
 
 func (d *SampleValueTypeEncoderDict) Reset() {

--- a/go/otel/oteltef/metric.go
+++ b/go/otel/oteltef/metric.go
@@ -642,10 +642,15 @@ func (d *MetricEncoderDict) Add(val *Metric) {
 	val.modifiedFields.refNum = refNum // Cache the refNum
 	d.slice = append(d.slice, val)     // Remember the value by refNum.
 
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
 	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
 	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
 	d.dict.Set(clone, refNum)
-	d.limiter.AddDictElemSize(val.byteSize())
 }
 
 func (d *MetricEncoderDict) Reset() {

--- a/go/otel/oteltef/resource.go
+++ b/go/otel/oteltef/resource.go
@@ -382,10 +382,15 @@ func (d *ResourceEncoderDict) Add(val *Resource) {
 	val.modifiedFields.refNum = refNum // Cache the refNum
 	d.slice = append(d.slice, val)     // Remember the value by refNum.
 
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
 	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
 	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
 	d.dict.Set(clone, refNum)
-	d.limiter.AddDictElemSize(val.byteSize())
 }
 
 func (d *ResourceEncoderDict) Reset() {

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -618,10 +618,15 @@ func (d *{{ .StructName }}EncoderDict) Add(val *{{ .StructName }}) {
     val.modifiedFields.refNum = refNum // Cache the refNum
     d.slice = append(d.slice, val) // Remember the value by refNum.
 
-    clone := val.Clone(d.allocators) // Clone before adding to dictionary.
-    clone.Freeze() // Freeze the clone so that it can be safely shared by pointer.
-    d.dict.Set(clone, refNum)
-    d.limiter.AddDictElemSize(val.byteSize())
+	d.limiter.AddDictElemSize(val.byteSize())
+	if val.isFrozen() {
+		// If val is frozen it means it is safe to share without cloning.
+		d.dict.Set(val, refNum)
+		return
+	}
+	clone := val.Clone(d.allocators) // Clone before adding to dictionary.
+	clone.Freeze()                   // Freeze the clone so that it can be safely shared by pointer.
+	d.dict.Set(clone, refNum)
 }
 
 func (d* {{ .StructName }}EncoderDict) Reset() {


### PR DESCRIPTION
This eliminates struct cloning during encoding if the struct is frozen.

Profile schema benchmarks:
```
                                                     │ bench_base.txt │         bench_current.txt          │
                                                     │     sec/op     │   sec/op     vs base               │
Serialization/file=deser_stef.prof/format=stef-10         1.160m ± 5%   1.006m ± 2%  -13.31% (p=0.000 n=9)
Serialization/file=otelcol_otlp.prof/format=stef-10       404.2µ ± 1%   334.1µ ± 2%  -17.35% (p=0.000 n=9)
Serialization/file=wsstreamasync.prof/format=stef-10      1.690m ± 1%   1.554m ± 0%   -8.06% (p=0.000 n=9)
Copy/file=deser_stef.prof/format=stef-10                  1.752m ± 1%   1.644m ± 1%   -6.20% (p=0.000 n=9)
Copy/file=otelcol_otlp.prof/format=stef-10                602.0µ ± 1%   536.0µ ± 2%  -10.97% (p=0.000 n=9)
Copy/file=wsstreamasync.prof/format=stef-10               2.563m ± 0%   2.466m ± 0%   -3.80% (p=0.000 n=9)
geomean                                                   1.135m        1.021m       -10.06%

                                                     │ bench_base.txt │         bench_current.txt          │
                                                     │   sec/sample   │ sec/sample   vs base               │
Serialization/file=deser_stef.prof/format=stef-10        1055.0n ± 5%   914.2n ± 2%  -13.35% (p=0.000 n=9)
Serialization/file=otelcol_otlp.prof/format=stef-10       4.646µ ± 1%   3.840µ ± 2%  -17.35% (p=0.000 n=9)
Serialization/file=wsstreamasync.prof/format=stef-10      1.520µ ± 1%   1.397µ ± 0%   -8.09% (p=0.000 n=9)
Copy/file=deser_stef.prof/format=stef-10                  1.593µ ± 1%   1.494µ ± 1%   -6.21% (p=0.000 n=9)
Copy/file=otelcol_otlp.prof/format=stef-10                6.920µ ± 1%   6.161µ ± 2%  -10.97% (p=0.000 n=9)
Copy/file=wsstreamasync.prof/format=stef-10               2.305µ ± 0%   2.218µ ± 0%   -3.77% (p=0.000 n=9)
geomean                                                   2.396µ        2.155µ       -10.07%

                                                     │ bench_base.txt │          bench_current.txt          │
                                                     │      B/op      │     B/op      vs base               │
Serialization/file=deser_stef.prof/format=stef-10       1052.4Ki ± 0%   671.0Ki ± 0%  -36.24% (p=0.000 n=9)
Serialization/file=otelcol_otlp.prof/format=stef-10      456.2Ki ± 0%   330.8Ki ± 0%  -27.48% (p=0.000 n=9)
Serialization/file=wsstreamasync.prof/format=stef-10    1240.8Ki ± 0%   926.5Ki ± 0%  -25.32% (p=0.000 n=9)
Copy/file=deser_stef.prof/format=stef-10                 2.071Mi ± 0%   1.699Mi ± 0%  -17.97% (p=0.000 n=9)
Copy/file=otelcol_otlp.prof/format=stef-10               817.8Ki ± 0%   691.7Ki ± 0%  -15.41% (p=0.000 n=9)
Copy/file=wsstreamasync.prof/format=stef-10              2.721Mi ± 0%   2.415Mi ± 0%  -11.27% (p=0.000 n=9)
geomean                                                  1.165Mi        921.4Ki       -22.75%

                                                     │ bench_base.txt │         bench_current.txt          │
                                                     │   allocs/op    │  allocs/op   vs base               │
Serialization/file=deser_stef.prof/format=stef-10         1651.0 ± 0%    471.0 ± 0%  -71.47% (p=0.000 n=9)
Serialization/file=otelcol_otlp.prof/format=stef-10        762.0 ± 0%    398.0 ± 0%  -47.77% (p=0.000 n=9)
Serialization/file=wsstreamasync.prof/format=stef-10      1468.0 ± 0%    458.0 ± 0%  -68.80% (p=0.000 n=9)
Copy/file=deser_stef.prof/format=stef-10                  3.296k ± 0%   2.116k ± 0%  -35.80% (p=0.000 n=9)
Copy/file=otelcol_otlp.prof/format=stef-10                1.384k ± 0%   1.020k ± 0%  -26.30% (p=0.000 n=9)
Copy/file=wsstreamasync.prof/format=stef-10               2.967k ± 0%   1.957k ± 0%  -34.04% (p=0.000 n=9)
geomean                                                   1.710k         844.5       -50.61%
```