### PR TITLE
Make dependabot look in subdirectories for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This should result in all subdirectories to be examined for updates, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files