### PR TITLE
Prune unreachable schema elements when compiling

### DIFF
--- a/go/pkg/idl/lexer.go
+++ b/go/pkg/idl/lexer.go
@@ -36,6 +36,10 @@ type Pos struct {
 	Col     uint
 }
 
+func (p *Pos) Unknown() bool {
+	return *p == Pos{}
+}
+
 type Token uint
 
 const (

--- a/stefc/go.mod
+++ b/stefc/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/stefc/main.go
+++ b/stefc/main.go
@@ -46,6 +46,11 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	for _, msg := range parser.Messages() {
+		fmt.Println(msg.String())
+	}
+
 	wireSchema := parser.Schema()
 
 	fmt.Printf("Generating %s code to %s\n", *lang, *outDir)


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/212

If a map/struct/oneof is unreachable from root struct it is pruned during compilation and no code is generated for it. We also give a warning during compilation.