### PR TITLE
Make sure optional in struct in multimap works

### DIFF
--- a/go/pkg/schema/recursestack.go
+++ b/go/pkg/schema/recursestack.go
@@ -5,7 +5,14 @@ type recursable interface {
 }
 
 type recurseStack struct {
-	fields  []recursable
+	// Names of types in the path of the type tree currently being searched
+	// from top to bottom of the tree. Root struct is the first element.
 	asStack []string
-	asMap   map[string]bool
+
+	// Same types, but as a map for fast search by name.
+	asMap map[string]bool
+
+	// Fields of types through which the types in asStack are linked.
+	// fields[i] is a field in asStack[i] type.
+	fields []recursable
 }

--- a/stefc/generator/testdata/optional_in_struct_in_multimap.stef
+++ b/stefc/generator/testdata/optional_in_struct_in_multimap.stef
@@ -1,0 +1,25 @@
+package com.example.gentest.optional_in_struct_in_multimap
+
+multimap MultiMap2 {
+  key string
+  value Struct5
+}
+
+multimap MultiMap4 {
+  key Struct3
+  value bool
+}
+
+struct Struct3 {
+  Field1 Struct7
+  Field3 bool
+}
+
+struct Struct5 root {
+  Field1 Struct3 optional
+  Field2 MultiMap2
+}
+
+struct Struct7 {
+  Field1 MultiMap4
+}

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -362,8 +362,6 @@ func copy{{.StructName}}(dst *{{.StructName}}, src *{{.StructName}}) {
                 {{- if .Type.Flags.TakePtr}}&{{end}}src.{{.name}})
         }
     {{- if .Optional}}
-    } else {
-        dst.{{.name}} = nil
     }
     {{end}}
     {{- else}}


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/251

This was incorrectly resetting an optional struct pointer to nil, resulting in loss of state.