### PR TITLE
Make sure all encoders are included in WriterState

### DIFF
--- a/stefc/generator/testdata/array_multimap.stef
+++ b/stefc/generator/testdata/array_multimap.stef
@@ -1,0 +1,10 @@
+package com.example.gentest.array_multimap
+
+multimap MultiMap {
+  key int64
+  value int64
+}
+
+struct Struct root {
+  Field []MultiMap
+}


### PR DESCRIPTION
An array of multimap previously failed to generate the encoder in the WriterState because getEncoders was not correctly enumerating all multimaps. This is now fixed.