### PR TITLE
Make optional struct or oneof fields in struct work

### DIFF
--- a/stefc/generator/testdata/all_features.stef
+++ b/stefc/generator/testdata/all_features.stef
@@ -42,9 +42,9 @@ struct StructWithOptionals {
   F64 float64 optional
   S string optional
   By bytes optional
-  // AllMultimaps AllMultimaps optional // TODO: This does not work.
-  // O AllInOneOff optional // TODO: This does not work.
-  // AllArrays AllArrays optional // TODO: This does not work.
+  AllMultimaps AllMultimaps optional
+  O AllInOneOff optional
+  AllArrays AllArrays optional
   E Enum1 optional
 }
 

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -463,10 +463,12 @@ func (s *{{ .StructName }}) mutateRandom(random *rand.Rand, schem *schema.Schema
         s.optionalFieldsPresent ^= fieldPresent{{ $.StructName }}{{.Name}}
         s.mark{{.Name}}Modified()
         if s.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} !=0 {
+            {{if .Type.Flags.StoreByPtr}}
             if s.{{.name}} == nil {
                 s.{{.name}} = new({{ .Type.Storage }})
                 s.{{.name}}.init(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
             }
+            {{end -}}
             s.{{.name}}.mutateRandom(random, schem)
         }
         {{- else}}


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/191

Previously schemas like this did not work:

```
struct StructWithOptionals {
  AllMultimaps AllMultimaps optional // TODO: This does not work.
  O AllInOneOff optional // TODO: This does not work.
}

struct AllMultimaps {
}

oneof AllInOneOff {
}
```