### PR TITLE
Prepare release v0.0.9

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/klauspost/compress v1.18.2
 	github.com/open-telemetry/otel-arrow/go v0.45.0
 	github.com/parquet-go/parquet-go v0.26.0
-	github.com/splunk/stef/go/otel v0.0.8
+	github.com/splunk/stef/go/otel v0.0.9
 	github.com/splunk/stef/go/pdata v0.0.0
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/pdata v1.47.0
 	golang.org/x/text v0.31.0

--- a/examples/ints/go.sum
+++ b/examples/ints/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/jsonl/go.mod
+++ b/examples/jsonl/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/golang/protobuf v1.5.4
 	github.com/klauspost/compress v1.18.2
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.10
 )

--- a/examples/profile/go.mod
+++ b/examples/profile/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5
 	github.com/klauspost/compress v1.18.2
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	modernc.org/b/v2 v2.1.10
 )

--- a/go/grpc/go.mod
+++ b/go/grpc/go.mod
@@ -3,7 +3,7 @@ module github.com/splunk/stef/go/grpc
 go 1.24.0
 
 require (
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10

--- a/go/otel/go.mod
+++ b/go/otel/go.mod
@@ -3,8 +3,8 @@ module github.com/splunk/stef/go/otel
 go 1.24.0
 
 require (
-	github.com/splunk/stef/go/grpc v0.0.8
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/grpc v0.0.9
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.77.0
 )

--- a/go/pdata/go.mod
+++ b/go/pdata/go.mod
@@ -4,8 +4,8 @@ go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/splunk/stef/go/otel v0.0.8
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/otel v0.0.9
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/pdata v1.47.0
 	modernc.org/b/v2 v2.1.10

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/spf13/pflag v1.0.9 // indirect
-	github.com/splunk/stef/go/grpc v0.0.8
+	github.com/splunk/stef/go/grpc v0.0.9
 	github.com/splunk/stef/go/pdata v0.0.0
 	go.opentelemetry.io/collector v0.140.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.46.0
@@ -20,8 +20,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.140.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.140.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.140.0
-	github.com/splunk/stef/go/otel v0.0.8
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/otel v0.0.9
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componentstatus v0.140.0

--- a/stefc/generator/testdata/go.mod
+++ b/stefc/generator/testdata/go.mod
@@ -3,7 +3,7 @@ module github.com/splunk/stef/stefc/generator/testdata
 go 1.24.0
 
 require (
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 	modernc.org/b/v2 v2.1.10
 )

--- a/stefc/generator/testdata/go.sum
+++ b/stefc/generator/testdata/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/stefc/go.mod
+++ b/stefc/go.mod
@@ -3,7 +3,7 @@ module github.com/splunk/stef/stefc
 go 1.24.0
 
 require (
-	github.com/splunk/stef/go/pkg v0.0.8
+	github.com/splunk/stef/go/pkg v0.0.9
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/stefc/go.sum
+++ b/stefc/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Run `make prepver VERSION=v0.0.9` as require by
https://github.com/splunk/stef/blob/main/CONTRIBUTING.md#releasing