### PR TITLE
Fix bug with enum in multimap

### DIFF
--- a/stefc/generator/genschema.go
+++ b/stefc/generator/genschema.go
@@ -603,7 +603,7 @@ func (r *genArrayTypeRef) Storage() string {
 }
 
 func (r *genArrayTypeRef) ToExported(arg string) string {
-	return r.ToExported(arg)
+	return arg
 }
 
 func (r *genArrayTypeRef) ToStorage(arg string) string {

--- a/stefc/generator/testdata/multimap_enum.stef
+++ b/stefc/generator/testdata/multimap_enum.stef
@@ -1,0 +1,14 @@
+package com.example.gentest.multimap_enum
+
+enum Enum1 {
+  Item1 = 1
+}
+
+multimap MultiMap1 {
+  key Enum1
+  value string
+}
+
+struct Struct1 root {
+  Field1 MultiMap1
+}

--- a/stefc/templates/go/multimap.go.tmpl
+++ b/stefc/templates/go/multimap.go.tmpl
@@ -29,11 +29,11 @@ type {{ .MultimapName }}Elem struct {
 }
 
 func (e* {{ .MultimapName }}Elem) Key() {{if.Key.Type.Flags.PassByPtr}}*{{end}}{{.Key.Type.Exported}} {
-	return {{if.Key.Type.Flags.PassByPtr}}&{{end}}e.key
+	return {{if.Key.Type.Flags.PassByPtr}}&{{end}}{{.Key.Type.ToExported ("e.key")}}
 }
 
 func (e* {{ .MultimapName }}Elem) Value() {{if.Value.Type.Flags.PassByPtr}}*{{end}}{{.Value.Type.Exported}} {
-	return {{if.Value.Type.Flags.PassByPtr}}&{{end}}e.value
+	return {{if.Value.Type.Flags.PassByPtr}}&{{end}}{{.Value.Type.ToExported ("e.value")}}
 }
 
 func (m *{{.MultimapName}}) init(parentModifiedFields *modifiedFields, parentModifiedBit uint64) {


### PR DESCRIPTION
We had a bug where enum as a multimap key or value was failing:

```
enum Enum1 {
  Item1 = 1
}

multimap MultiMap1 {
  key Enum1 // This was generated Go code that didn't compile
  value string
}
```

Now it works.