### PR TITLE
Remember seeds of failing test cases and rerun

### DIFF
--- a/examples/ints/internal/ints/recordwriter_test.go
+++ b/examples/ints/internal/ints/recordwriter_test.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +39,9 @@ func genRecordRecords(random *rand.Rand, schem *schema.Schema) (records []Record
 	return records
 }
 
-func TestRecordWriteRead(t *testing.T) {
+func testRecordWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
+	retVal = true
+
 	opts := []pkg.WriterOptions{
 		{},
 		{Compression: pkg.CompressionZstd},
@@ -61,17 +66,14 @@ func TestRecordWriteRead(t *testing.T) {
 		},
 	}
 
-	// Choose a seed (non-pseudo) randomly. We will print the seed
-	// on failure for easy reproduction.
-	seed1 := uint64(time.Now().UnixNano())
-	random := rand.New(rand.NewPCG(seed1, 0))
+	random := rand.New(rand.NewPCG(seed, 0))
 
 	// Load the schema from the allSchemaContent variable.
 	schem, err := idl.Parse([]byte(allSchemaContent), "")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	schem, err = schem.PrunedForRoot("Record")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	if random.IntN(2) == 0 {
 		// Randomly shrink the schema in approximately half of the test runs.
@@ -86,7 +88,8 @@ func TestRecordWriteRead(t *testing.T) {
 				succeeded := false
 				defer func() {
 					if !succeeded {
-						fmt.Printf("Test failed with seed %v\n", seed1)
+						retVal = false
+						fmt.Printf("Test failed with seed %v\n", seed)
 					}
 				}()
 
@@ -95,7 +98,7 @@ func TestRecordWriteRead(t *testing.T) {
 
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewRecordWriter(buf, opt)
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Generate records pseudo-randomly
 				records := genRecordRecords(random, schem)
@@ -103,26 +106,59 @@ func TestRecordWriteRead(t *testing.T) {
 				for i := 0; i < len(records); i++ {
 					writer.Record.CopyFrom(&records[i])
 					err = writer.Write()
-					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
 				}
 				err = writer.Flush()
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Read the records and compare to written.
 				reader, err := NewRecordReader(bytes.NewBuffer(buf.Bytes()))
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
-					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
-					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
-				require.ErrorIs(t, err, io.EOF, seed1)
+				require.ErrorIs(t, err, io.EOF, seed)
 
 				succeeded = true
 			},
 		)
 	}
+	return retVal
+}
+
+func TestRecordWriteRead(t *testing.T) {
+	seedFileName := "../../../seeds/ints_Record_seeds.txt"
+	seedsBytes, err := os.ReadFile(seedFileName)
+	var seeds []string
+	if err == nil {
+		seeds = strings.Split(strings.TrimSpace(string(seedsBytes)), "\n")
+	}
+
+	for _, seedStr := range seeds {
+		seed, err := strconv.ParseUint(seedStr, 10, 64)
+		fmt.Printf("Testing with seed from file: %v\n", seed)
+		require.NoError(t, err, "parsing seed from file "+seedFileName)
+		testRecordWriteReadSeed(t, seed)
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed := uint64(time.Now().UnixNano())
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			fmt.Printf("Test failed with seed %v, adding to seed file\n", seed)
+			err := os.WriteFile(seedFileName,
+				[]byte(string(seedsBytes)+fmt.Sprintf("%v\n", seed)), 0644)
+			require.NoError(t, err)
+		}
+	}()
+
+	succeeded = testRecordWriteReadSeed(t, seed)
 }

--- a/examples/jsonl/internal/jsonstef/recordwriter_test.go
+++ b/examples/jsonl/internal/jsonstef/recordwriter_test.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +39,9 @@ func genRecordRecords(random *rand.Rand, schem *schema.Schema) (records []Record
 	return records
 }
 
-func TestRecordWriteRead(t *testing.T) {
+func testRecordWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
+	retVal = true
+
 	opts := []pkg.WriterOptions{
 		{},
 		{Compression: pkg.CompressionZstd},
@@ -61,17 +66,14 @@ func TestRecordWriteRead(t *testing.T) {
 		},
 	}
 
-	// Choose a seed (non-pseudo) randomly. We will print the seed
-	// on failure for easy reproduction.
-	seed1 := uint64(time.Now().UnixNano())
-	random := rand.New(rand.NewPCG(seed1, 0))
+	random := rand.New(rand.NewPCG(seed, 0))
 
 	// Load the schema from the allSchemaContent variable.
 	schem, err := idl.Parse([]byte(allSchemaContent), "")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	schem, err = schem.PrunedForRoot("Record")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	if random.IntN(2) == 0 {
 		// Randomly shrink the schema in approximately half of the test runs.
@@ -86,7 +88,8 @@ func TestRecordWriteRead(t *testing.T) {
 				succeeded := false
 				defer func() {
 					if !succeeded {
-						fmt.Printf("Test failed with seed %v\n", seed1)
+						retVal = false
+						fmt.Printf("Test failed with seed %v\n", seed)
 					}
 				}()
 
@@ -95,7 +98,7 @@ func TestRecordWriteRead(t *testing.T) {
 
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewRecordWriter(buf, opt)
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Generate records pseudo-randomly
 				records := genRecordRecords(random, schem)
@@ -103,26 +106,59 @@ func TestRecordWriteRead(t *testing.T) {
 				for i := 0; i < len(records); i++ {
 					writer.Record.CopyFrom(&records[i])
 					err = writer.Write()
-					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
 				}
 				err = writer.Flush()
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Read the records and compare to written.
 				reader, err := NewRecordReader(bytes.NewBuffer(buf.Bytes()))
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
-					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
-					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
-				require.ErrorIs(t, err, io.EOF, seed1)
+				require.ErrorIs(t, err, io.EOF, seed)
 
 				succeeded = true
 			},
 		)
 	}
+	return retVal
+}
+
+func TestRecordWriteRead(t *testing.T) {
+	seedFileName := "../../../seeds/jsonstef_Record_seeds.txt"
+	seedsBytes, err := os.ReadFile(seedFileName)
+	var seeds []string
+	if err == nil {
+		seeds = strings.Split(strings.TrimSpace(string(seedsBytes)), "\n")
+	}
+
+	for _, seedStr := range seeds {
+		seed, err := strconv.ParseUint(seedStr, 10, 64)
+		fmt.Printf("Testing with seed from file: %v\n", seed)
+		require.NoError(t, err, "parsing seed from file "+seedFileName)
+		testRecordWriteReadSeed(t, seed)
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed := uint64(time.Now().UnixNano())
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			fmt.Printf("Test failed with seed %v, adding to seed file\n", seed)
+			err := os.WriteFile(seedFileName,
+				[]byte(string(seedsBytes)+fmt.Sprintf("%v\n", seed)), 0644)
+			require.NoError(t, err)
+		}
+	}()
+
+	succeeded = testRecordWriteReadSeed(t, seed)
 }

--- a/examples/profile/internal/profile/samplewriter_test.go
+++ b/examples/profile/internal/profile/samplewriter_test.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +39,9 @@ func genSampleRecords(random *rand.Rand, schem *schema.Schema) (records []Sample
 	return records
 }
 
-func TestSampleWriteRead(t *testing.T) {
+func testSampleWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
+	retVal = true
+
 	opts := []pkg.WriterOptions{
 		{},
 		{Compression: pkg.CompressionZstd},
@@ -61,17 +66,14 @@ func TestSampleWriteRead(t *testing.T) {
 		},
 	}
 
-	// Choose a seed (non-pseudo) randomly. We will print the seed
-	// on failure for easy reproduction.
-	seed1 := uint64(time.Now().UnixNano())
-	random := rand.New(rand.NewPCG(seed1, 0))
+	random := rand.New(rand.NewPCG(seed, 0))
 
 	// Load the schema from the allSchemaContent variable.
 	schem, err := idl.Parse([]byte(allSchemaContent), "")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	schem, err = schem.PrunedForRoot("Sample")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	if random.IntN(2) == 0 {
 		// Randomly shrink the schema in approximately half of the test runs.
@@ -86,7 +88,8 @@ func TestSampleWriteRead(t *testing.T) {
 				succeeded := false
 				defer func() {
 					if !succeeded {
-						fmt.Printf("Test failed with seed %v\n", seed1)
+						retVal = false
+						fmt.Printf("Test failed with seed %v\n", seed)
 					}
 				}()
 
@@ -95,7 +98,7 @@ func TestSampleWriteRead(t *testing.T) {
 
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewSampleWriter(buf, opt)
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Generate records pseudo-randomly
 				records := genSampleRecords(random, schem)
@@ -103,26 +106,59 @@ func TestSampleWriteRead(t *testing.T) {
 				for i := 0; i < len(records); i++ {
 					writer.Record.CopyFrom(&records[i])
 					err = writer.Write()
-					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
 				}
 				err = writer.Flush()
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Read the records and compare to written.
 				reader, err := NewSampleReader(bytes.NewBuffer(buf.Bytes()))
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
-					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
-					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
-				require.ErrorIs(t, err, io.EOF, seed1)
+				require.ErrorIs(t, err, io.EOF, seed)
 
 				succeeded = true
 			},
 		)
 	}
+	return retVal
+}
+
+func TestSampleWriteRead(t *testing.T) {
+	seedFileName := "../../../seeds/profile_Sample_seeds.txt"
+	seedsBytes, err := os.ReadFile(seedFileName)
+	var seeds []string
+	if err == nil {
+		seeds = strings.Split(strings.TrimSpace(string(seedsBytes)), "\n")
+	}
+
+	for _, seedStr := range seeds {
+		seed, err := strconv.ParseUint(seedStr, 10, 64)
+		fmt.Printf("Testing with seed from file: %v\n", seed)
+		require.NoError(t, err, "parsing seed from file "+seedFileName)
+		testSampleWriteReadSeed(t, seed)
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed := uint64(time.Now().UnixNano())
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			fmt.Printf("Test failed with seed %v, adding to seed file\n", seed)
+			err := os.WriteFile(seedFileName,
+				[]byte(string(seedsBytes)+fmt.Sprintf("%v\n", seed)), 0644)
+			require.NoError(t, err)
+		}
+	}()
+
+	succeeded = testSampleWriteReadSeed(t, seed)
 }

--- a/go/otel/oteltef/spanswriter_test.go
+++ b/go/otel/oteltef/spanswriter_test.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +39,9 @@ func genSpansRecords(random *rand.Rand, schem *schema.Schema) (records []Spans) 
 	return records
 }
 
-func TestSpansWriteRead(t *testing.T) {
+func testSpansWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
+	retVal = true
+
 	opts := []pkg.WriterOptions{
 		{},
 		{Compression: pkg.CompressionZstd},
@@ -61,17 +66,14 @@ func TestSpansWriteRead(t *testing.T) {
 		},
 	}
 
-	// Choose a seed (non-pseudo) randomly. We will print the seed
-	// on failure for easy reproduction.
-	seed1 := uint64(time.Now().UnixNano())
-	random := rand.New(rand.NewPCG(seed1, 0))
+	random := rand.New(rand.NewPCG(seed, 0))
 
 	// Load the schema from the allSchemaContent variable.
 	schem, err := idl.Parse([]byte(allSchemaContent), "")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	schem, err = schem.PrunedForRoot("Spans")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	if random.IntN(2) == 0 {
 		// Randomly shrink the schema in approximately half of the test runs.
@@ -86,7 +88,8 @@ func TestSpansWriteRead(t *testing.T) {
 				succeeded := false
 				defer func() {
 					if !succeeded {
-						fmt.Printf("Test failed with seed %v\n", seed1)
+						retVal = false
+						fmt.Printf("Test failed with seed %v\n", seed)
 					}
 				}()
 
@@ -95,7 +98,7 @@ func TestSpansWriteRead(t *testing.T) {
 
 				buf := &pkg.MemChunkWriter{}
 				writer, err := NewSpansWriter(buf, opt)
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Generate records pseudo-randomly
 				records := genSpansRecords(random, schem)
@@ -103,26 +106,59 @@ func TestSpansWriteRead(t *testing.T) {
 				for i := 0; i < len(records); i++ {
 					writer.Record.CopyFrom(&records[i])
 					err = writer.Write()
-					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
 				}
 				err = writer.Flush()
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Read the records and compare to written.
 				reader, err := NewSpansReader(bytes.NewBuffer(buf.Bytes()))
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
-					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
-					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
-				require.ErrorIs(t, err, io.EOF, seed1)
+				require.ErrorIs(t, err, io.EOF, seed)
 
 				succeeded = true
 			},
 		)
 	}
+	return retVal
+}
+
+func TestSpansWriteRead(t *testing.T) {
+	seedFileName := "../../../seeds/oteltef_Spans_seeds.txt"
+	seedsBytes, err := os.ReadFile(seedFileName)
+	var seeds []string
+	if err == nil {
+		seeds = strings.Split(strings.TrimSpace(string(seedsBytes)), "\n")
+	}
+
+	for _, seedStr := range seeds {
+		seed, err := strconv.ParseUint(seedStr, 10, 64)
+		fmt.Printf("Testing with seed from file: %v\n", seed)
+		require.NoError(t, err, "parsing seed from file "+seedFileName)
+		testSpansWriteReadSeed(t, seed)
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed := uint64(time.Now().UnixNano())
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			fmt.Printf("Test failed with seed %v, adding to seed file\n", seed)
+			err := os.WriteFile(seedFileName,
+				[]byte(string(seedsBytes)+fmt.Sprintf("%v\n", seed)), 0644)
+			require.NoError(t, err)
+		}
+	}()
+
+	succeeded = testSpansWriteReadSeed(t, seed)
 }

--- a/stefc/generator/testdata/seeds/README.md
+++ b/stefc/generator/testdata/seeds/README.md
@@ -1,0 +1,3 @@
+This directory contains files with list of seeds for each test cases that were previously found to generate failures.
+The seeds will be re-tested on corresponding test run to ensure there are no regressions. If a new random seed is
+found to cause a failure it will be automatically appended to the appropriate file.

--- a/stefc/templates/go/writer_test.go.tmpl
+++ b/stefc/templates/go/writer_test.go.tmpl
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,7 +38,9 @@ func gen{{.StructName}}Records(random *rand.Rand, schem *schema.Schema) (records
 	return records
 }
 
-func Test{{.StructName}}WriteRead(t *testing.T) {
+func test{{.StructName}}WriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
+    retVal = true
+
 	opts := []pkg.WriterOptions{
 		{},
 		{ Compression: pkg.CompressionZstd },
@@ -60,17 +65,14 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 		},
 	}
 
-	// Choose a seed (non-pseudo) randomly. We will print the seed
-	// on failure for easy reproduction.
-	seed1 := uint64(time.Now().UnixNano())
-	random := rand.New(rand.NewPCG(seed1, 0))
+	random := rand.New(rand.NewPCG(seed, 0))
 
 	// Load the schema from the allSchemaContent variable.
 	schem, err := idl.Parse([]byte(allSchemaContent), "")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	schem, err = schem.PrunedForRoot("{{.StructName}}")
-	require.NoError(t, err, "seed %v", seed1)
+	require.NoError(t, err, "seed %v", seed)
 
 	if random.IntN(2) == 0 {
 		// Randomly shrink the schema in approximately half of the test runs.
@@ -85,7 +87,8 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 				succeeded := false
 				defer func() {
 					if !succeeded {
-						fmt.Printf("Test failed with seed %v\n", seed1)
+					    retVal = false
+						fmt.Printf("Test failed with seed %v\n", seed)
 					}
 				}()
 
@@ -94,7 +97,7 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 
 				buf := &pkg.MemChunkWriter{}
 				writer, err := New{{.StructName}}Writer(buf, opt)
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Generate records pseudo-randomly
 				records := gen{{.StructName}}Records(random, schem)
@@ -102,26 +105,59 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
 				for i := 0; i < len(records); i++ {
 					writer.Record.CopyFrom(&records[i])
 					err = writer.Write()
-					require.NoError(t, err, "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
 				}
 				err = writer.Flush()
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				// Read the records and compare to written.
 				reader, err := New{{.StructName}}Reader(bytes.NewBuffer(buf.Bytes()))
-				require.NoError(t, err, "seed %v", seed1)
+				require.NoError(t, err, "seed %v", seed)
 
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
-					require.NoError(t, err, "record %d seed %v", i, seed1)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed1)
-					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed1)
+					require.NoError(t, err, "record %d seed %v", i, seed)
+					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
+					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
-				require.ErrorIs(t, err, io.EOF, seed1)
+				require.ErrorIs(t, err, io.EOF, seed)
 
 				succeeded = true
 			},
 		)
 	}
+	return retVal
+}
+
+func Test{{.StructName}}WriteRead(t *testing.T) {
+	seedFileName := "../../../seeds/{{.PackageName}}_{{.StructName}}_seeds.txt"
+	seedsBytes, err := os.ReadFile(seedFileName)
+	var seeds []string
+	if err == nil {
+		seeds = strings.Split(strings.TrimSpace(string(seedsBytes)), "\n")
+	}
+
+	for _, seedStr := range seeds {
+		seed, err := strconv.ParseUint(seedStr, 10, 64)
+		fmt.Printf("Testing with seed from file: %v\n", seed)
+		require.NoError(t, err, "parsing seed from file "+ seedFileName)
+		test{{.StructName}}WriteReadSeed(t, seed)
+	}
+
+	// Choose a seed (non-pseudo) randomly. We will print the seed
+	// on failure for easy reproduction.
+	seed := uint64(time.Now().UnixNano())
+
+	succeeded := false
+    defer func() {
+        if !succeeded {
+			fmt.Printf("Test failed with seed %v, adding to seed file\n", seed)
+			err := os.WriteFile(seedFileName,
+				[]byte(string(seedsBytes)+fmt.Sprintf("%v\n", seed)), 0644)
+			require.NoError(t, err)
+        }
+    }()
+
+    succeeded = test{{.StructName}}WriteReadSeed(t, seed)
 }


### PR DESCRIPTION
The "seeds" directory contains files with list of seeds for each test cases that were previously found to generate failures.

The seeds will be re-tested on corresponding test run to ensure there are no regressions.

If a new random seed is found to cause a failure it will be automatically appended to the appropriate file.

We will add seeds to the files as we find future bugs and fix them.