### PR TITLE
Correctly encode optional field mask

### DIFF
--- a/examples/jsonl/internal/jsonstef/record.go
+++ b/examples/jsonl/internal/jsonstef/record.go
@@ -351,9 +351,10 @@ func (e *RecordEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // RecordDecoder implements decoding of Record
 type RecordDecoder struct {
-	buf              pkg.BitsReader
-	column           *pkg.ReadableColumn
-	fieldCount       uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	valueDecoder     *JsonValueDecoder
 	isValueRecursive bool
 	allocators       *Allocators

--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -641,9 +641,10 @@ func (e *FunctionEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // FunctionDecoder implements decoding of Function
 type FunctionDecoder struct {
-	buf         pkg.BitsReader
-	column      *pkg.ReadableColumn
-	fieldCount  uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	nameDecoder encoders.StringDictDecoder
 
 	systemNameDecoder encoders.StringDictDecoder

--- a/examples/profile/internal/profile/line.go
+++ b/examples/profile/internal/profile/line.go
@@ -530,9 +530,10 @@ func (e *LineEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // LineDecoder implements decoding of Line
 type LineDecoder struct {
-	buf                 pkg.BitsReader
-	column              *pkg.ReadableColumn
-	fieldCount          uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	functionDecoder     *FunctionDecoder
 	isFunctionRecursive bool
 	lineDecoder         encoders.Uint64Decoder

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -710,9 +710,10 @@ func (e *LocationEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // LocationDecoder implements decoding of Location
 type LocationDecoder struct {
-	buf                pkg.BitsReader
-	column             *pkg.ReadableColumn
-	fieldCount         uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	mappingDecoder     *MappingDecoder
 	isMappingRecursive bool
 	addressDecoder     encoders.Uint64Decoder

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -1021,9 +1021,10 @@ func (e *MappingEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // MappingDecoder implements decoding of Mapping
 type MappingDecoder struct {
-	buf                pkg.BitsReader
-	column             *pkg.ReadableColumn
-	fieldCount         uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	memoryStartDecoder encoders.Uint64Decoder
 
 	memoryLimitDecoder encoders.Uint64Decoder

--- a/examples/profile/internal/profile/numvalue.go
+++ b/examples/profile/internal/profile/numvalue.go
@@ -399,6 +399,7 @@ type NumValueDecoder struct {
 	buf        pkg.BitsReader
 	column     *pkg.ReadableColumn
 	fieldCount uint
+
 	valDecoder encoders.Int64Decoder
 
 	unitDecoder encoders.StringDictDecoder

--- a/examples/profile/internal/profile/profilemetadata.go
+++ b/examples/profile/internal/profile/profilemetadata.go
@@ -979,9 +979,10 @@ func (e *ProfileMetadataEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // ProfileMetadataDecoder implements decoding of ProfileMetadata
 type ProfileMetadataDecoder struct {
-	buf               pkg.BitsReader
-	column            *pkg.ReadableColumn
-	fieldCount        uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	dropFramesDecoder encoders.StringDictDecoder
 
 	keepFramesDecoder encoders.StringDictDecoder

--- a/examples/profile/internal/profile/sample.go
+++ b/examples/profile/internal/profile/sample.go
@@ -591,9 +591,10 @@ func (e *SampleEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // SampleDecoder implements decoding of Sample
 type SampleDecoder struct {
-	buf                  pkg.BitsReader
-	column               *pkg.ReadableColumn
-	fieldCount           uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	metadataDecoder      *ProfileMetadataDecoder
 	isMetadataRecursive  bool
 	locationsDecoder     *LocationArrayDecoder

--- a/examples/profile/internal/profile/samplevalue.go
+++ b/examples/profile/internal/profile/samplevalue.go
@@ -457,6 +457,7 @@ type SampleValueDecoder struct {
 	buf        pkg.BitsReader
 	column     *pkg.ReadableColumn
 	fieldCount uint
+
 	valDecoder encoders.Int64Decoder
 
 	type_Decoder    *SampleValueTypeDecoder

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -489,9 +489,10 @@ func (e *SampleValueTypeEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // SampleValueTypeDecoder implements decoding of SampleValueType
 type SampleValueTypeDecoder struct {
-	buf          pkg.BitsReader
-	column       *pkg.ReadableColumn
-	fieldCount   uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	type_Decoder encoders.StringDecoder
 
 	unitDecoder encoders.StringDecoder

--- a/go/otel/oteltef/envelope.go
+++ b/go/otel/oteltef/envelope.go
@@ -330,9 +330,10 @@ func (e *EnvelopeEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // EnvelopeDecoder implements decoding of Envelope
 type EnvelopeDecoder struct {
-	buf                   pkg.BitsReader
-	column                *pkg.ReadableColumn
-	fieldCount            uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	attributesDecoder     *EnvelopeAttributesDecoder
 	isAttributesRecursive bool
 	allocators            *Allocators

--- a/go/otel/oteltef/event.go
+++ b/go/otel/oteltef/event.go
@@ -559,9 +559,10 @@ func (e *EventEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // EventDecoder implements decoding of Event
 type EventDecoder struct {
-	buf         pkg.BitsReader
-	column      *pkg.ReadableColumn
-	fieldCount  uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	nameDecoder encoders.StringDictDecoder
 
 	timeUnixNanoDecoder encoders.Uint64Decoder

--- a/go/otel/oteltef/exemplar.go
+++ b/go/otel/oteltef/exemplar.go
@@ -646,9 +646,10 @@ func (e *ExemplarEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // ExemplarDecoder implements decoding of Exemplar
 type ExemplarDecoder struct {
-	buf              pkg.BitsReader
-	column           *pkg.ReadableColumn
-	fieldCount       uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	timestampDecoder encoders.Uint64Decoder
 
 	valueDecoder     *ExemplarValueDecoder

--- a/go/otel/oteltef/exphistogrambuckets.go
+++ b/go/otel/oteltef/exphistogrambuckets.go
@@ -407,9 +407,10 @@ func (e *ExpHistogramBucketsEncoder) CollectColumns(columnSet *pkg.WriteColumnSe
 
 // ExpHistogramBucketsDecoder implements decoding of ExpHistogramBuckets
 type ExpHistogramBucketsDecoder struct {
-	buf           pkg.BitsReader
-	column        *pkg.ReadableColumn
-	fieldCount    uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	offsetDecoder encoders.Int64Decoder
 
 	bucketCountsDecoder     *Uint64ArrayDecoder

--- a/go/otel/oteltef/exphistogramvalue.go
+++ b/go/otel/oteltef/exphistogramvalue.go
@@ -809,8 +809,9 @@ type ExpHistogramValueEncoder struct {
 
 	allocators *Allocators
 
-	keepFieldMask uint64
-	fieldCount    uint
+	keepFieldMask      uint64
+	fieldCount         uint
+	optionalFieldCount uint
 }
 
 func (e *ExpHistogramValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) error {
@@ -833,6 +834,8 @@ func (e *ExpHistogramValueEncoder) Init(state *WriterState, columns *pkg.WriteCo
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
 	e.keepFieldMask = ^(^uint64(0) << e.fieldCount)
+
+	e.optionalFieldCount = pkg.OptionalFieldCount(0b1110, e.fieldCount)
 
 	// Init encoder for Count field.
 	if e.fieldCount <= 0 {
@@ -999,8 +1002,8 @@ func (e *ExpHistogramValueEncoder) Encode(val *ExpHistogramValue) {
 	bitCount += e.fieldCount
 
 	// Write bits to indicate which optional fields are set.
-	e.buf.WriteBits(val.optionalFieldsPresent, 3)
-	bitCount += 3
+	e.buf.WriteBits(val.optionalFieldsPresent, e.optionalFieldCount)
+	bitCount += e.optionalFieldCount
 
 	// Encode modified, present fields.
 
@@ -1126,10 +1129,11 @@ func (e *ExpHistogramValueEncoder) CollectColumns(columnSet *pkg.WriteColumnSet)
 
 // ExpHistogramValueDecoder implements decoding of ExpHistogramValue
 type ExpHistogramValueDecoder struct {
-	buf          pkg.BitsReader
-	column       *pkg.ReadableColumn
-	fieldCount   uint
-	countDecoder encoders.Uint64Decoder
+	buf                pkg.BitsReader
+	column             *pkg.ReadableColumn
+	fieldCount         uint
+	optionalFieldCount uint
+	countDecoder       encoders.Uint64Decoder
 
 	sumDecoder encoders.Float64Decoder
 
@@ -1167,6 +1171,8 @@ func (d *ExpHistogramValueDecoder) Init(state *ReaderState, columns *pkg.ReadCol
 	if err != nil {
 		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExpHistogramValue", err)
 	}
+
+	d.optionalFieldCount = pkg.OptionalFieldCount(0b1110, d.fieldCount)
 
 	d.column = columns.Column()
 
@@ -1363,8 +1369,8 @@ func (d *ExpHistogramValueDecoder) Decode(dstPtr *ExpHistogramValue) error {
 	d.buf.Consume(d.fieldCount)
 
 	// Read bits that indicate which optional fields are set.
-	val.optionalFieldsPresent = d.buf.PeekBits(3)
-	d.buf.Consume(3)
+	val.optionalFieldsPresent = d.buf.PeekBits(d.optionalFieldCount)
+	d.buf.Consume(d.optionalFieldCount)
 
 	if val.modifiedFields.mask&fieldModifiedExpHistogramValueCount != 0 {
 		// Field is changed and is present, decode it.

--- a/go/otel/oteltef/link.go
+++ b/go/otel/oteltef/link.go
@@ -711,9 +711,10 @@ func (e *LinkEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // LinkDecoder implements decoding of Link
 type LinkDecoder struct {
-	buf            pkg.BitsReader
-	column         *pkg.ReadableColumn
-	fieldCount     uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	traceIDDecoder encoders.BytesDecoder
 
 	spanIDDecoder encoders.BytesDecoder

--- a/go/otel/oteltef/metric.go
+++ b/go/otel/oteltef/metric.go
@@ -967,9 +967,10 @@ func (e *MetricEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // MetricDecoder implements decoding of Metric
 type MetricDecoder struct {
-	buf         pkg.BitsReader
-	column      *pkg.ReadableColumn
-	fieldCount  uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	nameDecoder encoders.StringDictDecoder
 
 	descriptionDecoder encoders.StringDictDecoder

--- a/go/otel/oteltef/metrics.go
+++ b/go/otel/oteltef/metrics.go
@@ -905,9 +905,10 @@ func (e *MetricsEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // MetricsDecoder implements decoding of Metrics
 type MetricsDecoder struct {
-	buf                   pkg.BitsReader
-	column                *pkg.ReadableColumn
-	fieldCount            uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	envelopeDecoder       *EnvelopeDecoder
 	isEnvelopeRecursive   bool
 	metricDecoder         *MetricDecoder

--- a/go/otel/oteltef/point.go
+++ b/go/otel/oteltef/point.go
@@ -570,9 +570,10 @@ func (e *PointEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // PointDecoder implements decoding of Point
 type PointDecoder struct {
-	buf                   pkg.BitsReader
-	column                *pkg.ReadableColumn
-	fieldCount            uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	startTimestampDecoder encoders.Uint64Decoder
 
 	timestampDecoder encoders.Uint64Decoder

--- a/go/otel/oteltef/quantilevalue.go
+++ b/go/otel/oteltef/quantilevalue.go
@@ -396,9 +396,10 @@ func (e *QuantileValueEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // QuantileValueDecoder implements decoding of QuantileValue
 type QuantileValueDecoder struct {
-	buf             pkg.BitsReader
-	column          *pkg.ReadableColumn
-	fieldCount      uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	quantileDecoder encoders.Float64Decoder
 
 	valueDecoder encoders.Float64Decoder

--- a/go/otel/oteltef/resource.go
+++ b/go/otel/oteltef/resource.go
@@ -576,9 +576,10 @@ func (e *ResourceEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // ResourceDecoder implements decoding of Resource
 type ResourceDecoder struct {
-	buf              pkg.BitsReader
-	column           *pkg.ReadableColumn
-	fieldCount       uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	schemaURLDecoder encoders.StringDictDecoder
 
 	attributesDecoder             *AttributesDecoder

--- a/go/otel/oteltef/scope.go
+++ b/go/otel/oteltef/scope.go
@@ -728,9 +728,10 @@ func (e *ScopeEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // ScopeDecoder implements decoding of Scope
 type ScopeDecoder struct {
-	buf         pkg.BitsReader
-	column      *pkg.ReadableColumn
-	fieldCount  uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	nameDecoder encoders.StringDictDecoder
 
 	versionDecoder encoders.StringDictDecoder

--- a/go/otel/oteltef/span.go
+++ b/go/otel/oteltef/span.go
@@ -1352,9 +1352,10 @@ func (e *SpanEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // SpanDecoder implements decoding of Span
 type SpanDecoder struct {
-	buf            pkg.BitsReader
-	column         *pkg.ReadableColumn
-	fieldCount     uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	traceIDDecoder encoders.BytesDecoder
 
 	spanIDDecoder encoders.BytesDecoder

--- a/go/otel/oteltef/spans.go
+++ b/go/otel/oteltef/spans.go
@@ -685,9 +685,10 @@ func (e *SpansEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // SpansDecoder implements decoding of Spans
 type SpansDecoder struct {
-	buf                 pkg.BitsReader
-	column              *pkg.ReadableColumn
-	fieldCount          uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	envelopeDecoder     *EnvelopeDecoder
 	isEnvelopeRecursive bool
 	resourceDecoder     *ResourceDecoder

--- a/go/otel/oteltef/spanstatus.go
+++ b/go/otel/oteltef/spanstatus.go
@@ -396,9 +396,10 @@ func (e *SpanStatusEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // SpanStatusDecoder implements decoding of SpanStatus
 type SpanStatusDecoder struct {
-	buf            pkg.BitsReader
-	column         *pkg.ReadableColumn
-	fieldCount     uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	messageDecoder encoders.StringDecoder
 
 	codeDecoder encoders.Uint64Decoder

--- a/go/otel/oteltef/summaryvalue.go
+++ b/go/otel/oteltef/summaryvalue.go
@@ -483,9 +483,10 @@ func (e *SummaryValueEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 
 // SummaryValueDecoder implements decoding of SummaryValue
 type SummaryValueDecoder struct {
-	buf          pkg.BitsReader
-	column       *pkg.ReadableColumn
-	fieldCount   uint
+	buf        pkg.BitsReader
+	column     *pkg.ReadableColumn
+	fieldCount uint
+
 	countDecoder encoders.Uint64Decoder
 
 	sumDecoder encoders.Float64Decoder

--- a/go/pkg/helpers.go
+++ b/go/pkg/helpers.go
@@ -1,0 +1,23 @@
+package pkg
+
+import "math/bits"
+
+// OptionalFieldCount calculates how many optional fields are within the
+// fields that are kept according to keepFieldMask.
+//
+// This is used to determine how many bits are needed to encode the presence
+// bits of optional fields when schema override is used to keep not all fields.
+// optionalsMask has 1 bits set for every optional field in the original schema.
+// keepFieldCount is the number of fields that we want to keep (all fields: optional and regular).
+// Returns the number of optional fields within the kept fields.
+func OptionalFieldCount(optionalsMask uint64, keepFieldCount uint) uint {
+	// Bit mask with 1 bit set for every field that we want to keep.
+	keepFieldMask := ^(^uint64(0) << keepFieldCount)
+
+	// Zero out bits for fields that we do not want to keep.
+	optionalsMask &= keepFieldMask
+
+	// Count the number of remaining 1 bits in the optionalsMask, that's the number
+	// of optional fields within the overall number of kept fields.
+	return uint(bits.OnesCount64(optionalsMask))
+}

--- a/java/src/main/java/com/example/oteltef/EnvelopeDecoder.java
+++ b/java/src/main/java/com/example/oteltef/EnvelopeDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class EnvelopeDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private EnvelopeAttributesDecoder attributesDecoder;
@@ -29,7 +31,6 @@ class EnvelopeDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getEnvelopeFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/EnvelopeEncoder.java
+++ b/java/src/main/java/com/example/oteltef/EnvelopeEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -26,6 +27,7 @@ class EnvelopeEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -35,13 +37,12 @@ class EnvelopeEncoder {
         state.EnvelopeEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getEnvelopeFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getEnvelopeFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.EnvelopeAttributesEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/EventDecoder.java
+++ b/java/src/main/java/com/example/oteltef/EventDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class EventDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private StringDictDecoder nameDecoder;
@@ -35,7 +37,6 @@ class EventDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getEventFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/EventEncoder.java
+++ b/java/src/main/java/com/example/oteltef/EventEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -32,6 +33,7 @@ class EventEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -41,25 +43,24 @@ class EventEncoder {
         state.EventEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getEventFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getEventFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Name field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Name and subsequent fields are skipped.
             }
             nameEncoder = new StringDictEncoder();
             nameEncoder.init(state.SpanEventName, limiter, columns.addSubColumn());
             // Init encoder for TimeUnixNano field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // TimeUnixNano and subsequent fields are skipped.
             }
             timeUnixNanoEncoder = new Uint64Encoder();
             timeUnixNanoEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -71,7 +72,7 @@ class EventEncoder {
                 attributesEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for DroppedAttributesCount field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // DroppedAttributesCount and subsequent fields are skipped.
             }
             droppedAttributesCountEncoder = new Uint64Encoder();

--- a/java/src/main/java/com/example/oteltef/ExemplarDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class ExemplarDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private Uint64Decoder timestampDecoder;
@@ -37,7 +39,6 @@ class ExemplarDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getExemplarFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/ExemplarEncoder.java
+++ b/java/src/main/java/com/example/oteltef/ExemplarEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -34,6 +35,7 @@ class ExemplarEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -43,19 +45,18 @@ class ExemplarEncoder {
         state.ExemplarEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getExemplarFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getExemplarFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Timestamp field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Timestamp and subsequent fields are skipped.
             }
             timestampEncoder = new Uint64Encoder();
             timestampEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Value field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Value and subsequent fields are skipped.
             }
             if (state.ExemplarValueEncoder != null) {
@@ -67,19 +68,19 @@ class ExemplarEncoder {
                 valueEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for SpanID field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // SpanID and subsequent fields are skipped.
             }
             spanIDEncoder = new BytesEncoder();
             spanIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for TraceID field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // TraceID and subsequent fields are skipped.
             }
             traceIDEncoder = new BytesEncoder();
             traceIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for FilteredAttributes field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // FilteredAttributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/ExpHistogramBucketsDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramBucketsDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class ExpHistogramBucketsDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private Int64Decoder offsetDecoder;
@@ -31,7 +33,6 @@ class ExpHistogramBucketsDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getExpHistogramBucketsFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/ExpHistogramBucketsEncoder.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramBucketsEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -28,6 +29,7 @@ class ExpHistogramBucketsEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -37,19 +39,18 @@ class ExpHistogramBucketsEncoder {
         state.ExpHistogramBucketsEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getExpHistogramBucketsFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getExpHistogramBucketsFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Offset field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Offset and subsequent fields are skipped.
             }
             offsetEncoder = new Int64Encoder();
             offsetEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for BucketCounts field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // BucketCounts and subsequent fields are skipped.
             }
             if (state.Uint64ArrayEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/ExpHistogramValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ExpHistogramValueDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class ExpHistogramValueDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    private int optionalFieldCount;
 
     
     private Uint64Decoder countDecoder;
@@ -45,7 +47,7 @@ class ExpHistogramValueDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getExpHistogramValueFieldCount();
-
+            optionalFieldCount = Helper.optionalFieldCount(0b1110, fieldCount);
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {
@@ -223,7 +225,7 @@ class ExpHistogramValueDecoder {
         val.modifiedFields.mask = buf.readBits(fieldCount);
         
         // Write bits to indicate which optional fields are set.
-        val.optionalFieldsPresent = buf.readBits(3);
+        val.optionalFieldsPresent = buf.readBits(optionalFieldCount);
         
         if ((val.modifiedFields.mask & ExpHistogramValue.fieldModifiedCount) != 0) {
             // Field is changed and is present, decode it.

--- a/java/src/main/java/com/example/oteltef/HistogramValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/HistogramValueDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class HistogramValueDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    private int optionalFieldCount;
 
     
     private Int64Decoder countDecoder;
@@ -37,7 +39,7 @@ class HistogramValueDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getHistogramValueFieldCount();
-
+            optionalFieldCount = Helper.optionalFieldCount(0b1110, fieldCount);
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {
@@ -147,7 +149,7 @@ class HistogramValueDecoder {
         val.modifiedFields.mask = buf.readBits(fieldCount);
         
         // Write bits to indicate which optional fields are set.
-        val.optionalFieldsPresent = buf.readBits(3);
+        val.optionalFieldsPresent = buf.readBits(optionalFieldCount);
         
         if ((val.modifiedFields.mask & HistogramValue.fieldModifiedCount) != 0) {
             // Field is changed and is present, decode it.

--- a/java/src/main/java/com/example/oteltef/HistogramValueEncoder.java
+++ b/java/src/main/java/com/example/oteltef/HistogramValueEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -34,6 +35,7 @@ class HistogramValueEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    private int optionalFieldCount;
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -43,37 +45,37 @@ class HistogramValueEncoder {
         state.HistogramValueEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getHistogramValueFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getHistogramValueFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
+            optionalFieldCount = Helper.optionalFieldCount(0b1110, fieldCount);
             // Init encoder for Count field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Count and subsequent fields are skipped.
             }
             countEncoder = new Int64Encoder();
             countEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Sum field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Sum and subsequent fields are skipped.
             }
             sumEncoder = new Float64Encoder();
             sumEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Min field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // Min and subsequent fields are skipped.
             }
             minEncoder = new Float64Encoder();
             minEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Max field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Max and subsequent fields are skipped.
             }
             maxEncoder = new Float64Encoder();
             maxEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for BucketCounts field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // BucketCounts and subsequent fields are skipped.
             }
             if (state.Uint64ArrayEncoder != null) {
@@ -146,7 +148,7 @@ class HistogramValueEncoder {
         this.buf.writeBits(fieldMask, this.fieldCount);
         
         // Write bits to indicate which optional fields are set.
-        this.buf.writeBits(val.optionalFieldsPresent, 3);
+        this.buf.writeBits(val.optionalFieldsPresent, optionalFieldCount);
         // Encode modified, present fields.
         
         if ((fieldMask & HistogramValue.fieldModifiedCount) != 0) {

--- a/java/src/main/java/com/example/oteltef/LinkDecoder.java
+++ b/java/src/main/java/com/example/oteltef/LinkDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class LinkDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private BytesDecoder traceIDDecoder;
@@ -39,7 +41,6 @@ class LinkDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getLinkFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/LinkEncoder.java
+++ b/java/src/main/java/com/example/oteltef/LinkEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -36,6 +37,7 @@ class LinkEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -45,37 +47,36 @@ class LinkEncoder {
         state.LinkEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getLinkFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getLinkFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for TraceID field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // TraceID and subsequent fields are skipped.
             }
             traceIDEncoder = new BytesEncoder();
             traceIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for SpanID field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // SpanID and subsequent fields are skipped.
             }
             spanIDEncoder = new BytesEncoder();
             spanIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for TraceState field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // TraceState and subsequent fields are skipped.
             }
             traceStateEncoder = new StringEncoder();
             traceStateEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Flags field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Flags and subsequent fields are skipped.
             }
             flagsEncoder = new Uint64Encoder();
             flagsEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -87,7 +88,7 @@ class LinkEncoder {
                 attributesEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for DroppedAttributesCount field.
-            if (this.fieldCount <= 5) {
+            if (fieldCount <= 5) {
                 return; // DroppedAttributesCount and subsequent fields are skipped.
             }
             droppedAttributesCountEncoder = new Uint64Encoder();

--- a/java/src/main/java/com/example/oteltef/MetricDecoder.java
+++ b/java/src/main/java/com/example/oteltef/MetricDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class MetricDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private StringDictDecoder nameDecoder;
@@ -45,7 +47,6 @@ class MetricDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getMetricFieldCount();
-
             column = columns.getColumn();
             dict = state.Metric;
             

--- a/java/src/main/java/com/example/oteltef/MetricEncoder.java
+++ b/java/src/main/java/com/example/oteltef/MetricEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -42,6 +43,7 @@ class MetricEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -51,38 +53,37 @@ class MetricEncoder {
         state.MetricEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
-            this.dict = state.Metric;
+            limiter = state.getLimiter();
+            dict = state.Metric;
 
-            this.fieldCount = state.getStructFieldCounts().getMetricFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getMetricFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Name field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Name and subsequent fields are skipped.
             }
             nameEncoder = new StringDictEncoder();
             nameEncoder.init(state.MetricName, limiter, columns.addSubColumn());
             // Init encoder for Description field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Description and subsequent fields are skipped.
             }
             descriptionEncoder = new StringDictEncoder();
             descriptionEncoder.init(state.MetricDescription, limiter, columns.addSubColumn());
             // Init encoder for Unit field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // Unit and subsequent fields are skipped.
             }
             unitEncoder = new StringDictEncoder();
             unitEncoder.init(state.MetricUnit, limiter, columns.addSubColumn());
             // Init encoder for Type field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Type and subsequent fields are skipped.
             }
             type_Encoder = new Uint64Encoder();
             type_Encoder.init(limiter, columns.addSubColumn());
             // Init encoder for Metadata field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // Metadata and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -94,7 +95,7 @@ class MetricEncoder {
                 metadataEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for HistogramBounds field.
-            if (this.fieldCount <= 5) {
+            if (fieldCount <= 5) {
                 return; // HistogramBounds and subsequent fields are skipped.
             }
             if (state.Float64ArrayEncoder != null) {
@@ -106,13 +107,13 @@ class MetricEncoder {
                 histogramBoundsEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for AggregationTemporality field.
-            if (this.fieldCount <= 6) {
+            if (fieldCount <= 6) {
                 return; // AggregationTemporality and subsequent fields are skipped.
             }
             aggregationTemporalityEncoder = new Uint64Encoder();
             aggregationTemporalityEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Monotonic field.
-            if (this.fieldCount <= 7) {
+            if (fieldCount <= 7) {
                 return; // Monotonic and subsequent fields are skipped.
             }
             monotonicEncoder = new BoolEncoder();

--- a/java/src/main/java/com/example/oteltef/MetricsDecoder.java
+++ b/java/src/main/java/com/example/oteltef/MetricsDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class MetricsDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private EnvelopeDecoder envelopeDecoder;
@@ -39,7 +41,6 @@ class MetricsDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getMetricsFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/MetricsEncoder.java
+++ b/java/src/main/java/com/example/oteltef/MetricsEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -36,6 +37,7 @@ class MetricsEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -45,13 +47,12 @@ class MetricsEncoder {
         state.MetricsEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getMetricsFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getMetricsFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Envelope field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Envelope and subsequent fields are skipped.
             }
             if (state.EnvelopeEncoder != null) {
@@ -63,7 +64,7 @@ class MetricsEncoder {
                 envelopeEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Metric field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Metric and subsequent fields are skipped.
             }
             if (state.MetricEncoder != null) {
@@ -75,7 +76,7 @@ class MetricsEncoder {
                 metricEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Resource field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // Resource and subsequent fields are skipped.
             }
             if (state.ResourceEncoder != null) {
@@ -87,7 +88,7 @@ class MetricsEncoder {
                 resourceEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Scope field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Scope and subsequent fields are skipped.
             }
             if (state.ScopeEncoder != null) {
@@ -99,7 +100,7 @@ class MetricsEncoder {
                 scopeEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -111,7 +112,7 @@ class MetricsEncoder {
                 attributesEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Point field.
-            if (this.fieldCount <= 5) {
+            if (fieldCount <= 5) {
                 return; // Point and subsequent fields are skipped.
             }
             if (state.PointEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/PointDecoder.java
+++ b/java/src/main/java/com/example/oteltef/PointDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class PointDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private Uint64Decoder startTimestampDecoder;
@@ -35,7 +37,6 @@ class PointDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getPointFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/PointEncoder.java
+++ b/java/src/main/java/com/example/oteltef/PointEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -32,6 +33,7 @@ class PointEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -41,25 +43,24 @@ class PointEncoder {
         state.PointEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getPointFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getPointFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for StartTimestamp field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // StartTimestamp and subsequent fields are skipped.
             }
             startTimestampEncoder = new Uint64Encoder();
             startTimestampEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Timestamp field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Timestamp and subsequent fields are skipped.
             }
             timestampEncoder = new Uint64Encoder();
             timestampEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Value field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // Value and subsequent fields are skipped.
             }
             if (state.PointValueEncoder != null) {
@@ -71,7 +72,7 @@ class PointEncoder {
                 valueEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Exemplars field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Exemplars and subsequent fields are skipped.
             }
             if (state.ExemplarArrayEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/QuantileValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/QuantileValueDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class QuantileValueDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private Float64Decoder quantileDecoder;
@@ -31,7 +33,6 @@ class QuantileValueDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getQuantileValueFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/QuantileValueEncoder.java
+++ b/java/src/main/java/com/example/oteltef/QuantileValueEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -28,6 +29,7 @@ class QuantileValueEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -37,19 +39,18 @@ class QuantileValueEncoder {
         state.QuantileValueEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getQuantileValueFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getQuantileValueFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Quantile field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Quantile and subsequent fields are skipped.
             }
             quantileEncoder = new Float64Encoder();
             quantileEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Value field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Value and subsequent fields are skipped.
             }
             valueEncoder = new Float64Encoder();

--- a/java/src/main/java/com/example/oteltef/ResourceDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ResourceDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class ResourceDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private StringDictDecoder schemaURLDecoder;
@@ -35,7 +37,6 @@ class ResourceDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getResourceFieldCount();
-
             column = columns.getColumn();
             dict = state.Resource;
             

--- a/java/src/main/java/com/example/oteltef/ResourceEncoder.java
+++ b/java/src/main/java/com/example/oteltef/ResourceEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -32,6 +33,7 @@ class ResourceEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -41,20 +43,19 @@ class ResourceEncoder {
         state.ResourceEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
-            this.dict = state.Resource;
+            limiter = state.getLimiter();
+            dict = state.Resource;
 
-            this.fieldCount = state.getStructFieldCounts().getResourceFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getResourceFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for SchemaURL field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // SchemaURL and subsequent fields are skipped.
             }
             schemaURLEncoder = new StringDictEncoder();
             schemaURLEncoder.init(state.SchemaURL, limiter, columns.addSubColumn());
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -66,7 +67,7 @@ class ResourceEncoder {
                 attributesEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for DroppedAttributesCount field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // DroppedAttributesCount and subsequent fields are skipped.
             }
             droppedAttributesCountEncoder = new Uint64Encoder();

--- a/java/src/main/java/com/example/oteltef/ScopeDecoder.java
+++ b/java/src/main/java/com/example/oteltef/ScopeDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class ScopeDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private StringDictDecoder nameDecoder;
@@ -39,7 +41,6 @@ class ScopeDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getScopeFieldCount();
-
             column = columns.getColumn();
             dict = state.Scope;
             

--- a/java/src/main/java/com/example/oteltef/ScopeEncoder.java
+++ b/java/src/main/java/com/example/oteltef/ScopeEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -36,6 +37,7 @@ class ScopeEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -45,32 +47,31 @@ class ScopeEncoder {
         state.ScopeEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
-            this.dict = state.Scope;
+            limiter = state.getLimiter();
+            dict = state.Scope;
 
-            this.fieldCount = state.getStructFieldCounts().getScopeFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getScopeFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Name field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Name and subsequent fields are skipped.
             }
             nameEncoder = new StringDictEncoder();
             nameEncoder.init(state.ScopeName, limiter, columns.addSubColumn());
             // Init encoder for Version field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Version and subsequent fields are skipped.
             }
             versionEncoder = new StringDictEncoder();
             versionEncoder.init(state.ScopeVersion, limiter, columns.addSubColumn());
             // Init encoder for SchemaURL field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // SchemaURL and subsequent fields are skipped.
             }
             schemaURLEncoder = new StringDictEncoder();
             schemaURLEncoder.init(state.SchemaURL, limiter, columns.addSubColumn());
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -82,7 +83,7 @@ class ScopeEncoder {
                 attributesEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for DroppedAttributesCount field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // DroppedAttributesCount and subsequent fields are skipped.
             }
             droppedAttributesCountEncoder = new Uint64Encoder();

--- a/java/src/main/java/com/example/oteltef/SpanDecoder.java
+++ b/java/src/main/java/com/example/oteltef/SpanDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class SpanDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private BytesDecoder traceIDDecoder;
@@ -55,7 +57,6 @@ class SpanDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getSpanFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/SpanEncoder.java
+++ b/java/src/main/java/com/example/oteltef/SpanEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -52,6 +53,7 @@ class SpanEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -61,67 +63,66 @@ class SpanEncoder {
         state.SpanEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getSpanFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getSpanFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for TraceID field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // TraceID and subsequent fields are skipped.
             }
             traceIDEncoder = new BytesEncoder();
             traceIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for SpanID field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // SpanID and subsequent fields are skipped.
             }
             spanIDEncoder = new BytesEncoder();
             spanIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for TraceState field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // TraceState and subsequent fields are skipped.
             }
             traceStateEncoder = new StringEncoder();
             traceStateEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for ParentSpanID field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // ParentSpanID and subsequent fields are skipped.
             }
             parentSpanIDEncoder = new BytesEncoder();
             parentSpanIDEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Flags field.
-            if (this.fieldCount <= 4) {
+            if (fieldCount <= 4) {
                 return; // Flags and subsequent fields are skipped.
             }
             flagsEncoder = new Uint64Encoder();
             flagsEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Name field.
-            if (this.fieldCount <= 5) {
+            if (fieldCount <= 5) {
                 return; // Name and subsequent fields are skipped.
             }
             nameEncoder = new StringDictEncoder();
             nameEncoder.init(state.SpanName, limiter, columns.addSubColumn());
             // Init encoder for Kind field.
-            if (this.fieldCount <= 6) {
+            if (fieldCount <= 6) {
                 return; // Kind and subsequent fields are skipped.
             }
             kindEncoder = new Uint64Encoder();
             kindEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for StartTimeUnixNano field.
-            if (this.fieldCount <= 7) {
+            if (fieldCount <= 7) {
                 return; // StartTimeUnixNano and subsequent fields are skipped.
             }
             startTimeUnixNanoEncoder = new Uint64Encoder();
             startTimeUnixNanoEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for EndTimeUnixNano field.
-            if (this.fieldCount <= 8) {
+            if (fieldCount <= 8) {
                 return; // EndTimeUnixNano and subsequent fields are skipped.
             }
             endTimeUnixNanoEncoder = new Uint64Encoder();
             endTimeUnixNanoEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Attributes field.
-            if (this.fieldCount <= 9) {
+            if (fieldCount <= 9) {
                 return; // Attributes and subsequent fields are skipped.
             }
             if (state.AttributesEncoder != null) {
@@ -133,13 +134,13 @@ class SpanEncoder {
                 attributesEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for DroppedAttributesCount field.
-            if (this.fieldCount <= 10) {
+            if (fieldCount <= 10) {
                 return; // DroppedAttributesCount and subsequent fields are skipped.
             }
             droppedAttributesCountEncoder = new Uint64Encoder();
             droppedAttributesCountEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Events field.
-            if (this.fieldCount <= 11) {
+            if (fieldCount <= 11) {
                 return; // Events and subsequent fields are skipped.
             }
             if (state.EventArrayEncoder != null) {
@@ -151,7 +152,7 @@ class SpanEncoder {
                 eventsEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Links field.
-            if (this.fieldCount <= 12) {
+            if (fieldCount <= 12) {
                 return; // Links and subsequent fields are skipped.
             }
             if (state.LinkArrayEncoder != null) {
@@ -163,7 +164,7 @@ class SpanEncoder {
                 linksEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Status field.
-            if (this.fieldCount <= 13) {
+            if (fieldCount <= 13) {
                 return; // Status and subsequent fields are skipped.
             }
             if (state.SpanStatusEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/SpanStatusDecoder.java
+++ b/java/src/main/java/com/example/oteltef/SpanStatusDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class SpanStatusDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private StringDecoder messageDecoder;
@@ -31,7 +33,6 @@ class SpanStatusDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getSpanStatusFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/SpanStatusEncoder.java
+++ b/java/src/main/java/com/example/oteltef/SpanStatusEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -28,6 +29,7 @@ class SpanStatusEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -37,19 +39,18 @@ class SpanStatusEncoder {
         state.SpanStatusEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getSpanStatusFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getSpanStatusFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Message field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Message and subsequent fields are skipped.
             }
             messageEncoder = new StringEncoder();
             messageEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Code field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Code and subsequent fields are skipped.
             }
             codeEncoder = new Uint64Encoder();

--- a/java/src/main/java/com/example/oteltef/SpansDecoder.java
+++ b/java/src/main/java/com/example/oteltef/SpansDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class SpansDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private EnvelopeDecoder envelopeDecoder;
@@ -35,7 +37,6 @@ class SpansDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getSpansFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/SpansEncoder.java
+++ b/java/src/main/java/com/example/oteltef/SpansEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -32,6 +33,7 @@ class SpansEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -41,13 +43,12 @@ class SpansEncoder {
         state.SpansEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getSpansFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getSpansFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Envelope field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Envelope and subsequent fields are skipped.
             }
             if (state.EnvelopeEncoder != null) {
@@ -59,7 +60,7 @@ class SpansEncoder {
                 envelopeEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Resource field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Resource and subsequent fields are skipped.
             }
             if (state.ResourceEncoder != null) {
@@ -71,7 +72,7 @@ class SpansEncoder {
                 resourceEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Scope field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // Scope and subsequent fields are skipped.
             }
             if (state.ScopeEncoder != null) {
@@ -83,7 +84,7 @@ class SpansEncoder {
                 scopeEncoder.init(state, columns.addSubColumn());
             }
             // Init encoder for Span field.
-            if (this.fieldCount <= 3) {
+            if (fieldCount <= 3) {
                 return; // Span and subsequent fields are skipped.
             }
             if (state.SpanEncoder != null) {

--- a/java/src/main/java/com/example/oteltef/SummaryValueDecoder.java
+++ b/java/src/main/java/com/example/oteltef/SummaryValueDecoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -13,6 +14,7 @@ class SummaryValueDecoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    
 
     
     private Uint64Decoder countDecoder;
@@ -33,7 +35,6 @@ class SummaryValueDecoder {
 
         try {
             fieldCount = state.getStructFieldCounts().getSummaryValueFieldCount();
-
             column = columns.getColumn();
             
             if (this.fieldCount <= 0) {

--- a/java/src/main/java/com/example/oteltef/SummaryValueEncoder.java
+++ b/java/src/main/java/com/example/oteltef/SummaryValueEncoder.java
@@ -3,6 +3,7 @@
 package com.example.oteltef;
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -30,6 +31,7 @@ class SummaryValueEncoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -39,25 +41,24 @@ class SummaryValueEncoder {
         state.SummaryValueEncoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
 
-            this.fieldCount = state.getStructFieldCounts().getSummaryValueFieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
-            
+            fieldCount = state.getStructFieldCounts().getSummaryValueFieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
             // Init encoder for Count field.
-            if (this.fieldCount <= 0) {
+            if (fieldCount <= 0) {
                 return; // Count and subsequent fields are skipped.
             }
             countEncoder = new Uint64Encoder();
             countEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for Sum field.
-            if (this.fieldCount <= 1) {
+            if (fieldCount <= 1) {
                 return; // Sum and subsequent fields are skipped.
             }
             sumEncoder = new Float64Encoder();
             sumEncoder.init(limiter, columns.addSubColumn());
             // Init encoder for QuantileValues field.
-            if (this.fieldCount <= 2) {
+            if (fieldCount <= 2) {
                 return; // QuantileValues and subsequent fields are skipped.
             }
             if (state.QuantileValueArrayEncoder != null) {

--- a/java/src/main/java/net/stef/Helper.java
+++ b/java/src/main/java/net/stef/Helper.java
@@ -1,0 +1,30 @@
+package net.stef;
+
+/**
+ * Helper utility functions for STEF operations.
+ */
+public class Helper {
+
+    /**
+     * Calculates how many optional fields are within the fields that are kept
+     * according to keepFieldCount.
+     *
+     * This is used to determine how many bits are needed to encode the presence
+     * bits of optional fields when schema override is used to keep not all fields.
+     *
+     * @param optionalsMask has 1 bits set for every optional field in the original schema
+     * @param keepFieldCount the number of fields that we want to keep (all fields: optional and regular)
+     * @return the number of optional fields within the kept fields
+     */
+    public static int optionalFieldCount(long optionalsMask, int keepFieldCount) {
+        // Bit mask with 1 bit set for every field that we want to keep.
+        long keepFieldMask = ~(~0L << keepFieldCount);
+
+        // Zero out bits for fields that we do not want to keep.
+        optionalsMask &= keepFieldMask;
+
+        // Count the number of remaining 1 bits in the optionalsMask, that's the number
+        // of optional fields within the overall number of kept fields.
+        return Long.bitCount(optionalsMask);
+    }
+}

--- a/stefc/generator/structs.go
+++ b/stefc/generator/structs.go
@@ -29,6 +29,7 @@ func (g *Generator) oStruct(str *genStructDef) error {
 	fields := []any{}
 
 	modifier := " = uint64(1 << iota)"
+	optionalsMask := uint64(0)
 	optionalFieldIndex := 0
 	for i, field := range str.Fields {
 		passByPointer := false
@@ -66,6 +67,7 @@ func (g *Generator) oStruct(str *genStructDef) error {
 		if field.Optional {
 			fieldData["OptionalIndex"] = optionalFieldIndex
 			optionalFieldIndex++
+			optionalsMask |= 1 << uint64(i)
 		}
 
 		fields = append(fields, fieldData)
@@ -80,6 +82,7 @@ func (g *Generator) oStruct(str *genStructDef) error {
 		"Type":               str,
 		"IsMainStruct":       str.IsRoot,
 		"OptionalFieldCount": optionalFieldIndex,
+		"OptionalsMask":      optionalsMask,
 	}
 
 	if str.IsRoot {

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -585,6 +585,7 @@ type {{ .StructName }}Encoder struct {
 
     keepFieldMask uint64
     fieldCount uint
+    {{if .OptionalFieldCount}}optionalFieldCount uint{{- end}}
 }
 
 {{if .DictName}}
@@ -662,6 +663,10 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
     // Set that many 1 bits in the keepFieldMask. All fields with higher number
     // will be skipped when encoding.
     e.keepFieldMask = ^(^uint64(0) << e.fieldCount)
+
+    {{if .OptionalFieldCount}}
+    e.optionalFieldCount = pkg.OptionalFieldCount({{printf "0b%b" .OptionalsMask}}, e.fieldCount)
+    {{end}}
 
     {{ range $i, $e := .Fields }}
     // Init encoder for {{.Name}} field.
@@ -755,8 +760,8 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
 
 	{{ if .OptionalFieldCount}}
     // Write bits to indicate which optional fields are set.
-    e.buf.WriteBits(val.optionalFieldsPresent, {{ .OptionalFieldCount}})
-    bitCount += {{ .OptionalFieldCount}}
+    e.buf.WriteBits(val.optionalFieldsPresent, e.optionalFieldCount)
+    bitCount += e.optionalFieldCount
 	{{- end}}
 
     // Encode modified, present fields.
@@ -805,6 +810,7 @@ type {{ .StructName }}Decoder struct {
     buf pkg.BitsReader
     column *pkg.ReadableColumn
     fieldCount uint
+    {{if .OptionalFieldCount}}optionalFieldCount uint{{end}}
 
     {{- range .Fields}}
     {{.name}}Decoder {{if not .IsPrimitive}}*{{end}}{{ .Type.EncoderType }}Decoder
@@ -833,6 +839,10 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     if err != nil {
         return fmt.Errorf("cannot find struct %s in override schema: %v", {{printf "%q" .StructName}}, err)
     }
+
+    {{if .OptionalFieldCount}}
+    d.optionalFieldCount = pkg.OptionalFieldCount({{printf "0b%b" .OptionalsMask}}, d.fieldCount)
+    {{end}}
 
     d.column = columns.Column()
 
@@ -938,12 +948,12 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
     {{ if .OptionalFieldCount}}
     // Read bits that indicate which optional fields are set.
     {{if le .OptionalFieldCount 56 -}}
-    {{/* Fast path, no more than 56 fields */ -}}
-    val.optionalFieldsPresent = d.buf.PeekBits({{ .OptionalFieldCount}})
-    d.buf.Consume({{ .OptionalFieldCount}})
+    {{/* Fast path, no more than 56 optional fields */ -}}
+    val.optionalFieldsPresent = d.buf.PeekBits(d.optionalFieldCount)
+    d.buf.Consume(d.optionalFieldCount)
     {{else -}}
     {{/* Slow path, more than 56 fields */ -}}
-    val.optionalFieldsPresent = d.buf.ReadBits({{ .OptionalFieldCount}})
+    val.optionalFieldsPresent = d.buf.ReadBits(d.optionalFieldCount)
     {{end}}
     {{- end}}
 

--- a/stefc/templates/java/structDecoder.java.tmpl
+++ b/stefc/templates/java/structDecoder.java.tmpl
@@ -2,6 +2,7 @@
 package {{ .PackageName }};
 
 import net.stef.BitsReader;
+import net.stef.Helper;
 import net.stef.ReadColumnSet;
 import net.stef.ReadableColumn;
 import net.stef.codecs.*;
@@ -12,6 +13,7 @@ class {{ .StructName }}Decoder {
     private final BitsReader buf = new BitsReader();
     private ReadableColumn column;
     private int fieldCount;
+    {{if .OptionalFieldCount}}private int optionalFieldCount;{{end}}
 
     {{ range .Fields }}
     private {{ .Type.EncoderType }}Decoder {{.name}}Decoder;
@@ -31,7 +33,9 @@ class {{ .StructName }}Decoder {
 
         try {
             fieldCount = state.getStructFieldCounts().get{{.StructName}}FieldCount();
-
+            {{- if .OptionalFieldCount}}
+            optionalFieldCount = Helper.optionalFieldCount({{printf "0b%b" .OptionalsMask}}, fieldCount);
+            {{- end}}
             column = columns.getColumn();
             {{- if .DictName}}
             dict = state.{{.DictName}};
@@ -116,7 +120,7 @@ class {{ .StructName }}Decoder {
         val.modifiedFields.mask = buf.readBits(fieldCount);
         {{ if .OptionalFieldCount}}
         // Write bits to indicate which optional fields are set.
-        val.optionalFieldsPresent = buf.readBits({{ .OptionalFieldCount}});
+        val.optionalFieldsPresent = buf.readBits(optionalFieldCount);
         {{- end}}
         {{ range .Fields }}
         if ((val.modifiedFields.mask & {{ $.StructName }}.fieldModified{{.Name}}) != 0

--- a/stefc/templates/java/structEncoder.java.tmpl
+++ b/stefc/templates/java/structEncoder.java.tmpl
@@ -2,6 +2,7 @@
 package {{ .PackageName }};
 
 import net.stef.BitsWriter;
+import net.stef.Helper;
 import net.stef.SizeLimiter;
 import net.stef.WriteColumnSet;
 import net.stef.codecs.*;
@@ -28,6 +29,7 @@ class {{ .StructName }}Encoder {
 
     private long keepFieldMask;
     private int fieldCount;
+    {{if .OptionalFieldCount}}private int optionalFieldCount;{{end}}
 
     public void init(WriterState state, WriteColumnSet columns) throws IOException {
         // Remember this encoder in the state so that we can detect recursion.
@@ -37,16 +39,21 @@ class {{ .StructName }}Encoder {
         state.{{.StructName}}Encoder = this;
 
         try {
-            this.limiter = state.getLimiter();
+            limiter = state.getLimiter();
             {{- if .DictName}}
-            this.dict = state.{{.DictName}};
+            dict = state.{{.DictName}};
             {{- end}}
 
-            this.fieldCount = state.getStructFieldCounts().get{{.StructName}}FieldCount();
-            this.keepFieldMask = ~((~0L) << this.fieldCount);
+            fieldCount = state.getStructFieldCounts().get{{.StructName}}FieldCount();
+            keepFieldMask = ~((~0L) << fieldCount);
+
+            {{- if .OptionalFieldCount}}
+            optionalFieldCount = Helper.optionalFieldCount({{printf "0b%b" .OptionalsMask}}, fieldCount);
+            {{- end -}}
+
             {{ range $i, $e := .Fields }}
             // Init encoder for {{.Name}} field.
-            if (this.fieldCount <= {{$i}}) {
+            if (fieldCount <= {{$i}}) {
                 return; // {{.Name}} and subsequent fields are skipped.
             }
             {{- if .IsPrimitive}}
@@ -132,7 +139,7 @@ class {{ .StructName }}Encoder {
         this.buf.writeBits(fieldMask, this.fieldCount);
         {{ if .OptionalFieldCount}}
         // Write bits to indicate which optional fields are set.
-        this.buf.writeBits(val.optionalFieldsPresent, {{ .OptionalFieldCount}});
+        this.buf.writeBits(val.optionalFieldsPresent, optionalFieldCount);
         {{- end}}
         // Encode modified, present fields.
         {{ range .Fields }}


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/207

The count of optional fields is calculated based on the
overridden schema, like it is done for the count of all
fields. Previously the count of optional fields was static
and that was not working correctly when schema was overridden
schema.

We don't yet have automated tests that verify this fully.
For that we need to generate code for overridden schema.
It will be added in a future PR.