### PR TITLE
Make multimap value of array of structs work

### DIFF
--- a/examples/jsonl/internal/jsonstef/jsonvaluearray.go
+++ b/examples/jsonl/internal/jsonstef/jsonvaluearray.go
@@ -234,6 +234,10 @@ func (e *JsonValueArray) IsEqual(val *JsonValueArray) bool {
 	return true
 }
 
+func JsonValueArrayEqual(left, right *JsonValueArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpJsonValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpJsonValueArray(left, right *JsonValueArray) int {

--- a/examples/profile/internal/profile/linearray.go
+++ b/examples/profile/internal/profile/linearray.go
@@ -234,6 +234,10 @@ func (e *LineArray) IsEqual(val *LineArray) bool {
 	return true
 }
 
+func LineArrayEqual(left, right *LineArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpLineArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpLineArray(left, right *LineArray) int {

--- a/examples/profile/internal/profile/locationarray.go
+++ b/examples/profile/internal/profile/locationarray.go
@@ -234,6 +234,10 @@ func (e *LocationArray) IsEqual(val *LocationArray) bool {
 	return true
 }
 
+func LocationArrayEqual(left, right *LocationArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpLocationArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpLocationArray(left, right *LocationArray) int {

--- a/examples/profile/internal/profile/samplevaluearray.go
+++ b/examples/profile/internal/profile/samplevaluearray.go
@@ -234,6 +234,10 @@ func (e *SampleValueArray) IsEqual(val *SampleValueArray) bool {
 	return true
 }
 
+func SampleValueArrayEqual(left, right *SampleValueArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpSampleValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpSampleValueArray(left, right *SampleValueArray) int {

--- a/examples/profile/internal/profile/stringarray.go
+++ b/examples/profile/internal/profile/stringarray.go
@@ -204,6 +204,10 @@ func (e *StringArray) IsEqual(val *StringArray) bool {
 	return true
 }
 
+func StringArrayEqual(left, right *StringArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpStringArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpStringArray(left, right *StringArray) int {

--- a/go/otel/oteltef/anyvaluearray.go
+++ b/go/otel/oteltef/anyvaluearray.go
@@ -234,6 +234,10 @@ func (e *AnyValueArray) IsEqual(val *AnyValueArray) bool {
 	return true
 }
 
+func AnyValueArrayEqual(left, right *AnyValueArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpAnyValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpAnyValueArray(left, right *AnyValueArray) int {

--- a/go/otel/oteltef/eventarray.go
+++ b/go/otel/oteltef/eventarray.go
@@ -234,6 +234,10 @@ func (e *EventArray) IsEqual(val *EventArray) bool {
 	return true
 }
 
+func EventArrayEqual(left, right *EventArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpEventArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpEventArray(left, right *EventArray) int {

--- a/go/otel/oteltef/exemplararray.go
+++ b/go/otel/oteltef/exemplararray.go
@@ -234,6 +234,10 @@ func (e *ExemplarArray) IsEqual(val *ExemplarArray) bool {
 	return true
 }
 
+func ExemplarArrayEqual(left, right *ExemplarArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpExemplarArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpExemplarArray(left, right *ExemplarArray) int {

--- a/go/otel/oteltef/float64array.go
+++ b/go/otel/oteltef/float64array.go
@@ -204,6 +204,10 @@ func (e *Float64Array) IsEqual(val *Float64Array) bool {
 	return true
 }
 
+func Float64ArrayEqual(left, right *Float64Array) bool {
+	return left.IsEqual(right)
+}
+
 // CmpFloat64Array performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpFloat64Array(left, right *Float64Array) int {

--- a/go/otel/oteltef/linkarray.go
+++ b/go/otel/oteltef/linkarray.go
@@ -234,6 +234,10 @@ func (e *LinkArray) IsEqual(val *LinkArray) bool {
 	return true
 }
 
+func LinkArrayEqual(left, right *LinkArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpLinkArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpLinkArray(left, right *LinkArray) int {

--- a/go/otel/oteltef/quantilevaluearray.go
+++ b/go/otel/oteltef/quantilevaluearray.go
@@ -234,6 +234,10 @@ func (e *QuantileValueArray) IsEqual(val *QuantileValueArray) bool {
 	return true
 }
 
+func QuantileValueArrayEqual(left, right *QuantileValueArray) bool {
+	return left.IsEqual(right)
+}
+
 // CmpQuantileValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpQuantileValueArray(left, right *QuantileValueArray) int {

--- a/go/otel/oteltef/uint64array.go
+++ b/go/otel/oteltef/uint64array.go
@@ -204,6 +204,10 @@ func (e *Uint64Array) IsEqual(val *Uint64Array) bool {
 	return true
 }
 
+func Uint64ArrayEqual(left, right *Uint64Array) bool {
+	return left.IsEqual(right)
+}
+
 // CmpUint64Array performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpUint64Array(left, right *Uint64Array) int {

--- a/stefc/generator/dicts.go
+++ b/stefc/generator/dicts.go
@@ -57,10 +57,10 @@ func (g *Generator) getEncoders() (ret map[string]bool) {
 	}
 	for _, m := range g.compiledSchema.Multimaps {
 		if !m.Key.Type.IsPrimitive() {
-			//ret[m.KeyType.] = field.Type
+			ret[m.Key.Type.EncoderType()] = true
 		}
 		if !m.Value.Type.IsPrimitive() {
-			//ret[field.Name] = field.Type
+			ret[m.Value.Type.EncoderType()] = true
 		}
 	}
 	return ret

--- a/stefc/generator/genschema.go
+++ b/stefc/generator/genschema.go
@@ -52,11 +52,15 @@ func (s *genSchema) SchemaStr() string {
 	return str
 }
 
-type genStructFieldDef struct {
-	Name      string
+type genFieldDef struct {
 	Type      genFieldTypeRef
-	Optional  bool
 	Recursive bool
+}
+
+type genStructFieldDef struct {
+	genFieldDef
+	Name     string
+	Optional bool
 }
 
 type TypeFlags struct {
@@ -467,8 +471,7 @@ func (r *genStructDef) Flags() TypeFlags {
 }
 
 type genMapFieldDef struct {
-	Type      genFieldTypeRef
-	Recursive bool
+	genFieldDef
 }
 
 type genMapDef struct {

--- a/stefc/generator/testdata/all_features.stef
+++ b/stefc/generator/testdata/all_features.stef
@@ -63,7 +63,7 @@ struct AllMultimaps {
   IIM IntIntMultimap
   ISM IntStructMultimap
   SSM2 StructStructMultimap
-  // SAM StructArrayMultimap // See bug comment below.
+  SAM StructArrayMultimap
   SSMD StringStringMultimapDict
   //SSMDC StringStringMultimapDictComplex
 }
@@ -98,10 +98,10 @@ multimap StringStringMultimapDict {
 //  value OneofDict
 //}
 
-//multimap StructArrayMultimap {
-//  key StructRecurseSelf
-//  value []StructWithOptionals // This does not work. Must fix a bug.
-//}
+multimap StructArrayMultimap {
+  key StructRecurseSelf
+  value []StructWithOptionals
+}
 
 oneof AllInOneOff {
   B bool

--- a/stefc/templates/go/array.go.tmpl
+++ b/stefc/templates/go/array.go.tmpl
@@ -291,6 +291,10 @@ func (e *{{ .ArrayName }}) IsEqual(val *{{ .ArrayName }}) bool {
 	return true
 }
 
+func {{.ArrayName}}Equal(left, right *{{.ArrayName}}) bool {
+	return left.IsEqual(right)
+}
+
 // Cmp{{.ArrayName}} performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func Cmp{{.ArrayName}}(left, right *{{ .ArrayName }}) int {


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/189

Previously schemas like this did not work:

```
multimap StructArrayMultimap {
  key StructRecurseSelf
  value []StructWithOptionals // This does not work. Must fix a bug.
}
```