### PR TITLE
Fix bug: Modified field tracking works incorrectly for array multimap

### DIFF
--- a/examples/ints/internal/ints/record.go
+++ b/examples/ints/internal/ints/record.go
@@ -243,7 +243,7 @@ func (e *RecordEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) er
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.RecordFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Record", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Record", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -344,7 +344,7 @@ func (d *RecordDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) err
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.RecordFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Record", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Record", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/ints/internal/ints/recordwriter.go
+++ b/examples/ints/internal/ints/recordwriter.go
@@ -53,7 +53,9 @@ func NewRecordWriter(dst pkg.ChunkWriter, opts pkg.WriterOptions) (*RecordWriter
 
 	writer.Record.Init()
 	writer.state.Init(&writer.opts)
-	writer.encoder.Init(&writer.state, &writer.writeBufs.Columns)
+	if err := writer.encoder.Init(&writer.state, &writer.writeBufs.Columns); err != nil {
+		return nil, err
+	}
 
 	if !writer.state.StructFieldCounts.AllFetched() {
 		return nil, errors.New("override schema iterator is not done, likely supplied schema override does not match the generated code")

--- a/examples/jsonl/internal/jsonstef/jsonvalue.go
+++ b/examples/jsonl/internal/jsonstef/jsonvalue.go
@@ -442,7 +442,7 @@ func (e *JsonValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet)
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.JsonValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "JsonValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "JsonValue", err)
 	}
 	e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount) + 1))
 
@@ -669,7 +669,7 @@ func (d *JsonValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) 
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.JsonValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "JsonValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "JsonValue", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/jsonl/internal/jsonstef/jsonvaluearray.go
+++ b/examples/jsonl/internal/jsonstef/jsonvaluearray.go
@@ -114,7 +114,7 @@ func copyJsonValueArray(dst *JsonValueArray, src *JsonValueArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewJsonValueArray(dst *JsonValueArray, src *JsonValueArray, allocator
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *JsonValueArray) At(i int) *JsonValue {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *JsonValueArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*JsonValue, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(JsonValue)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *JsonValueArray) EnsureLen(newLen int) {
 func (e *JsonValueArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*JsonValue, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *JsonValueArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.JsonValue.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/examples/jsonl/internal/jsonstef/record.go
+++ b/examples/jsonl/internal/jsonstef/record.go
@@ -263,7 +263,7 @@ func (e *RecordEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) er
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.RecordFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Record", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Record", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -375,7 +375,7 @@ func (d *RecordDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) err
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.RecordFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Record", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Record", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/jsonl/internal/jsonstef/recordwriter.go
+++ b/examples/jsonl/internal/jsonstef/recordwriter.go
@@ -53,7 +53,9 @@ func NewRecordWriter(dst pkg.ChunkWriter, opts pkg.WriterOptions) (*RecordWriter
 
 	writer.Record.Init()
 	writer.state.Init(&writer.opts)
-	writer.encoder.Init(&writer.state, &writer.writeBufs.Columns)
+	if err := writer.encoder.Init(&writer.state, &writer.writeBufs.Columns); err != nil {
+		return nil, err
+	}
 
 	if !writer.state.StructFieldCounts.AllFetched() {
 		return nil, errors.New("override schema iterator is not done, likely supplied schema override does not match the generated code")

--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -468,7 +468,7 @@ func (e *FunctionEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.FunctionFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Function", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Function", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -672,7 +672,7 @@ func (d *FunctionDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.FunctionFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Function", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Function", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/labelvalue.go
+++ b/examples/profile/internal/profile/labelvalue.go
@@ -327,7 +327,7 @@ func (e *LabelValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.LabelValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "LabelValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "LabelValue", err)
 	}
 	e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount) + 1))
 
@@ -460,7 +460,7 @@ func (d *LabelValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.LabelValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "LabelValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "LabelValue", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/line.go
+++ b/examples/profile/internal/profile/line.go
@@ -394,7 +394,7 @@ func (e *LineEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) erro
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.LineFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Line", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Line", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -558,7 +558,7 @@ func (d *LineDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) error
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.LineFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Line", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Line", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/linearray.go
+++ b/examples/profile/internal/profile/linearray.go
@@ -114,7 +114,7 @@ func copyLineArray(dst *LineArray, src *LineArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewLineArray(dst *LineArray, src *LineArray, allocators *Allocators) 
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *LineArray) At(i int) *Line {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *LineArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*Line, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(Line)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *LineArray) EnsureLen(newLen int) {
 func (e *LineArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*Line, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *LineArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.Line.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -515,7 +515,7 @@ func (e *LocationEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.LocationFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Location", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Location", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -741,7 +741,7 @@ func (d *LocationDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.LocationFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Location", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Location", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/locationarray.go
+++ b/examples/profile/internal/profile/locationarray.go
@@ -114,7 +114,7 @@ func copyLocationArray(dst *LocationArray, src *LocationArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewLocationArray(dst *LocationArray, src *LocationArray, allocators *
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *LocationArray) At(i int) *Location {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *LocationArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*Location, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(Location)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *LocationArray) EnsureLen(newLen int) {
 func (e *LocationArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*Location, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *LocationArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.Location.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -728,7 +728,7 @@ func (e *MappingEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) e
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.MappingFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Mapping", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Mapping", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -1062,7 +1062,7 @@ func (d *MappingDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) er
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.MappingFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Mapping", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Mapping", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/numvalue.go
+++ b/examples/profile/internal/profile/numvalue.go
@@ -295,7 +295,7 @@ func (e *NumValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.NumValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "NumValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "NumValue", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -422,7 +422,7 @@ func (d *NumValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.NumValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "NumValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "NumValue", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/profilemetadata.go
+++ b/examples/profile/internal/profile/profilemetadata.go
@@ -701,7 +701,7 @@ func (e *ProfileMetadataEncoder) Init(state *WriterState, columns *pkg.WriteColu
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ProfileMetadataFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ProfileMetadata", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ProfileMetadata", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -1017,7 +1017,7 @@ func (d *ProfileMetadataDecoder) Init(state *ReaderState, columns *pkg.ReadColum
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ProfileMetadataFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ProfileMetadata", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ProfileMetadata", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/sample.go
+++ b/examples/profile/internal/profile/sample.go
@@ -398,7 +398,7 @@ func (e *SampleEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) er
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SampleFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Sample", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Sample", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -621,7 +621,7 @@ func (d *SampleDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) err
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SampleFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Sample", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Sample", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/samplevalue.go
+++ b/examples/profile/internal/profile/samplevalue.go
@@ -342,7 +342,7 @@ func (e *SampleValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSe
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SampleValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SampleValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SampleValue", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -480,7 +480,7 @@ func (d *SampleValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SampleValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SampleValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SampleValue", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/samplevaluearray.go
+++ b/examples/profile/internal/profile/samplevaluearray.go
@@ -114,7 +114,7 @@ func copySampleValueArray(dst *SampleValueArray, src *SampleValueArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewSampleValueArray(dst *SampleValueArray, src *SampleValueArray, all
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *SampleValueArray) At(i int) *SampleValue {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *SampleValueArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*SampleValue, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(SampleValue)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *SampleValueArray) EnsureLen(newLen int) {
 func (e *SampleValueArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*SampleValue, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *SampleValueArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.SampleValue.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -364,7 +364,7 @@ func (e *SampleValueTypeEncoder) Init(state *WriterState, columns *pkg.WriteColu
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SampleValueTypeFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SampleValueType", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SampleValueType", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -516,7 +516,7 @@ func (d *SampleValueTypeDecoder) Init(state *ReaderState, columns *pkg.ReadColum
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SampleValueTypeFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SampleValueType", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SampleValueType", err)
 	}
 
 	d.column = columns.Column()

--- a/examples/profile/internal/profile/samplewriter.go
+++ b/examples/profile/internal/profile/samplewriter.go
@@ -53,7 +53,9 @@ func NewSampleWriter(dst pkg.ChunkWriter, opts pkg.WriterOptions) (*SampleWriter
 
 	writer.Record.Init()
 	writer.state.Init(&writer.opts)
-	writer.encoder.Init(&writer.state, &writer.writeBufs.Columns)
+	if err := writer.encoder.Init(&writer.state, &writer.writeBufs.Columns); err != nil {
+		return nil, err
+	}
 
 	if !writer.state.StructFieldCounts.AllFetched() {
 		return nil, errors.New("override schema iterator is not done, likely supplied schema override does not match the generated code")

--- a/go/otel/oteltef/anyvalue.go
+++ b/go/otel/oteltef/anyvalue.go
@@ -518,7 +518,7 @@ func (e *AnyValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.AnyValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "AnyValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "AnyValue", err)
 	}
 	e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount) + 1))
 
@@ -799,7 +799,7 @@ func (d *AnyValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.AnyValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "AnyValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "AnyValue", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/envelope.go
+++ b/go/otel/oteltef/envelope.go
@@ -242,7 +242,7 @@ func (e *EnvelopeEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.EnvelopeFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Envelope", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Envelope", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -354,7 +354,7 @@ func (d *EnvelopeDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.EnvelopeFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Envelope", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Envelope", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/event.go
+++ b/go/otel/oteltef/event.go
@@ -399,7 +399,7 @@ func (e *EventEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) err
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.EventFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Event", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Event", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -589,7 +589,7 @@ func (d *EventDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) erro
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.EventFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Event", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Event", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/eventarray.go
+++ b/go/otel/oteltef/eventarray.go
@@ -114,7 +114,7 @@ func copyEventArray(dst *EventArray, src *EventArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewEventArray(dst *EventArray, src *EventArray, allocators *Allocator
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *EventArray) At(i int) *Event {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *EventArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*Event, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(Event)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *EventArray) EnsureLen(newLen int) {
 func (e *EventArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*Event, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *EventArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.Event.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/go/otel/oteltef/exemplar.go
+++ b/go/otel/oteltef/exemplar.go
@@ -451,7 +451,7 @@ func (e *ExemplarEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ExemplarFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Exemplar", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Exemplar", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -678,7 +678,7 @@ func (d *ExemplarDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ExemplarFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Exemplar", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Exemplar", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/exemplararray.go
+++ b/go/otel/oteltef/exemplararray.go
@@ -114,7 +114,7 @@ func copyExemplarArray(dst *ExemplarArray, src *ExemplarArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewExemplarArray(dst *ExemplarArray, src *ExemplarArray, allocators *
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *ExemplarArray) At(i int) *Exemplar {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *ExemplarArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*Exemplar, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(Exemplar)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *ExemplarArray) EnsureLen(newLen int) {
 func (e *ExemplarArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*Exemplar, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *ExemplarArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.Exemplar.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/go/otel/oteltef/exemplarvalue.go
+++ b/go/otel/oteltef/exemplarvalue.go
@@ -324,7 +324,7 @@ func (e *ExemplarValueEncoder) Init(state *WriterState, columns *pkg.WriteColumn
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ExemplarValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExemplarValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ExemplarValue", err)
 	}
 	e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount) + 1))
 
@@ -444,7 +444,7 @@ func (d *ExemplarValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnS
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ExemplarValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExemplarValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ExemplarValue", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/exphistogrambuckets.go
+++ b/go/otel/oteltef/exphistogrambuckets.go
@@ -295,7 +295,7 @@ func (e *ExpHistogramBucketsEncoder) Init(state *WriterState, columns *pkg.Write
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ExpHistogramBucketsFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExpHistogramBuckets", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ExpHistogramBuckets", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -433,7 +433,7 @@ func (d *ExpHistogramBucketsDecoder) Init(state *ReaderState, columns *pkg.ReadC
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ExpHistogramBucketsFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExpHistogramBuckets", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ExpHistogramBuckets", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/exphistogramvalue.go
+++ b/go/otel/oteltef/exphistogramvalue.go
@@ -829,7 +829,7 @@ func (e *ExpHistogramValueEncoder) Init(state *WriterState, columns *pkg.WriteCo
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ExpHistogramValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExpHistogramValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ExpHistogramValue", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -1169,7 +1169,7 @@ func (d *ExpHistogramValueDecoder) Init(state *ReaderState, columns *pkg.ReadCol
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ExpHistogramValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "ExpHistogramValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "ExpHistogramValue", err)
 	}
 
 	d.optionalFieldCount = pkg.OptionalFieldCount(0b1110, d.fieldCount)

--- a/go/otel/oteltef/float64array.go
+++ b/go/otel/oteltef/float64array.go
@@ -69,7 +69,7 @@ func (e *Float64Array) byteSize() uint {
 // the array will be assigned from elements of the slice.
 func (e *Float64Array) CopyFromSlice(src []float64) {
 	if !slices.Equal(e.elems, src) {
-		e.elems = pkg.EnsureLen(e.elems, len(src))
+		e.EnsureLen(len(src))
 		copy(e.elems, src)
 		e.markModified()
 	}
@@ -115,7 +115,7 @@ func copyFloat64Array(dst *Float64Array, src *Float64Array) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -145,7 +145,7 @@ func copyToNewFloat64Array(dst *Float64Array, src *Float64Array, allocators *All
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	for i := 0; i < len(dst.elems); i++ {
 		dst.elems[i] = src.elems[i]
 	}
@@ -164,16 +164,7 @@ func (m *Float64Array) At(i int) float64 {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *Float64Array) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]float64, newLen-oldLen)...)
-		e.markModified()
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -181,6 +172,8 @@ func (e *Float64Array) EnsureLen(newLen int) {
 func (e *Float64Array) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+
 		// Grow the array
 		e.elems = append(e.elems, make([]float64, newLen-oldLen)...)
 		e.markModified()

--- a/go/otel/oteltef/histogramvalue.go
+++ b/go/otel/oteltef/histogramvalue.go
@@ -621,7 +621,7 @@ func (e *HistogramValueEncoder) Init(state *WriterState, columns *pkg.WriteColum
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.HistogramValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "HistogramValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "HistogramValue", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -846,7 +846,7 @@ func (d *HistogramValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumn
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.HistogramValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "HistogramValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "HistogramValue", err)
 	}
 
 	d.optionalFieldCount = pkg.OptionalFieldCount(0b1110, d.fieldCount)

--- a/go/otel/oteltef/link.go
+++ b/go/otel/oteltef/link.go
@@ -503,7 +503,7 @@ func (e *LinkEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) erro
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.LinkFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Link", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Link", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -745,7 +745,7 @@ func (d *LinkDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) error
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.LinkFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Link", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Link", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/linkarray.go
+++ b/go/otel/oteltef/linkarray.go
@@ -114,7 +114,7 @@ func copyLinkArray(dst *LinkArray, src *LinkArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewLinkArray(dst *LinkArray, src *LinkArray, allocators *Allocators) 
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *LinkArray) At(i int) *Link {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *LinkArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*Link, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(Link)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *LinkArray) EnsureLen(newLen int) {
 func (e *LinkArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*Link, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *LinkArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.Link.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/go/otel/oteltef/metric.go
+++ b/go/otel/oteltef/metric.go
@@ -676,7 +676,7 @@ func (e *MetricEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) er
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.MetricFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Metric", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Metric", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -1006,7 +1006,7 @@ func (d *MetricDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) err
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.MetricFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Metric", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Metric", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/metrics.go
+++ b/go/otel/oteltef/metrics.go
@@ -642,7 +642,7 @@ func (e *MetricsEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) e
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.MetricsFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Metrics", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Metrics", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -939,7 +939,7 @@ func (d *MetricsDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) er
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.MetricsFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Metrics", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Metrics", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/metricswriter.go
+++ b/go/otel/oteltef/metricswriter.go
@@ -53,7 +53,9 @@ func NewMetricsWriter(dst pkg.ChunkWriter, opts pkg.WriterOptions) (*MetricsWrit
 
 	writer.Record.Init()
 	writer.state.Init(&writer.opts)
-	writer.encoder.Init(&writer.state, &writer.writeBufs.Columns)
+	if err := writer.encoder.Init(&writer.state, &writer.writeBufs.Columns); err != nil {
+		return nil, err
+	}
 
 	if !writer.state.StructFieldCounts.AllFetched() {
 		return nil, errors.New("override schema iterator is not done, likely supplied schema override does not match the generated code")

--- a/go/otel/oteltef/point.go
+++ b/go/otel/oteltef/point.go
@@ -399,7 +399,7 @@ func (e *PointEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) err
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.PointFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Point", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Point", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -600,7 +600,7 @@ func (d *PointDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) erro
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.PointFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Point", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Point", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/pointvalue.go
+++ b/go/otel/oteltef/pointvalue.go
@@ -445,7 +445,7 @@ func (e *PointValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.PointValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "PointValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "PointValue", err)
 	}
 	e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount) + 1))
 
@@ -685,7 +685,7 @@ func (d *PointValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.PointValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "PointValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "PointValue", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/quantilevalue.go
+++ b/go/otel/oteltef/quantilevalue.go
@@ -295,7 +295,7 @@ func (e *QuantileValueEncoder) Init(state *WriterState, columns *pkg.WriteColumn
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.QuantileValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "QuantileValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "QuantileValue", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -422,7 +422,7 @@ func (d *QuantileValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnS
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.QuantileValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "QuantileValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "QuantileValue", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/quantilevaluearray.go
+++ b/go/otel/oteltef/quantilevaluearray.go
@@ -114,7 +114,7 @@ func copyQuantileValueArray(dst *QuantileValueArray, src *QuantileValueArray) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -156,7 +156,7 @@ func copyToNewQuantileValueArray(dst *QuantileValueArray, src *QuantileValueArra
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	// Need to allocate new elements for the part of the array that has grown.
 	for j := 0; j < len(dst.elems); j++ {
 		if src.elems[j].canBeShared() {
@@ -184,21 +184,7 @@ func (m *QuantileValueArray) At(i int) *QuantileValue {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *QuantileValueArray) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]*QuantileValue, newLen-oldLen)...)
-		e.markModified()
-		// Initialize newlly added elements.
-		for ; oldLen < newLen; oldLen++ {
-			e.elems[oldLen] = new(QuantileValue)
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -206,6 +192,9 @@ func (e *QuantileValueArray) EnsureLen(newLen int) {
 func (e *QuantileValueArray) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+		beforePtr := unsafe.SliceData(e.elems)
+
 		// Grow the array
 		e.elems = append(e.elems, make([]*QuantileValue, newLen-oldLen)...)
 		e.markModified()
@@ -213,6 +202,13 @@ func (e *QuantileValueArray) ensureLen(newLen int, allocators *Allocators) {
 		for ; oldLen < newLen; oldLen++ {
 			e.elems[oldLen] = allocators.QuantileValue.Alloc()
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
+		}
+		if beforePtr != unsafe.SliceData(e.elems) {
+			// Underlying array was reallocated, we need to fix parent pointers
+			// in all elements.
+			for i := 0; i < newLen; i++ {
+				e.elems[i].fixParent(e.parentModifiedFields)
+			}
 		}
 	} else if oldLen > newLen {
 		// Shrink it

--- a/go/otel/oteltef/resource.go
+++ b/go/otel/oteltef/resource.go
@@ -416,7 +416,7 @@ func (e *ResourceEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) 
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ResourceFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Resource", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Resource", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -605,7 +605,7 @@ func (d *ResourceDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) e
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ResourceFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Resource", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Resource", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/scope.go
+++ b/go/otel/oteltef/scope.go
@@ -520,7 +520,7 @@ func (e *ScopeEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) err
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.ScopeFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Scope", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Scope", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -761,7 +761,7 @@ func (d *ScopeDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) erro
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.ScopeFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Scope", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Scope", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/span.go
+++ b/go/otel/oteltef/span.go
@@ -919,7 +919,7 @@ func (e *SpanEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) erro
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SpanFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Span", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Span", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -1402,7 +1402,7 @@ func (d *SpanDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) error
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SpanFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Span", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Span", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/spans.go
+++ b/go/otel/oteltef/spans.go
@@ -492,7 +492,7 @@ func (e *SpansEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) err
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SpansFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Spans", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Spans", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -715,7 +715,7 @@ func (d *SpansDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) erro
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SpansFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "Spans", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "Spans", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/spanstatus.go
+++ b/go/otel/oteltef/spanstatus.go
@@ -295,7 +295,7 @@ func (e *SpanStatusEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SpanStatusFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SpanStatus", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SpanStatus", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -422,7 +422,7 @@ func (d *SpanStatusDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SpanStatusFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SpanStatus", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SpanStatus", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/spanswriter.go
+++ b/go/otel/oteltef/spanswriter.go
@@ -53,7 +53,9 @@ func NewSpansWriter(dst pkg.ChunkWriter, opts pkg.WriterOptions) (*SpansWriter, 
 
 	writer.Record.Init()
 	writer.state.Init(&writer.opts)
-	writer.encoder.Init(&writer.state, &writer.writeBufs.Columns)
+	if err := writer.encoder.Init(&writer.state, &writer.writeBufs.Columns); err != nil {
+		return nil, err
+	}
 
 	if !writer.state.StructFieldCounts.AllFetched() {
 		return nil, errors.New("override schema iterator is not done, likely supplied schema override does not match the generated code")

--- a/go/otel/oteltef/summaryvalue.go
+++ b/go/otel/oteltef/summaryvalue.go
@@ -347,7 +347,7 @@ func (e *SummaryValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnS
 	var err error
 	e.fieldCount, err = state.StructFieldCounts.SummaryValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SummaryValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SummaryValue", err)
 	}
 	// Set that many 1 bits in the keepFieldMask. All fields with higher number
 	// will be skipped when encoding.
@@ -511,7 +511,7 @@ func (d *SummaryValueDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSe
 	var err error
 	d.fieldCount, err = state.StructFieldCounts.SummaryValueFieldCount()
 	if err != nil {
-		return fmt.Errorf("cannot find struct %s in override schema: %v", "SummaryValue", err)
+		return fmt.Errorf("cannot find struct %s in override schema: %w", "SummaryValue", err)
 	}
 
 	d.column = columns.Column()

--- a/go/otel/oteltef/uint64array.go
+++ b/go/otel/oteltef/uint64array.go
@@ -69,7 +69,7 @@ func (e *Uint64Array) byteSize() uint {
 // the array will be assigned from elements of the slice.
 func (e *Uint64Array) CopyFromSlice(src []uint64) {
 	if !slices.Equal(e.elems, src) {
-		e.elems = pkg.EnsureLen(e.elems, len(src))
+		e.EnsureLen(len(src))
 		copy(e.elems, src)
 		e.markModified()
 	}
@@ -115,7 +115,7 @@ func copyUint64Array(dst *Uint64Array, src *Uint64Array) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+		dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -145,7 +145,7 @@ func copyToNewUint64Array(dst *Uint64Array, src *Uint64Array, allocators *Alloca
 		return
 	}
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 	for i := 0; i < len(dst.elems); i++ {
 		dst.elems[i] = src.elems[i]
 	}
@@ -164,16 +164,7 @@ func (m *Uint64Array) At(i int) uint64 {
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *Uint64Array) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]uint64, newLen-oldLen)...)
-		e.markModified()
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+	e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -181,6 +172,8 @@ func (e *Uint64Array) EnsureLen(newLen int) {
 func (e *Uint64Array) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+		// Check if the underlying array is reallocated.
+
 		// Grow the array
 		e.elems = append(e.elems, make([]uint64, newLen-oldLen)...)
 		e.markModified()

--- a/go/pkg/schema/wireschema.go
+++ b/go/pkg/schema/wireschema.go
@@ -41,14 +41,16 @@ func NewWireSchema(schema *Schema, rootStructName string) WireSchema {
 	rootStruc := schema.Structs[rootStructName]
 	stack := recurseStack{asMap: map[string]bool{}}
 
-	rootType := &FieldType{
-		Struct:    rootStruc.Name,
-		StructDef: rootStruc,
-		DictName:  rootStruc.DictName,
+	tree := structCountTree{
+		structName: rootStruc.Name,
+		fieldCount: uint(len(rootStruc.Fields)),
 	}
-	tree := structCountTree{}
+	stack.asStack = append(stack.asStack, rootStruc.Name)
+	stack.asMap[rootStruc.Name] = true
 
-	schemaToStructCountTree(rootType, &tree, &stack)
+	for _, field := range rootStruc.Fields {
+		schemaToStructCountTree(&field.FieldType, &tree.structFields, &stack)
+	}
 
 	w := WireSchema{}
 

--- a/stefc/generator/testdata/array_multimap_struct.stef
+++ b/stefc/generator/testdata/array_multimap_struct.stef
@@ -1,0 +1,14 @@
+package com.example.gentest.array_multimap_struct
+
+multimap MultiMap {
+  key int64
+  value InnerStruct
+}
+
+struct RootStruct root {
+  Field2 []MultiMap
+}
+
+struct InnerStruct {
+    X int64
+}

--- a/stefc/templates/go/array.go.tmpl
+++ b/stefc/templates/go/array.go.tmpl
@@ -85,7 +85,7 @@ func (e* {{.ArrayName}}) CopyFromSlice(src []{{.ElemType.Exported}}) {
         }
     }
     if differ {
-        e.elems = pkg.EnsureLen(e.elems, len(src))
+        e.EnsureLen(len(src))
         for i:=0; i<len(src); i++ {
             e.elems[i] = {{.ElemType.ToStorage "src[i]" }}
         }
@@ -93,7 +93,7 @@ func (e* {{.ArrayName}}) CopyFromSlice(src []{{.ElemType.Exported}}) {
     }
 {{else -}}
 	if !slices.Equal(e.elems, src) {
-		e.elems = pkg.EnsureLen(e.elems, len(src))
+		e.EnsureLen(len(src))
 		copy(e.elems, src)
 		e.markModified()
 	}
@@ -159,7 +159,7 @@ func copy{{.ArrayName}}(dst* {{.ArrayName}}, src *{{.ArrayName}}) {
 
 	minLen := min(len(dst.elems), len(src.elems))
 	if len(dst.elems) != len(src.elems) {
-		dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	    dst.EnsureLen(len(src.elems))
 		isModified = true
 	}
 
@@ -218,7 +218,7 @@ func copyToNew{{.ArrayName}}(dst* {{.ArrayName}}, src *{{.ArrayName}}, allocator
         return
     }
 
-	dst.elems = pkg.EnsureLen(dst.elems, len(src.elems))
+	dst.ensureLen(len(src.elems), allocators)
 
 	{{- if .ElemType.MustClone}}
     // Need to allocate new elements for the part of the array that has grown.
@@ -253,23 +253,7 @@ func (m *{{.ArrayName}}) At(i int) {{if .IsStructType}}*{{end}}{{.ElemType.Expor
 // EnsureLen ensures the length of the array is equal to newLen.
 // It will grow or shrink the array if needed.
 func (e *{{.ArrayName}}) EnsureLen(newLen int) {
-	oldLen := len(e.elems)
-	if newLen > oldLen {
-		// Grow the array
-		e.elems = append(e.elems, make([]{{if .IsStructType}}*{{end}}{{.ElemType.Storage}}, newLen-oldLen)...)
-		e.markModified()
-		{{- if .IsStructType}}
-		// Initialize newlly added elements.
-		for ; oldLen<newLen; oldLen++ {
-			e.elems[oldLen] = new({{.ElemType.Storage}})
-			e.elems[oldLen].init(e.parentModifiedFields, e.parentModifiedBit)
-		}
-		{{- end}}
-	} else if oldLen > newLen {
-		// Shrink it
-		e.elems = e.elems[:newLen]
-		e.markModified()
-	}
+    e.ensureLen(newLen, &Allocators{})
 }
 
 // EnsureLen ensures the length of the array is equal to newLen.
@@ -277,6 +261,11 @@ func (e *{{.ArrayName}}) EnsureLen(newLen int) {
 func (e *{{.ArrayName}}) ensureLen(newLen int, allocators *Allocators) {
 	oldLen := len(e.elems)
 	if newLen > oldLen {
+        // Check if the underlying array is reallocated.
+        {{- if not .ElemType.IsPrimitive}}
+        beforePtr := unsafe.SliceData(e.elems)
+		{{- end}}
+
 		// Grow the array
 		e.elems = append(e.elems, make([]{{if .IsStructType}}*{{end}}{{.ElemType.Storage}}, newLen-oldLen)...)
 		e.markModified()
@@ -287,6 +276,16 @@ func (e *{{.ArrayName}}) ensureLen(newLen int, allocators *Allocators) {
 			e.elems[oldLen].initAlloc(e.parentModifiedFields, e.parentModifiedBit, allocators)
 		}
 		{{- end}}
+
+        {{- if not .ElemType.IsPrimitive}}
+		if beforePtr != unsafe.SliceData(e.elems) {
+		    // Underlying array was reallocated, we need to fix parent pointers
+		    // in all elements.
+		    for i:=0; i < newLen; i++ {
+		        e.elems[i].fixParent(e.parentModifiedFields)
+		    }
+		}
+        {{- end}}
 	} else if oldLen > newLen {
 		// Shrink it
 		e.elems = e.elems[:newLen]

--- a/stefc/templates/go/oneof.go.tmpl
+++ b/stefc/templates/go/oneof.go.tmpl
@@ -442,7 +442,7 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
     var err error
     e.fieldCount, err = state.StructFieldCounts.{{.StructName}}FieldCount()
     if err != nil {
-        return fmt.Errorf("cannot find struct %s in override schema: %v", {{printf "%q" .StructName}}, err)
+        return fmt.Errorf("cannot find struct %s in override schema: %w", {{printf "%q" .StructName}}, err)
     }
     e.typeBitCount = uint(bits.Len64(uint64(e.fieldCount)+1))
 
@@ -570,7 +570,7 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     var err error
     d.fieldCount, err = state.StructFieldCounts.{{.StructName}}FieldCount()
     if err != nil {
-        return fmt.Errorf("cannot find struct %s in override schema: %v", {{printf "%q" .StructName}}, err)
+        return fmt.Errorf("cannot find struct %s in override schema: %w", {{printf "%q" .StructName}}, err)
     }
 
     d.column = columns.Column()

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -658,7 +658,7 @@ func (e *{{ .StructName }}Encoder) Init(state* WriterState, columns *pkg.WriteCo
     var err error
     e.fieldCount, err = state.StructFieldCounts.{{.StructName}}FieldCount()
     if err != nil {
-        return fmt.Errorf("cannot find struct %s in override schema: %v", {{printf "%q" .StructName}}, err)
+        return fmt.Errorf("cannot find struct %s in override schema: %w", {{printf "%q" .StructName}}, err)
     }
     // Set that many 1 bits in the keepFieldMask. All fields with higher number
     // will be skipped when encoding.
@@ -837,7 +837,7 @@ func (d *{{ .StructName }}Decoder) Init(state* ReaderState, columns *pkg.ReadCol
     var err error
     d.fieldCount, err = state.StructFieldCounts.{{.StructName}}FieldCount()
     if err != nil {
-        return fmt.Errorf("cannot find struct %s in override schema: %v", {{printf "%q" .StructName}}, err)
+        return fmt.Errorf("cannot find struct %s in override schema: %w", {{printf "%q" .StructName}}, err)
     }
 
     {{if .OptionalFieldCount}}

--- a/stefc/templates/go/writer.go.tmpl
+++ b/stefc/templates/go/writer.go.tmpl
@@ -52,7 +52,9 @@ func New{{.StructName}}Writer(dst pkg.ChunkWriter, opts pkg.WriterOptions) (*{{.
 
 	writer.Record.Init()
 	writer.state.Init(&writer.opts)
-	writer.encoder.Init(&writer.state, &writer.writeBufs.Columns)
+	if err := writer.encoder.Init(&writer.state, &writer.writeBufs.Columns); err != nil {
+		return nil, err
+	}
 
 	if !writer.state.StructFieldCounts.AllFetched() {
 		return nil, errors.New("override schema iterator is not done, likely supplied schema override does not match the generated code")

--- a/stefc/templates/go/writer_test.go.tmpl
+++ b/stefc/templates/go/writer_test.go.tmpl
@@ -125,4 +125,3 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 		)
 	}
 }
-


### PR DESCRIPTION
A multimap contained in an array was not correctly fixing parent pointers
in its containing elements when array was resized.

This fixes the bug by tracking array resizes in the same way we previously
tracked multimap resizes.

Fixes https://github.com/splunk/stef/issues/249