### PR TITLE
Cleanup generated Go API

### DIFF
--- a/examples/ints/internal/ints/record.go
+++ b/examples/ints/internal/ints/record.go
@@ -71,13 +71,6 @@ func (s *Record) fixParent(parentModifiedFields *modifiedFields) {
 	s.modifiedFields.parent = parentModifiedFields
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Record) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Record) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -131,9 +124,9 @@ func (s *Record) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Record) CloneShared(allocators *Allocators) Record {
+func (s *Record) cloneShared(allocators *Allocators) Record {
 	return s.Clone(allocators)
 }
 
@@ -197,10 +190,6 @@ func (s *Record) IsEqual(right *Record) bool {
 	}
 
 	return true
-}
-
-func RecordEqual(left, right *Record) bool {
-	return left.IsEqual(right)
 }
 
 // CmpRecord performs deep comparison and returns an integer that

--- a/examples/jsonl/internal/jsonstef/jsonobject.go
+++ b/examples/jsonl/internal/jsonstef/jsonobject.go
@@ -182,7 +182,7 @@ func copyJsonObject(dst *JsonObject, src *JsonObject) {
 			dst.modifiedElems.markKeyModified(i)
 		}
 
-		if !JsonValueEqual(&dst.elems[i].value, &src.elems[i].value) {
+		if !dst.elems[i].value.IsEqual(&src.elems[i].value) {
 			copyJsonValue(&dst.elems[i].value, &src.elems[i].value)
 		}
 	}
@@ -220,10 +220,6 @@ func (e *JsonObject) IsEqual(val *JsonObject) bool {
 		}
 	}
 	return true
-}
-
-func JsonObjectEqual(left, right *JsonObject) bool {
-	return left.IsEqual(right)
 }
 
 func CmpJsonObject(left, right *JsonObject) int {

--- a/examples/jsonl/internal/jsonstef/jsonvalue.go
+++ b/examples/jsonl/internal/jsonstef/jsonvalue.go
@@ -174,8 +174,8 @@ func (s *JsonValue) canBeShared() bool {
 	return false
 }
 
-func (s *JsonValue) CloneShared(allocators *Allocators) *JsonValue {
-	// Oneof is not shareable, so CloneShared is just a Clone.
+func (s *JsonValue) cloneShared(allocators *Allocators) *JsonValue {
+	// Oneof is not shareable, so cloneShared is just a Clone.
 	return s.Clone(allocators)
 }
 
@@ -334,10 +334,6 @@ func (e *JsonValue) IsEqual(val *JsonValue) bool {
 	}
 
 	return true
-}
-
-func JsonValueEqual(left, right *JsonValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpJsonValue performs deep comparison and returns an integer that

--- a/examples/jsonl/internal/jsonstef/jsonvaluearray.go
+++ b/examples/jsonl/internal/jsonstef/jsonvaluearray.go
@@ -235,10 +235,6 @@ func (e *JsonValueArray) IsEqual(val *JsonValueArray) bool {
 	return true
 }
 
-func JsonValueArrayEqual(left, right *JsonValueArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpJsonValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpJsonValueArray(left, right *JsonValueArray) int {

--- a/examples/jsonl/internal/jsonstef/record.go
+++ b/examples/jsonl/internal/jsonstef/record.go
@@ -78,13 +78,6 @@ func (s *Record) fixParent(parentModifiedFields *modifiedFields) {
 	s.value.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Record) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Record) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -134,15 +127,15 @@ func (s *Record) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Record) CloneShared(allocators *Allocators) Record {
+func (s *Record) cloneShared(allocators *Allocators) Record {
 	return s.Clone(allocators)
 }
 
 func (s *Record) Clone(allocators *Allocators) Record {
 	c := Record{
-		value: s.value.CloneShared(allocators),
+		value: s.value.cloneShared(allocators),
 	}
 	return c
 }
@@ -220,10 +213,6 @@ func (s *Record) IsEqual(right *Record) bool {
 	}
 
 	return true
-}
-
-func RecordEqual(left, right *Record) bool {
-	return left.IsEqual(right)
 }
 
 // CmpRecord performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -242,9 +242,9 @@ func (s *Function) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Function) CloneShared(allocators *Allocators) *Function {
+func (s *Function) cloneShared(allocators *Allocators) *Function {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -355,10 +355,6 @@ func (s *Function) IsEqual(right *Function) bool {
 	}
 
 	return true
-}
-
-func FunctionEqual(left, right *Function) bool {
-	return left.IsEqual(right)
 }
 
 // CmpFunction performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/labels.go
+++ b/examples/profile/internal/profile/labels.go
@@ -182,7 +182,7 @@ func copyLabels(dst *Labels, src *Labels) {
 			dst.modifiedElems.markKeyModified(i)
 		}
 
-		if !LabelValueEqual(&dst.elems[i].value, &src.elems[i].value) {
+		if !dst.elems[i].value.IsEqual(&src.elems[i].value) {
 			copyLabelValue(&dst.elems[i].value, &src.elems[i].value)
 		}
 	}
@@ -220,10 +220,6 @@ func (e *Labels) IsEqual(val *Labels) bool {
 		}
 	}
 	return true
-}
-
-func LabelsEqual(left, right *Labels) bool {
-	return left.IsEqual(right)
 }
 
 func CmpLabels(left, right *Labels) int {

--- a/examples/profile/internal/profile/labelvalue.go
+++ b/examples/profile/internal/profile/labelvalue.go
@@ -127,8 +127,8 @@ func (s *LabelValue) canBeShared() bool {
 	return false
 }
 
-func (s *LabelValue) CloneShared(allocators *Allocators) LabelValue {
-	// Oneof is not shareable, so CloneShared is just a Clone.
+func (s *LabelValue) cloneShared(allocators *Allocators) LabelValue {
+	// Oneof is not shareable, so cloneShared is just a Clone.
 	return s.Clone(allocators)
 }
 
@@ -243,10 +243,6 @@ func (e *LabelValue) IsEqual(val *LabelValue) bool {
 	}
 
 	return true
-}
-
-func LabelValueEqual(left, right *LabelValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpLabelValue performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/line.go
+++ b/examples/profile/internal/profile/line.go
@@ -82,13 +82,6 @@ func (s *Line) fixParent(parentModifiedFields *modifiedFields) {
 	s.function.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Line) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Line) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -217,15 +210,15 @@ func (s *Line) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Line) CloneShared(allocators *Allocators) Line {
+func (s *Line) cloneShared(allocators *Allocators) Line {
 	return s.Clone(allocators)
 }
 
 func (s *Line) Clone(allocators *Allocators) Line {
 	c := Line{
-		function: s.function.CloneShared(allocators),
+		function: s.function.cloneShared(allocators),
 		line:     s.line,
 		column:   s.column,
 	}
@@ -348,10 +341,6 @@ func (s *Line) IsEqual(right *Line) bool {
 	}
 
 	return true
-}
-
-func LineEqual(left, right *Line) bool {
-	return left.IsEqual(right)
 }
 
 // CmpLine performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/linearray.go
+++ b/examples/profile/internal/profile/linearray.go
@@ -235,10 +235,6 @@ func (e *LineArray) IsEqual(val *LineArray) bool {
 	return true
 }
 
-func LineArrayEqual(left, right *LineArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpLineArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpLineArray(left, right *LineArray) int {

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -261,9 +261,9 @@ func (s *Location) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Location) CloneShared(allocators *Allocators) *Location {
+func (s *Location) cloneShared(allocators *Allocators) *Location {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -274,7 +274,7 @@ func (s *Location) CloneShared(allocators *Allocators) *Location {
 func (s *Location) Clone(allocators *Allocators) *Location {
 	c := allocators.Location.Alloc()
 	*c = Location{
-		mapping:  s.mapping.CloneShared(allocators),
+		mapping:  s.mapping.cloneShared(allocators),
 		address:  s.address,
 		isFolded: s.isFolded,
 	}
@@ -411,10 +411,6 @@ func (s *Location) IsEqual(right *Location) bool {
 	}
 
 	return true
-}
-
-func LocationEqual(left, right *Location) bool {
-	return left.IsEqual(right)
 }
 
 // CmpLocation performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/locationarray.go
+++ b/examples/profile/internal/profile/locationarray.go
@@ -235,10 +235,6 @@ func (e *LocationArray) IsEqual(val *LocationArray) bool {
 	return true
 }
 
-func LocationArrayEqual(left, right *LocationArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpLocationArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpLocationArray(left, right *LocationArray) int {

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -407,9 +407,9 @@ func (s *Mapping) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Mapping) CloneShared(allocators *Allocators) *Mapping {
+func (s *Mapping) cloneShared(allocators *Allocators) *Mapping {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -590,10 +590,6 @@ func (s *Mapping) IsEqual(right *Mapping) bool {
 	}
 
 	return true
-}
-
-func MappingEqual(left, right *Mapping) bool {
-	return left.IsEqual(right)
 }
 
 // CmpMapping performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/numvalue.go
+++ b/examples/profile/internal/profile/numvalue.go
@@ -74,13 +74,6 @@ func (s *NumValue) fixParent(parentModifiedFields *modifiedFields) {
 	s.modifiedFields.parent = parentModifiedFields
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *NumValue) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *NumValue) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -164,9 +157,9 @@ func (s *NumValue) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *NumValue) CloneShared(allocators *Allocators) NumValue {
+func (s *NumValue) cloneShared(allocators *Allocators) NumValue {
 	return s.Clone(allocators)
 }
 
@@ -244,10 +237,6 @@ func (s *NumValue) IsEqual(right *NumValue) bool {
 	}
 
 	return true
-}
-
-func NumValueEqual(left, right *NumValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpNumValue performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/profilemetadata.go
+++ b/examples/profile/internal/profile/profilemetadata.go
@@ -105,13 +105,6 @@ func (s *ProfileMetadata) fixParent(parentModifiedFields *modifiedFields) {
 	s.defaultSampleType.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *ProfileMetadata) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *ProfileMetadata) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -401,9 +394,9 @@ func (s *ProfileMetadata) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *ProfileMetadata) CloneShared(allocators *Allocators) ProfileMetadata {
+func (s *ProfileMetadata) cloneShared(allocators *Allocators) ProfileMetadata {
 	return s.Clone(allocators)
 }
 
@@ -413,9 +406,9 @@ func (s *ProfileMetadata) Clone(allocators *Allocators) ProfileMetadata {
 		keepFrames:        s.keepFrames,
 		timeNanos:         s.timeNanos,
 		durationNanos:     s.durationNanos,
-		periodType:        s.periodType.CloneShared(allocators),
+		periodType:        s.periodType.cloneShared(allocators),
 		period:            s.period,
-		defaultSampleType: s.defaultSampleType.CloneShared(allocators),
+		defaultSampleType: s.defaultSampleType.cloneShared(allocators),
 	}
 	copyToNewStringArray(&c.comments, &s.comments, allocators)
 	return c
@@ -639,10 +632,6 @@ func (s *ProfileMetadata) IsEqual(right *ProfileMetadata) bool {
 	}
 
 	return true
-}
-
-func ProfileMetadataEqual(left, right *ProfileMetadata) bool {
-	return left.IsEqual(right)
 }
 
 // CmpProfileMetadata performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/sample.go
+++ b/examples/profile/internal/profile/sample.go
@@ -92,13 +92,6 @@ func (s *Sample) fixParent(parentModifiedFields *modifiedFields) {
 	s.labels.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Sample) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Sample) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -226,9 +219,9 @@ func (s *Sample) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Sample) CloneShared(allocators *Allocators) Sample {
+func (s *Sample) cloneShared(allocators *Allocators) Sample {
 	return s.Clone(allocators)
 }
 
@@ -333,10 +326,6 @@ func (s *Sample) IsEqual(right *Sample) bool {
 	}
 
 	return true
-}
-
-func SampleEqual(left, right *Sample) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSample performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/samplevalue.go
+++ b/examples/profile/internal/profile/samplevalue.go
@@ -79,13 +79,6 @@ func (s *SampleValue) fixParent(parentModifiedFields *modifiedFields) {
 	s.type_.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *SampleValue) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *SampleValue) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -184,16 +177,16 @@ func (s *SampleValue) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *SampleValue) CloneShared(allocators *Allocators) SampleValue {
+func (s *SampleValue) cloneShared(allocators *Allocators) SampleValue {
 	return s.Clone(allocators)
 }
 
 func (s *SampleValue) Clone(allocators *Allocators) SampleValue {
 	c := SampleValue{
 		val:   s.val,
-		type_: s.type_.CloneShared(allocators),
+		type_: s.type_.cloneShared(allocators),
 	}
 	return c
 }
@@ -301,10 +294,6 @@ func (s *SampleValue) IsEqual(right *SampleValue) bool {
 	}
 
 	return true
-}
-
-func SampleValueEqual(left, right *SampleValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSampleValue performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/samplevaluearray.go
+++ b/examples/profile/internal/profile/samplevaluearray.go
@@ -235,10 +235,6 @@ func (e *SampleValueArray) IsEqual(val *SampleValueArray) bool {
 	return true
 }
 
-func SampleValueArrayEqual(left, right *SampleValueArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpSampleValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpSampleValueArray(left, right *SampleValueArray) int {

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -176,9 +176,9 @@ func (s *SampleValueType) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *SampleValueType) CloneShared(allocators *Allocators) *SampleValueType {
+func (s *SampleValueType) cloneShared(allocators *Allocators) *SampleValueType {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -261,10 +261,6 @@ func (s *SampleValueType) IsEqual(right *SampleValueType) bool {
 	}
 
 	return true
-}
-
-func SampleValueTypeEqual(left, right *SampleValueType) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSampleValueType performs deep comparison and returns an integer that

--- a/examples/profile/internal/profile/stringarray.go
+++ b/examples/profile/internal/profile/stringarray.go
@@ -197,10 +197,6 @@ func (e *StringArray) IsEqual(val *StringArray) bool {
 	return true
 }
 
-func StringArrayEqual(left, right *StringArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpStringArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpStringArray(left, right *StringArray) int {

--- a/go/otel/otelstef/anyvalue.go
+++ b/go/otel/otelstef/anyvalue.go
@@ -208,8 +208,8 @@ func (s *AnyValue) canBeShared() bool {
 	return false
 }
 
-func (s *AnyValue) CloneShared(allocators *Allocators) *AnyValue {
-	// Oneof is not shareable, so CloneShared is just a Clone.
+func (s *AnyValue) cloneShared(allocators *Allocators) *AnyValue {
+	// Oneof is not shareable, so cloneShared is just a Clone.
 	return s.Clone(allocators)
 }
 
@@ -394,10 +394,6 @@ func (e *AnyValue) IsEqual(val *AnyValue) bool {
 	}
 
 	return true
-}
-
-func AnyValueEqual(left, right *AnyValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpAnyValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/anyvaluearray.go
+++ b/go/otel/otelstef/anyvaluearray.go
@@ -235,10 +235,6 @@ func (e *AnyValueArray) IsEqual(val *AnyValueArray) bool {
 	return true
 }
 
-func AnyValueArrayEqual(left, right *AnyValueArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpAnyValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpAnyValueArray(left, right *AnyValueArray) int {

--- a/go/otel/otelstef/attributes.go
+++ b/go/otel/otelstef/attributes.go
@@ -182,7 +182,7 @@ func copyAttributes(dst *Attributes, src *Attributes) {
 			dst.modifiedElems.markKeyModified(i)
 		}
 
-		if !AnyValueEqual(&dst.elems[i].value, &src.elems[i].value) {
+		if !dst.elems[i].value.IsEqual(&src.elems[i].value) {
 			copyAnyValue(&dst.elems[i].value, &src.elems[i].value)
 		}
 	}
@@ -220,10 +220,6 @@ func (e *Attributes) IsEqual(val *Attributes) bool {
 		}
 	}
 	return true
-}
-
-func AttributesEqual(left, right *Attributes) bool {
-	return left.IsEqual(right)
 }
 
 func CmpAttributes(left, right *Attributes) int {

--- a/go/otel/otelstef/envelope.go
+++ b/go/otel/otelstef/envelope.go
@@ -74,13 +74,6 @@ func (s *Envelope) fixParent(parentModifiedFields *modifiedFields) {
 	s.attributes.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Envelope) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Envelope) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -130,9 +123,9 @@ func (s *Envelope) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Envelope) CloneShared(allocators *Allocators) Envelope {
+func (s *Envelope) cloneShared(allocators *Allocators) Envelope {
 	return s.Clone(allocators)
 }
 
@@ -195,10 +188,6 @@ func (s *Envelope) IsEqual(right *Envelope) bool {
 	}
 
 	return true
-}
-
-func EnvelopeEqual(left, right *Envelope) bool {
-	return left.IsEqual(right)
 }
 
 // CmpEnvelope performs deep comparison and returns an integer that

--- a/go/otel/otelstef/envelopeattributes.go
+++ b/go/otel/otelstef/envelopeattributes.go
@@ -225,10 +225,6 @@ func (e *EnvelopeAttributes) IsEqual(val *EnvelopeAttributes) bool {
 	return true
 }
 
-func EnvelopeAttributesEqual(left, right *EnvelopeAttributes) bool {
-	return left.IsEqual(right)
-}
-
 func CmpEnvelopeAttributes(left, right *EnvelopeAttributes) int {
 	l := min(len(left.elems), len(right.elems))
 	for i := 0; i < l; i++ {

--- a/go/otel/otelstef/event.go
+++ b/go/otel/otelstef/event.go
@@ -83,13 +83,6 @@ func (s *Event) fixParent(parentModifiedFields *modifiedFields) {
 	s.attributes.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Event) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Event) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -229,9 +222,9 @@ func (s *Event) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Event) CloneShared(allocators *Allocators) Event {
+func (s *Event) cloneShared(allocators *Allocators) Event {
 	return s.Clone(allocators)
 }
 
@@ -337,10 +330,6 @@ func (s *Event) IsEqual(right *Event) bool {
 	}
 
 	return true
-}
-
-func EventEqual(left, right *Event) bool {
-	return left.IsEqual(right)
 }
 
 // CmpEvent performs deep comparison and returns an integer that

--- a/go/otel/otelstef/eventarray.go
+++ b/go/otel/otelstef/eventarray.go
@@ -235,10 +235,6 @@ func (e *EventArray) IsEqual(val *EventArray) bool {
 	return true
 }
 
-func EventArrayEqual(left, right *EventArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpEventArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpEventArray(left, right *EventArray) int {

--- a/go/otel/otelstef/exemplar.go
+++ b/go/otel/otelstef/exemplar.go
@@ -89,13 +89,6 @@ func (s *Exemplar) fixParent(parentModifiedFields *modifiedFields) {
 	s.filteredAttributes.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Exemplar) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Exemplar) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -261,9 +254,9 @@ func (s *Exemplar) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Exemplar) CloneShared(allocators *Allocators) Exemplar {
+func (s *Exemplar) cloneShared(allocators *Allocators) Exemplar {
 	return s.Clone(allocators)
 }
 
@@ -383,10 +376,6 @@ func (s *Exemplar) IsEqual(right *Exemplar) bool {
 	}
 
 	return true
-}
-
-func ExemplarEqual(left, right *Exemplar) bool {
-	return left.IsEqual(right)
 }
 
 // CmpExemplar performs deep comparison and returns an integer that

--- a/go/otel/otelstef/exemplararray.go
+++ b/go/otel/otelstef/exemplararray.go
@@ -235,10 +235,6 @@ func (e *ExemplarArray) IsEqual(val *ExemplarArray) bool {
 	return true
 }
 
-func ExemplarArrayEqual(left, right *ExemplarArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpExemplarArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpExemplarArray(left, right *ExemplarArray) int {

--- a/go/otel/otelstef/exemplarvalue.go
+++ b/go/otel/otelstef/exemplarvalue.go
@@ -131,8 +131,8 @@ func (s *ExemplarValue) canBeShared() bool {
 	return false
 }
 
-func (s *ExemplarValue) CloneShared(allocators *Allocators) ExemplarValue {
-	// Oneof is not shareable, so CloneShared is just a Clone.
+func (s *ExemplarValue) cloneShared(allocators *Allocators) ExemplarValue {
+	// Oneof is not shareable, so cloneShared is just a Clone.
 	return s.Clone(allocators)
 }
 
@@ -242,10 +242,6 @@ func (e *ExemplarValue) IsEqual(val *ExemplarValue) bool {
 	}
 
 	return true
-}
-
-func ExemplarValueEqual(left, right *ExemplarValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpExemplarValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/exphistogrambuckets.go
+++ b/go/otel/otelstef/exphistogrambuckets.go
@@ -77,13 +77,6 @@ func (s *ExpHistogramBuckets) fixParent(parentModifiedFields *modifiedFields) {
 	s.bucketCounts.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *ExpHistogramBuckets) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *ExpHistogramBuckets) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -163,9 +156,9 @@ func (s *ExpHistogramBuckets) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *ExpHistogramBuckets) CloneShared(allocators *Allocators) ExpHistogramBuckets {
+func (s *ExpHistogramBuckets) cloneShared(allocators *Allocators) ExpHistogramBuckets {
 	return s.Clone(allocators)
 }
 
@@ -243,10 +236,6 @@ func (s *ExpHistogramBuckets) IsEqual(right *ExpHistogramBuckets) bool {
 	}
 
 	return true
-}
-
-func ExpHistogramBucketsEqual(left, right *ExpHistogramBuckets) bool {
-	return left.IsEqual(right)
 }
 
 // CmpExpHistogramBuckets performs deep comparison and returns an integer that

--- a/go/otel/otelstef/exphistogramvalue.go
+++ b/go/otel/otelstef/exphistogramvalue.go
@@ -112,13 +112,6 @@ func (s *ExpHistogramValue) fixParent(parentModifiedFields *modifiedFields) {
 	s.negativeBuckets.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *ExpHistogramValue) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *ExpHistogramValue) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -488,9 +481,9 @@ func (s *ExpHistogramValue) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *ExpHistogramValue) CloneShared(allocators *Allocators) ExpHistogramValue {
+func (s *ExpHistogramValue) cloneShared(allocators *Allocators) ExpHistogramValue {
 	return s.Clone(allocators)
 }
 
@@ -713,10 +706,6 @@ func (s *ExpHistogramValue) IsEqual(right *ExpHistogramValue) bool {
 	}
 
 	return true
-}
-
-func ExpHistogramValueEqual(left, right *ExpHistogramValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpExpHistogramValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/float64array.go
+++ b/go/otel/otelstef/float64array.go
@@ -197,10 +197,6 @@ func (e *Float64Array) IsEqual(val *Float64Array) bool {
 	return true
 }
 
-func Float64ArrayEqual(left, right *Float64Array) bool {
-	return left.IsEqual(right)
-}
-
 // CmpFloat64Array performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpFloat64Array(left, right *Float64Array) int {

--- a/go/otel/otelstef/histogramvalue.go
+++ b/go/otel/otelstef/histogramvalue.go
@@ -97,13 +97,6 @@ func (s *HistogramValue) fixParent(parentModifiedFields *modifiedFields) {
 	s.bucketCounts.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *HistogramValue) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *HistogramValue) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -357,9 +350,9 @@ func (s *HistogramValue) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *HistogramValue) CloneShared(allocators *Allocators) HistogramValue {
+func (s *HistogramValue) cloneShared(allocators *Allocators) HistogramValue {
 	return s.Clone(allocators)
 }
 
@@ -526,10 +519,6 @@ func (s *HistogramValue) IsEqual(right *HistogramValue) bool {
 	}
 
 	return true
-}
-
-func HistogramValueEqual(left, right *HistogramValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpHistogramValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/keyvaluelist.go
+++ b/go/otel/otelstef/keyvaluelist.go
@@ -182,7 +182,7 @@ func copyKeyValueList(dst *KeyValueList, src *KeyValueList) {
 			dst.modifiedElems.markKeyModified(i)
 		}
 
-		if !AnyValueEqual(&dst.elems[i].value, &src.elems[i].value) {
+		if !dst.elems[i].value.IsEqual(&src.elems[i].value) {
 			copyAnyValue(&dst.elems[i].value, &src.elems[i].value)
 		}
 	}
@@ -220,10 +220,6 @@ func (e *KeyValueList) IsEqual(val *KeyValueList) bool {
 		}
 	}
 	return true
-}
-
-func KeyValueListEqual(left, right *KeyValueList) bool {
-	return left.IsEqual(right)
 }
 
 func CmpKeyValueList(left, right *KeyValueList) int {

--- a/go/otel/otelstef/link.go
+++ b/go/otel/otelstef/link.go
@@ -89,13 +89,6 @@ func (s *Link) fixParent(parentModifiedFields *modifiedFields) {
 	s.attributes.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Link) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Link) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -295,9 +288,9 @@ func (s *Link) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Link) CloneShared(allocators *Allocators) Link {
+func (s *Link) cloneShared(allocators *Allocators) Link {
 	return s.Clone(allocators)
 }
 
@@ -431,10 +424,6 @@ func (s *Link) IsEqual(right *Link) bool {
 	}
 
 	return true
-}
-
-func LinkEqual(left, right *Link) bool {
-	return left.IsEqual(right)
 }
 
 // CmpLink performs deep comparison and returns an integer that

--- a/go/otel/otelstef/linkarray.go
+++ b/go/otel/otelstef/linkarray.go
@@ -235,10 +235,6 @@ func (e *LinkArray) IsEqual(val *LinkArray) bool {
 	return true
 }
 
-func LinkArrayEqual(left, right *LinkArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpLinkArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpLinkArray(left, right *LinkArray) int {

--- a/go/otel/otelstef/metric.go
+++ b/go/otel/otelstef/metric.go
@@ -372,9 +372,9 @@ func (s *Metric) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Metric) CloneShared(allocators *Allocators) *Metric {
+func (s *Metric) cloneShared(allocators *Allocators) *Metric {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -541,10 +541,6 @@ func (s *Metric) IsEqual(right *Metric) bool {
 	}
 
 	return true
-}
-
-func MetricEqual(left, right *Metric) bool {
-	return left.IsEqual(right)
 }
 
 // CmpMetric performs deep comparison and returns an integer that

--- a/go/otel/otelstef/metrics.go
+++ b/go/otel/otelstef/metrics.go
@@ -110,13 +110,6 @@ func (s *Metrics) fixParent(parentModifiedFields *modifiedFields) {
 	s.point.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Metrics) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Metrics) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -353,17 +346,17 @@ func (s *Metrics) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Metrics) CloneShared(allocators *Allocators) Metrics {
+func (s *Metrics) cloneShared(allocators *Allocators) Metrics {
 	return s.Clone(allocators)
 }
 
 func (s *Metrics) Clone(allocators *Allocators) Metrics {
 	c := Metrics{
-		metric:   s.metric.CloneShared(allocators),
-		resource: s.resource.CloneShared(allocators),
-		scope:    s.scope.CloneShared(allocators),
+		metric:   s.metric.cloneShared(allocators),
+		resource: s.resource.cloneShared(allocators),
+		scope:    s.scope.cloneShared(allocators),
 	}
 	copyToNewEnvelope(&c.envelope, &s.envelope, allocators)
 	copyToNewAttributes(&c.attributes, &s.attributes, allocators)
@@ -598,10 +591,6 @@ func (s *Metrics) IsEqual(right *Metrics) bool {
 	}
 
 	return true
-}
-
-func MetricsEqual(left, right *Metrics) bool {
-	return left.IsEqual(right)
 }
 
 // CmpMetrics performs deep comparison and returns an integer that

--- a/go/otel/otelstef/point.go
+++ b/go/otel/otelstef/point.go
@@ -86,13 +86,6 @@ func (s *Point) fixParent(parentModifiedFields *modifiedFields) {
 	s.exemplars.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Point) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Point) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -228,9 +221,9 @@ func (s *Point) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Point) CloneShared(allocators *Allocators) Point {
+func (s *Point) cloneShared(allocators *Allocators) Point {
 	return s.Clone(allocators)
 }
 
@@ -336,10 +329,6 @@ func (s *Point) IsEqual(right *Point) bool {
 	}
 
 	return true
-}
-
-func PointEqual(left, right *Point) bool {
-	return left.IsEqual(right)
 }
 
 // CmpPoint performs deep comparison and returns an integer that

--- a/go/otel/otelstef/pointvalue.go
+++ b/go/otel/otelstef/pointvalue.go
@@ -170,8 +170,8 @@ func (s *PointValue) canBeShared() bool {
 	return false
 }
 
-func (s *PointValue) CloneShared(allocators *Allocators) PointValue {
-	// Oneof is not shareable, so CloneShared is just a Clone.
+func (s *PointValue) cloneShared(allocators *Allocators) PointValue {
+	// Oneof is not shareable, so cloneShared is just a Clone.
 	return s.Clone(allocators)
 }
 
@@ -335,10 +335,6 @@ func (e *PointValue) IsEqual(val *PointValue) bool {
 	}
 
 	return true
-}
-
-func PointValueEqual(left, right *PointValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpPointValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/quantilevalue.go
+++ b/go/otel/otelstef/quantilevalue.go
@@ -74,13 +74,6 @@ func (s *QuantileValue) fixParent(parentModifiedFields *modifiedFields) {
 	s.modifiedFields.parent = parentModifiedFields
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *QuantileValue) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *QuantileValue) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -164,9 +157,9 @@ func (s *QuantileValue) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *QuantileValue) CloneShared(allocators *Allocators) QuantileValue {
+func (s *QuantileValue) cloneShared(allocators *Allocators) QuantileValue {
 	return s.Clone(allocators)
 }
 
@@ -244,10 +237,6 @@ func (s *QuantileValue) IsEqual(right *QuantileValue) bool {
 	}
 
 	return true
-}
-
-func QuantileValueEqual(left, right *QuantileValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpQuantileValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/quantilevaluearray.go
+++ b/go/otel/otelstef/quantilevaluearray.go
@@ -235,10 +235,6 @@ func (e *QuantileValueArray) IsEqual(val *QuantileValueArray) bool {
 	return true
 }
 
-func QuantileValueArrayEqual(left, right *QuantileValueArray) bool {
-	return left.IsEqual(right)
-}
-
 // CmpQuantileValueArray performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpQuantileValueArray(left, right *QuantileValueArray) int {

--- a/go/otel/otelstef/resource.go
+++ b/go/otel/otelstef/resource.go
@@ -208,9 +208,9 @@ func (s *Resource) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Resource) CloneShared(allocators *Allocators) *Resource {
+func (s *Resource) cloneShared(allocators *Allocators) *Resource {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -307,10 +307,6 @@ func (s *Resource) IsEqual(right *Resource) bool {
 	}
 
 	return true
-}
-
-func ResourceEqual(left, right *Resource) bool {
-	return left.IsEqual(right)
 }
 
 // CmpResource performs deep comparison and returns an integer that

--- a/go/otel/otelstef/scope.go
+++ b/go/otel/otelstef/scope.go
@@ -274,9 +274,9 @@ func (s *Scope) canBeShared() bool {
 	return s.isFrozen()
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Scope) CloneShared(allocators *Allocators) *Scope {
+func (s *Scope) cloneShared(allocators *Allocators) *Scope {
 	if s.isFrozen() {
 		// If s is frozen it means it is safe to share without cloning.
 		return s
@@ -401,10 +401,6 @@ func (s *Scope) IsEqual(right *Scope) bool {
 	}
 
 	return true
-}
-
-func ScopeEqual(left, right *Scope) bool {
-	return left.IsEqual(right)
 }
 
 // CmpScope performs deep comparison and returns an integer that

--- a/go/otel/otelstef/span.go
+++ b/go/otel/otelstef/span.go
@@ -122,13 +122,6 @@ func (s *Span) fixParent(parentModifiedFields *modifiedFields) {
 	s.status.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Span) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Span) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -556,9 +549,9 @@ func (s *Span) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Span) CloneShared(allocators *Allocators) Span {
+func (s *Span) cloneShared(allocators *Allocators) Span {
 	return s.Clone(allocators)
 }
 
@@ -804,10 +797,6 @@ func (s *Span) IsEqual(right *Span) bool {
 	}
 
 	return true
-}
-
-func SpanEqual(left, right *Span) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSpan performs deep comparison and returns an integer that

--- a/go/otel/otelstef/spans.go
+++ b/go/otel/otelstef/spans.go
@@ -96,13 +96,6 @@ func (s *Spans) fixParent(parentModifiedFields *modifiedFields) {
 	s.span.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *Spans) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *Spans) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -268,16 +261,16 @@ func (s *Spans) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *Spans) CloneShared(allocators *Allocators) Spans {
+func (s *Spans) cloneShared(allocators *Allocators) Spans {
 	return s.Clone(allocators)
 }
 
 func (s *Spans) Clone(allocators *Allocators) Spans {
 	c := Spans{
-		resource: s.resource.CloneShared(allocators),
-		scope:    s.scope.CloneShared(allocators),
+		resource: s.resource.cloneShared(allocators),
+		scope:    s.scope.cloneShared(allocators),
 	}
 	copyToNewEnvelope(&c.envelope, &s.envelope, allocators)
 	copyToNewSpan(&c.span, &s.span, allocators)
@@ -449,10 +442,6 @@ func (s *Spans) IsEqual(right *Spans) bool {
 	}
 
 	return true
-}
-
-func SpansEqual(left, right *Spans) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSpans performs deep comparison and returns an integer that

--- a/go/otel/otelstef/spanstatus.go
+++ b/go/otel/otelstef/spanstatus.go
@@ -74,13 +74,6 @@ func (s *SpanStatus) fixParent(parentModifiedFields *modifiedFields) {
 	s.modifiedFields.parent = parentModifiedFields
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *SpanStatus) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *SpanStatus) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -164,9 +157,9 @@ func (s *SpanStatus) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *SpanStatus) CloneShared(allocators *Allocators) SpanStatus {
+func (s *SpanStatus) cloneShared(allocators *Allocators) SpanStatus {
 	return s.Clone(allocators)
 }
 
@@ -244,10 +237,6 @@ func (s *SpanStatus) IsEqual(right *SpanStatus) bool {
 	}
 
 	return true
-}
-
-func SpanStatusEqual(left, right *SpanStatus) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSpanStatus performs deep comparison and returns an integer that

--- a/go/otel/otelstef/summaryvalue.go
+++ b/go/otel/otelstef/summaryvalue.go
@@ -80,13 +80,6 @@ func (s *SummaryValue) fixParent(parentModifiedFields *modifiedFields) {
 	s.quantileValues.fixParent(&s.modifiedFields)
 }
 
-// Freeze the struct. Any attempt to modify it after this will panic.
-// This marks the struct as eligible for safely sharing by pointer without cloning,
-// which can improve encoding performance.
-func (s *SummaryValue) Freeze() {
-	s.modifiedFields.freeze()
-}
-
 func (s *SummaryValue) isFrozen() bool {
 	return s.modifiedFields.isFrozen()
 }
@@ -196,9 +189,9 @@ func (s *SummaryValue) canBeShared() bool {
 	return false
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *SummaryValue) CloneShared(allocators *Allocators) SummaryValue {
+func (s *SummaryValue) cloneShared(allocators *Allocators) SummaryValue {
 	return s.Clone(allocators)
 }
 
@@ -290,10 +283,6 @@ func (s *SummaryValue) IsEqual(right *SummaryValue) bool {
 	}
 
 	return true
-}
-
-func SummaryValueEqual(left, right *SummaryValue) bool {
-	return left.IsEqual(right)
 }
 
 // CmpSummaryValue performs deep comparison and returns an integer that

--- a/go/otel/otelstef/uint64array.go
+++ b/go/otel/otelstef/uint64array.go
@@ -197,10 +197,6 @@ func (e *Uint64Array) IsEqual(val *Uint64Array) bool {
 	return true
 }
 
-func Uint64ArrayEqual(left, right *Uint64Array) bool {
-	return left.IsEqual(right)
-}
-
 // CmpUint64Array performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func CmpUint64Array(left, right *Uint64Array) int {

--- a/stefc/templates/go/array.go.tmpl
+++ b/stefc/templates/go/array.go.tmpl
@@ -321,10 +321,6 @@ func (e *{{ .ArrayName }}) IsEqual(val *{{ .ArrayName }}) bool {
 	return true
 }
 
-func {{.ArrayName}}Equal(left, right *{{.ArrayName}}) bool {
-	return left.IsEqual(right)
-}
-
 // Cmp{{.ArrayName}} performs deep comparison and returns an integer that
 // will be 0 if left == right, negative if left < right, positive if left > right.
 func Cmp{{.ArrayName}}(left, right *{{ .ArrayName }}) int {

--- a/stefc/templates/go/multimap.go.tmpl
+++ b/stefc/templates/go/multimap.go.tmpl
@@ -248,7 +248,7 @@ func copy{{.MultimapName}}(dst *{{.MultimapName}}, src *{{.MultimapName}}) {
 			dst.modifiedElems.markKeyModified(i)
 		}
 		{{else}}
-		if !{{.Key.Type.EqualFunc}}({{if not .KeyStoreByPtr}}&{{end}}dst.elems[i].key, {{if not .KeyStoreByPtr}}&{{end}}src.elems[i].key) {
+		if !dst.elems[i].key.IsEqual({{if not .KeyStoreByPtr}}&{{end}}src.elems[i].key) {
 			copy{{.Key.Type.TypeName}}({{if not .KeyStoreByPtr}}&{{end}}dst.elems[i].key, {{if not .KeyStoreByPtr}}&{{end}}src.elems[i].key)
 		}
 		{{end}}
@@ -259,7 +259,7 @@ func copy{{.MultimapName}}(dst *{{.MultimapName}}, src *{{.MultimapName}}) {
 			dst.modifiedElems.markValModified(i)
 		}
 		{{else}}
-		if !{{.Value.Type.EqualFunc}}({{if not .ValueStoreByPtr}}&{{end}}dst.elems[i].value, {{if not .ValueStoreByPtr}}&{{end}}src.elems[i].value) {
+		if !dst.elems[i].value.IsEqual({{if not .ValueStoreByPtr}}&{{end}}src.elems[i].value) {
 			copy{{.Value.Type.TypeName}}({{if not .ValueStoreByPtr}}&{{end}}dst.elems[i].value, {{if not .ValueStoreByPtr}}&{{end}}src.elems[i].value)
 		}
 		{{- end}}
@@ -321,10 +321,6 @@ func (e *{{.MultimapName}}) IsEqual(val *{{.MultimapName}}) bool {
 		{{- end}}
 	}
 	return true
-}
-
-func {{.MultimapName}}Equal(left, right *{{.MultimapName}}) bool {
-	return left.IsEqual(right)
 }
 
 func Cmp{{.MultimapName}}(left, right *{{.MultimapName}}) int {

--- a/stefc/templates/go/oneof.go.tmpl
+++ b/stefc/templates/go/oneof.go.tmpl
@@ -162,8 +162,8 @@ func (s *{{ .StructName }}) canBeShared() bool {
     return false
 }
 
-func (s *{{ .StructName }}) CloneShared(allocators *Allocators) {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
-    // Oneof is not shareable, so CloneShared is just a Clone.
+func (s *{{ .StructName }}) cloneShared(allocators *Allocators) {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
+    // Oneof is not shareable, so cloneShared is just a Clone.
     return s.Clone(allocators)
 }
 
@@ -180,7 +180,7 @@ func (s *{{ .StructName }}) Clone(allocators *Allocators) {{if .Type.Flags.Store
         {{- if .Type.IsPrimitive}}
         c.{{.name}} = s.{{.name}}
         {{- else if .Type.Flags.StoreByPtr}}
-        c.{{.name}} = s.{{.name}}.CloneShared(allocators)
+        c.{{.name}} = s.{{.name}}.cloneShared(allocators)
         {{- else}}
         copyToNew{{.Type.Storage}}({{if .Type.Flags.TakePtr}}&{{end}}c.{{.name}}, {{if .Type.Flags.TakePtr}}&{{end}}s.{{.name}}, allocators)
         {{- end}}
@@ -324,10 +324,6 @@ func (e *{{ .StructName }}) IsEqual(val *{{ .StructName }}) bool {
     }
 
     return true
-}
-
-func {{.StructName}}Equal(left, right *{{.StructName}}) bool {
-    return left.IsEqual(right)
 }
 
 // Cmp{{.StructName}} performs deep comparison and returns an integer that

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -158,12 +158,14 @@ func (s *{{ $.StructName }}) fixParent(parentModifiedFields *modifiedFields) {
     {{- end -}}
 }
 
+{{if .DictName}}
 // Freeze the struct. Any attempt to modify it after this will panic.
 // This marks the struct as eligible for safely sharing by pointer without cloning,
 // which can improve encoding performance.
 func (s *{{ $.StructName }}) Freeze() {
     s.modifiedFields.freeze()
 }
+{{end}}
 
 func (s *{{ $.StructName }}) isFrozen() bool {
     return s.modifiedFields.isFrozen()
@@ -315,9 +317,9 @@ func (s *{{ .StructName }}) canBeShared() bool {
     return {{if .DictName}}s.isFrozen(){{else}}false{{end}}
 }
 
-// CloneShared returns a clone of s. It may return s if it is safe to share without cloning
+// cloneShared returns a clone of s. It may return s if it is safe to share without cloning
 // (for example if s is frozen).
-func (s *{{ .StructName }}) CloneShared(allocators *Allocators) {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
+func (s *{{ .StructName }}) cloneShared(allocators *Allocators) {{if .Type.Flags.StoreByPtr}}*{{end}}{{.StructName}} {
 {{- if .DictName}}
     if s.isFrozen() {
         // If s is frozen it means it is safe to share without cloning.
@@ -338,7 +340,7 @@ func (s *{{ .StructName }}) Clone(allocators *Allocators) {{if .Type.Flags.Store
         {{- if .Type.IsPrimitive}}
         {{.name}}: s.{{.name}},
         {{- else if .Type.Flags.StoreByPtr}}
-        {{.name}}: s.{{.name}}.CloneShared(allocators),
+        {{.name}}: s.{{.name}}.cloneShared(allocators),
         {{- end}}
         {{- end }}
 	}
@@ -562,10 +564,6 @@ func (s *{{ .StructName }}) IsEqual(right *{{ .StructName }}) bool {
     {{- end }}
 
     return true
-}
-
-func {{.StructName}}Equal(left, right *{{.StructName}}) bool {
-    return left.IsEqual(right)
 }
 
 // Cmp{{.StructName}} performs deep comparison and returns an integer that


### PR DESCRIPTION
- Remove struct {{.StructName}}Equal standalone func
- Remove oneof {{.StructName}}Equal standalone func
- Remove {{.MultimapName}}Equal standalone func
- Remove {{.ArrayName}}Equal standalone func
- Remove Freeze() from non-dictionary structs
- Unexport cloneShared