### PR TITLE
Fix Java BitsWriter.writeBitsSlow bug

### DIFF
--- a/java/src/main/java/net/stef/BitsWriter.java
+++ b/java/src/main/java/net/stef/BitsWriter.java
@@ -58,7 +58,9 @@ public class BitsWriter {
     private void writeBitsSlow(long val, int nbits) {
         // Complete bitsBuf to 64 bits.
         int bitsBufFree = 64 - bitsBufUsed;
-        bitsBuf |= val >>> (nbits - bitsBufFree);
+        if (bitsBufFree>0) {
+            bitsBuf |= val >>> (nbits - bitsBufFree);
+        }
 
         // And append 64 bits to stream.
         writeUint64(bitsBuf);

--- a/java/src/test/java/net/stef/BitsWriterTest.java
+++ b/java/src/test/java/net/stef/BitsWriterTest.java
@@ -84,12 +84,12 @@ class BitsWriterTest {
         final long seed1 = System.nanoTime();
         Random random = new Random(seed1);
 
-        final long count = random.nextLong(0, 1000);
+        final long count = random.nextLong(0, 1000000);
 
         for (long i = 1; i <= count; i++) {
             int shift = random.nextInt(64);
-            long v = (random.nextLong()& Long.MAX_VALUE) >>> shift;
-            int bitCount = (v == 0) ? 0 : (int) (Math.floor(Math.log(  v) / Math.log(2)) + 1);
+            long v = (random.nextLong()) >>> shift;
+            int bitCount = 64-Long.numberOfLeadingZeros(v);
             bw.writeBits(v, bitCount);
         }
         bw.close();
@@ -98,12 +98,12 @@ class BitsWriterTest {
         br.reset(bw.toBytes());
 
         random = new Random(seed1);
-        random.nextLong(0, 1000); // ignore, make sure we start reading from the same point
+        random.nextLong(0, 1000000); // ignore, make sure we start reading from the same point
 
         for (long i = 1; i <= count; i++) {
             int shift = random.nextInt(64);
-            long v = (random.nextLong()& Long.MAX_VALUE) >>> shift;
-            int bitCount = (v == 0) ? 0 : (int) (Math.floor(Math.log(v) / Math.log(2)) + 1);
+            long v = (random.nextLong()) >>> shift;
+            int bitCount = 64-Long.numberOfLeadingZeros(v);
             long val = br.readBits(bitCount);
             assertEquals(v, val, "Mismatch at index " + i + " with seed " + seed1);
         }

--- a/java/src/test/java/net/stef/Float64EncoderTest.java
+++ b/java/src/test/java/net/stef/Float64EncoderTest.java
@@ -1,0 +1,106 @@
+package net.stef;
+
+import net.stef.codecs.Float64Decoder;
+import net.stef.codecs.Float64Encoder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Float64EncoderTest {
+    // This sequence was failing before bug fix https://github.com/splunk/stef/issues/268
+    private double testVals[] = {
+        0.516459,
+        0.516459,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.026014,
+        0.516459,
+        0.404796,
+        0.516459,
+        0.404796,
+        0.516459,
+        0.404796,
+        0.516459,
+    };
+
+    @Test
+    void testEncodeDecode() throws IOException {
+        Float64Encoder encoder = new Float64Encoder();
+        WriteBufs writeBufs = new WriteBufs();
+        encoder.init(new SizeLimiter(), writeBufs.columns);
+        for (int i = 0; i < testVals.length; i++) {
+            encoder.encode(testVals[i]);
+        }
+
+        encoder.collectColumns(writeBufs.columns);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeBufs.writeTo(out);
+
+        ReadBufs readBufs = new ReadBufs();
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        readBufs.readFrom(in);
+
+        Float64Decoder decoder = new Float64Decoder();
+        decoder.init(readBufs.columns);
+        decoder.continueDecoding();
+        for (int i = 0; i < testVals.length; i++) {
+            double decodedVal = decoder.decode();
+            assertEquals(testVals[i], decodedVal, "decoded value at index " + i + " does not match");
+        }
+    }
+
+    @Test
+    void testEncodeDecodeRandomSequence() throws IOException {
+        final int N = 100000;
+        final long seed = System.nanoTime();;
+        java.util.Random rand = new java.util.Random(seed);
+        Float64Encoder encoder = new Float64Encoder();
+        WriteBufs writeBufs = new WriteBufs();
+        encoder.init(new SizeLimiter(), writeBufs.columns);
+        for (int i = 0; i < N; i++) {
+            encoder.encode(rand.nextDouble()*rand.nextInt());
+        }
+        encoder.collectColumns(writeBufs.columns);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeBufs.writeTo(out);
+
+        ReadBufs readBufs = new ReadBufs();
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        readBufs.readFrom(in);
+
+        Float64Decoder decoder = new Float64Decoder();
+        decoder.init(readBufs.columns);
+        decoder.continueDecoding();
+        java.util.Random rand2 = new java.util.Random(seed);
+        for (int i = 0; i < N; i++) {
+            double expected = rand2.nextDouble()*rand2.nextInt();
+            double decoded = decoder.decode();
+            assertEquals(expected, decoded, "seed "+seed+", index " + i + " does not match");
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/268
Fixes https://github.com/splunk/stef/issues/267

The bug was in BitsWriter that was using >>> shift operator without checking that the operand was 64. This was directly copied from Go implementation where semantics of shift operator is different.