### PR TITLE
Add schema backward compatibility tests

### DIFF
--- a/examples/ints/internal/ints/recordreader.go
+++ b/examples/ints/internal/ints/recordreader.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/splunk/stef/go/pkg"
+	"github.com/splunk/stef/go/pkg/schema"
 )
 
 type RecordReader struct {
@@ -127,4 +128,9 @@ func (r *RecordReader) nextFrame() error {
 
 	r.decoder.Continue()
 	return nil
+}
+
+// Schema returns the schema of the STEF stream being read.
+func (r *RecordReader) Schema() *schema.WireSchema {
+	return r.base.Schema
 }

--- a/examples/jsonl/internal/jsonstef/recordreader.go
+++ b/examples/jsonl/internal/jsonstef/recordreader.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/splunk/stef/go/pkg"
+	"github.com/splunk/stef/go/pkg/schema"
 )
 
 type RecordReader struct {
@@ -127,4 +128,9 @@ func (r *RecordReader) nextFrame() error {
 
 	r.decoder.Continue()
 	return nil
+}
+
+// Schema returns the schema of the STEF stream being read.
+func (r *RecordReader) Schema() *schema.WireSchema {
+	return r.base.Schema
 }

--- a/examples/profile/internal/profile/samplereader.go
+++ b/examples/profile/internal/profile/samplereader.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/splunk/stef/go/pkg"
+	"github.com/splunk/stef/go/pkg/schema"
 )
 
 type SampleReader struct {
@@ -127,4 +128,9 @@ func (r *SampleReader) nextFrame() error {
 
 	r.decoder.Continue()
 	return nil
+}
+
+// Schema returns the schema of the STEF stream being read.
+func (r *SampleReader) Schema() *schema.WireSchema {
+	return r.base.Schema
 }

--- a/go/otel/otelstef/metricsreader.go
+++ b/go/otel/otelstef/metricsreader.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/splunk/stef/go/pkg"
+	"github.com/splunk/stef/go/pkg/schema"
 )
 
 type MetricsReader struct {
@@ -127,4 +128,9 @@ func (r *MetricsReader) nextFrame() error {
 
 	r.decoder.Continue()
 	return nil
+}
+
+// Schema returns the schema of the STEF stream being read.
+func (r *MetricsReader) Schema() *schema.WireSchema {
+	return r.base.Schema
 }

--- a/go/otel/otelstef/spansreader.go
+++ b/go/otel/otelstef/spansreader.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/splunk/stef/go/pkg"
+	"github.com/splunk/stef/go/pkg/schema"
 )
 
 type SpansReader struct {
@@ -127,4 +128,9 @@ func (r *SpansReader) nextFrame() error {
 
 	r.decoder.Continue()
 	return nil
+}
+
+// Schema returns the schema of the STEF stream being read.
+func (r *SpansReader) Schema() *schema.WireSchema {
+	return r.base.Schema
 }

--- a/go/pkg/schema/utils.go
+++ b/go/pkg/schema/utils.go
@@ -9,10 +9,17 @@ import (
 // schema by removing the last field from one of the structs or oneofs.
 // This function is used for testing schema changes.
 func ShrinkRandomly(r *rand.Rand, schem *Schema) {
+	totalFieldCount := 0
 	var structNames []string
 	for structName := range schem.Structs {
 		structNames = append(structNames, structName)
+		totalFieldCount += len(schem.Structs[structName].Fields)
 	}
+	if totalFieldCount == 0 {
+		// Nothing to shrink
+		return
+	}
+
 	sort.Strings(structNames)
 
 	for {

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    maxParallelForks = (Runtime.getRuntime().availableProcessors()/2).coerceAtLeast(1)
 }
 
 // JMH benchmark task

--- a/java/src/main/java/com/example/otelstef/MetricsReader.java
+++ b/java/src/main/java/com/example/otelstef/MetricsReader.java
@@ -100,4 +100,9 @@ public class MetricsReader {
         decoder.decode(record);
         return ReadResult.Success;
     }
+
+    // Returns the schema of the STEF stream being read.
+    public WireSchema getSchema() {
+        return base.getSchema();
+    }
 }

--- a/java/src/main/java/com/example/otelstef/ModifiedFieldsMultimap.java
+++ b/java/src/main/java/com/example/otelstef/ModifiedFieldsMultimap.java
@@ -43,7 +43,7 @@ public class ModifiedFieldsMultimap {
         if (index >= 64) {
             keys.markModified(~0L);
         } else {
-            keys.markModified(1 << index);
+            keys.markModified(1L << index);
         }
     }
     
@@ -51,7 +51,7 @@ public class ModifiedFieldsMultimap {
         if (index >= 64) {
             vals.markModified(~0L);
         } else {
-            vals.markModified(1 << index);
+            vals.markModified(1L << index);
         }
     }
     
@@ -92,6 +92,6 @@ public class ModifiedFieldsMultimap {
     
     // areKeysModified returns true if the length or any key was modified.
     boolean areKeysModified() {
-        return modifiedLen || keys.mask!=0;
+        return modifiedLen || keys.mask!=0L;
     }
 }

--- a/java/src/main/java/com/example/otelstef/SpansReader.java
+++ b/java/src/main/java/com/example/otelstef/SpansReader.java
@@ -100,4 +100,9 @@ public class SpansReader {
         decoder.decode(record);
         return ReadResult.Success;
     }
+
+    // Returns the schema of the STEF stream being read.
+    public WireSchema getSchema() {
+        return base.getSchema();
+    }
 }

--- a/stefc/generator/structs.go
+++ b/stefc/generator/structs.go
@@ -118,3 +118,24 @@ func (g *Generator) oStruct(str *genStructDef) error {
 
 	return g.lastErr
 }
+
+// StructTemplateModel is the data model passed to the struct template to facilitate autocompletion.
+type StructTemplateModel struct {
+	PackageName string
+	StructName  string
+	Fields      []StructFieldTemplateModel
+}
+
+// StructFieldTemplateModel is the data model passed to the struct template to facilitate autocompletion.
+type StructFieldTemplateModel struct {
+	name          string
+	Name          string
+	Type          genFieldTypeRef
+	Optional      bool
+	FieldIndex    int
+	OptionalIndex int
+	ConstModifier string
+	PassByPtr     bool
+	IsPrimitive   bool
+	IsStructType  bool
+}

--- a/stefc/makefile
+++ b/stefc/makefile
@@ -2,7 +2,11 @@
 default: test
 
 .PHONY: all
-all: test build
+all: all-test build
+
+.PHONY: test
+all-test:
+	STEF_ENABLE_SLOW_TESTS=1 make test
 
 .PHONY: test
 test:

--- a/stefc/templates/go/oneof.go.tmpl
+++ b/stefc/templates/go/oneof.go.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/splunk/stef/stefc/generator.StructTemplateModel*/ -}}
 package {{ .PackageName }}
 
 import (
@@ -349,6 +350,7 @@ func Cmp{{.StructName}}(left, right *{{.StructName}}) int {
 // random parameter as a deterministic generator. Only fields that exist
 // in the schema are mutated, allowing to generate data for specified schema.
 func (s *{{ .StructName }}) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
+    {{- if len .Fields }}
     // Get the field count for this oneof from the schema. If the schema specifies
     // fewer field count than the one we have in this code then we will not mutate
     // the type of the oneof to the choices that are not in the schema.
@@ -362,7 +364,7 @@ typeChanged := false
         s.SetType({{$.StructName }}Type(random.IntN(fieldCount+1)))
         typeChanged = true
     }
-
+    {{ end }}
     switch s.typ {
     {{- range .Fields }}
     case {{ $.StructName }}Type{{.Name}}:
@@ -510,7 +512,9 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
 // CollectColumns collects all buffers from all encoders into buf.
 func (e *{{ .StructName }}Encoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
     columnSet.SetBits(&e.buf)
+    {{- if len .Fields }}
     colIdx := 0
+    {{- end }}
     {{ range $i,$e := .Fields }}
     // Collect {{.Name}} field.
     if e.fieldCount <= {{$i}} {

--- a/stefc/templates/go/reader.go.tmpl
+++ b/stefc/templates/go/reader.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/splunk/stef/go/pkg"
+	"github.com/splunk/stef/go/pkg/schema"
 )
 
 type {{.StructName}}Reader struct {
@@ -126,4 +127,9 @@ func (r *{{.StructName}}Reader) nextFrame() error {
 
 	r.decoder.Continue()
 	return nil
+}
+
+// Schema returns the schema of the STEF stream being read.
+func (r *{{.StructName}}Reader) Schema() *schema.WireSchema {
+    return r.base.Schema
 }

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/splunk/stef/stefc/generator.StructTemplateModel*/ -}}
 package {{ .PackageName }}
 
 import (
@@ -482,6 +483,7 @@ func (s* {{.StructName}}) CopyFrom(src *{{.StructName}}) {
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
 func (s *{{ .StructName }}) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
+    {{- if len .Fields }}
     // Get the field count for this struct from the schema. If the schema specifies
     // fewer field count than the one we have in this code then we will not mutate
     // fields that are not in the schema.
@@ -491,6 +493,7 @@ func (s *{{ .StructName }}) mutateRandom(random *rand.Rand, schem *schema.Schema
     }
 
     const randRange = max({{len .Fields}},2) // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
+    {{ end }}
 
 {{ range $i, $e := .Fields }}
     if fieldCount <= {{$i}} {
@@ -839,7 +842,9 @@ func (e *{{ .StructName }}Encoder) Encode(val *{{ .StructName }}) {
 // CollectColumns collects all buffers from all encoders into buf.
 func (e *{{ .StructName }}Encoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
     columnSet.SetBits(&e.buf)
+    {{- if len .Fields }}
     colIdx := 0
+    {{- end }}
     {{- range $i,$e := .Fields }}
     // Collect {{.Name}} field.
     if e.fieldCount <= {{$i}} {
@@ -985,7 +990,9 @@ func (d *{{ .StructName }}Decoder) Decode(dstPtr {{if.DictName}}*{{end}}*{{.Stru
     val := dstPtr
     {{- end}}
 
+    {{ if len .Fields }}
     var err error
+    {{ end }}
 
     // Read bits that indicate which fields follow.
     {{if le (len .Fields) 56 -}}

--- a/stefc/templates/go/tools_test.go.tmpl
+++ b/stefc/templates/go/tools_test.go.tmpl
@@ -9,6 +9,10 @@ import (
 	"io"
 	"math/rand/v2"
 	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,15 +21,17 @@ import (
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var generateFlag = flag.Bool("generate", false, "stef -generate -root=structname -out=filename [-seed=seed]")
+var generateFlag = flag.Bool("generate", false, "stef -generate -root=structname -out=filename [-seed=seed] [-records=n] [-withschema]")
 
 var rootFlag = flag.String("root", "", "root struct name")
 var seedFlag = flag.Uint64("seed", 0, "non-zero seed for random number generation (optional, default is current time)")
-var countFlag = flag.Uint64("count", 1000, "number of records to generate (default is 1000)")
+var countFlag = flag.Uint64("records", 1000, "number of records to generate (default is 1000)")
 var outFlag = flag.String("out", "", "output file name for the generated data")
+var schemaFlag = flag.Bool("withschema", false, "to force specifying schema in the output file")
 
 var diffFlag = flag.Bool("diff", false, "stef -diff -root=structname file1 file2")
 var copyFlag = flag.Bool("copy", false, "stef -copy -root=structname input-file output-file")
+var compatFlag = flag.Bool("compat", false, "stef -compat -root=structname [-seed=seed] [-records=n]")
 
 func TestTool(t *testing.T) {
 	// This test can be invoked via command line to generate data, compare files, or copy data.
@@ -36,12 +42,12 @@ func TestTool(t *testing.T) {
 		if *rootFlag == "" || *outFlag == "" {
 			fmt.Println("Error: -root and -out flags are required for generation.")
 			flag.Usage()
-			os.Exit(1)
+			t.Fail()
 		}
-		err := generateData(*rootFlag, *outFlag, *seedFlag, *countFlag)
+		err := generateData(*rootFlag, *outFlag, *seedFlag, *countFlag, *schemaFlag)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			t.Fail()
 		}
 		return
 	}
@@ -50,12 +56,12 @@ func TestTool(t *testing.T) {
 		if len(flag.Args()) != 2 {
 			fmt.Println("Error: -diff requires exactly two file arguments.")
 			flag.Usage()
-			os.Exit(1)
+			t.Fail()
 		}
 		if *rootFlag == "" {
 			fmt.Println("Error: -root flag is required for diff.")
 			flag.Usage()
-			os.Exit(1)
+			t.Fail()
 		}
 		file1 := flag.Args()[0]
 		file2 := flag.Args()[1]
@@ -63,7 +69,7 @@ func TestTool(t *testing.T) {
 		err := diffData(*rootFlag, file1, file2)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			t.Fail()
 		}
 		return
 	}
@@ -72,20 +78,35 @@ func TestTool(t *testing.T) {
 		if len(flag.Args()) != 2 {
 			fmt.Println("Error: -copy requires exactly two file arguments.")
 			flag.Usage()
-			os.Exit(1)
+			t.Fail()
 		}
 		if *rootFlag == "" {
 			fmt.Println("Error: -root flag is required for copy.")
 			flag.Usage()
-			os.Exit(1)
+			t.Fail()
 		}
 		file1 := flag.Args()[0]
 		file2 := flag.Args()[1]
 
-		err := copyData(*rootFlag, file1, file2)
+		err := copyData(*rootFlag, file1, file2, *schemaFlag)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			t.Fail()
+		}
+		return
+	}
+
+	if *compatFlag {
+		if *rootFlag == "" {
+			fmt.Println("Error: -root flag is required for compat.")
+			flag.Usage()
+			t.Fail()
+		}
+
+		err := verifyCompat(*rootFlag, *seedFlag, *countFlag)
+		if err != nil {
+			fmt.Println(err)
+			t.Fail()
 		}
 		return
 	}
@@ -156,7 +177,7 @@ func diffData(rootStruct, fname1, fname2 string) error {
 }
 
 // copyData copies records from one STEF file to another for the specified root struct.
-func copyData(rootStruct, sourceFname, destFname string) (retErr error) {
+func copyData(rootStruct, sourceFname, destFname string, includeSchema bool) (retErr error) {
 	fmt.Printf("Copying content from %s to %s...\n", sourceFname, destFname)
 
 	// Open source file for reading
@@ -187,8 +208,14 @@ func copyData(rootStruct, sourceFname, destFname string) (retErr error) {
 		if err != nil {
 			return fmt.Errorf("Cannot create reader for %s: %v", sourceFname, err)
 		}
+		opts := pkg.WriterOptions{}
+		if includeSchema {
+		    // Include the schema from the source file in the copy.
+			opts.Schema = reader.Schema()
+			opts.IncludeDescriptor = true
+		}
 
-		writer, err := New{{$StructName}}Writer(dst, pkg.WriterOptions{})
+		writer, err := New{{$StructName}}Writer(dst, opts)
 		if err != nil {
 			return fmt.Errorf("Cannot create writer for %s: %v", destFname, err)
 		}
@@ -226,7 +253,7 @@ func copyData(rootStruct, sourceFname, destFname string) (retErr error) {
 }
 
 // generateData generates random records of the specified root struct and writes them to the output file.
-func generateData(rootStruct, outFileName string, randSeed uint64, recordCount uint64) (retErr error) {
+func generateData(rootStruct, outFileName string, randSeed uint64, recordCount uint64, specifySchema bool) (retErr error) {
 	fmt.Printf("Generating %d random %s records...\n", recordCount, rootStruct)
 
 	outFile, err := os.Create(outFileName)
@@ -256,7 +283,8 @@ func generateData(rootStruct, outFileName string, randSeed uint64, recordCount u
 		random := rand.New(rand.NewPCG(randSeed, 0))
 
 		opts := pkg.WriterOptions{}
-		if random.IntN(2) == 0 { // Approx half of the times specify the schema in the writer.
+		if specifySchema || random.IntN(2) == 0 {
+		    // Specify the schema in the writer.
 			if random.IntN(2) == 0 { // Randomly shrink the schema.
 				// This is to test that the writer/reader can handle schema changes.
 				schema.ShrinkRandomly(random, schem)
@@ -295,3 +323,87 @@ func generateData(rootStruct, outFileName string, randSeed uint64, recordCount u
 		return fmt.Errorf("Unsupported root struct: %s", rootStruct)
 	}
 }
+
+func runGoTestTool(inDir string, args []string) error {
+	args = append([]string{"test", "-v", "-run=TestTool"}, args...)
+	cmd := exec.Command("go", args...)
+    var err error
+    cmd.Dir, err = filepath.Abs(inDir)
+    if err != nil {
+        return err
+    }
+
+    stdoutStderr, err := cmd.CombinedOutput()
+    if err != nil {
+        fmt.Printf("%s\n", stdoutStderr)
+        return fmt.Errorf("go test command failed: %v", err)
+    }
+    return nil
+}
+
+func verifyCompat(rootStruct string, randSeed uint64, recordCount uint64) (retErr error) {
+    fmt.Printf("Verifying backward compatibility for %s...\n", rootStruct)
+
+    if randSeed == 0 {
+        randSeed = uint64(time.Now().UnixNano())
+    }
+    fmt.Printf("Using random seed: %d\n", randSeed)
+
+	switch rootStruct {
+{{ range $i, $StructName := .RootStructs }}
+	case "{{$StructName}}":
+		dataDir, err := filepath.Abs("tempdata")
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(dataDir, 0755); err!=nil {
+			return err
+		}
+
+		sourceFile := path.Join(dataDir, "gen_by_shrunk_MainRoot.stef")
+		copiedFile := path.Join(dataDir, "copied_from_shrunk_MainRoot.stef")
+
+        // Generate data using shrunk schema
+        shrunkPkgDir := "../shrunk/{{ $.PackageName }}"
+        err = runGoTestTool(shrunkPkgDir, []string{
+            "-generate",
+            "-root="+rootStruct,
+            "-seed="+strconv.FormatUint(randSeed, 10),
+            "-records="+strconv.FormatUint(recordCount, 10),
+            "-out="+sourceFile,
+            "-withschema", // Make sure schema is specified in generated file.
+        })
+        if err!=nil {
+            return err
+        }
+
+        // Copy using current schema
+        if err := copyData(rootStruct, sourceFile, copiedFile, true); err!=nil {
+            return err
+        }
+
+        // Diff using shrunk schema
+        err = runGoTestTool(shrunkPkgDir, []string{
+            "-diff",
+            "-root="+rootStruct,
+            sourceFile, copiedFile,
+        })
+        if err!=nil {
+            return err
+        }
+
+		return nil
+{{end}}
+	default:
+		return fmt.Errorf("Unsupported root struct: %s", rootStruct)
+	}
+}
+
+{{ range $i, $StructName := .RootStructs }}
+func Test{{$StructName}}BackwardCompatiblity(t *testing.T) {
+    if os.Getenv("STEF_ENABLE_SLOW_TESTS") != "1" {
+        t.Skip("Skipping slow test. Set STEF_ENABLE_SLOW_TESTS=1 to enable.")
+    }
+    verifyCompat("{{$StructName}}", 0, 10000)
+}
+{{end}}

--- a/stefc/templates/java/modifiedfieldsMultimap.java.tmpl
+++ b/stefc/templates/java/modifiedfieldsMultimap.java.tmpl
@@ -42,7 +42,7 @@ public class ModifiedFieldsMultimap {
         if (index >= 64) {
             keys.markModified(~0L);
         } else {
-            keys.markModified(1 << index);
+            keys.markModified(1L << index);
         }
     }
     
@@ -50,7 +50,7 @@ public class ModifiedFieldsMultimap {
         if (index >= 64) {
             vals.markModified(~0L);
         } else {
-            vals.markModified(1 << index);
+            vals.markModified(1L << index);
         }
     }
     
@@ -91,6 +91,6 @@ public class ModifiedFieldsMultimap {
     
     // areKeysModified returns true if the length or any key was modified.
     boolean areKeysModified() {
-        return modifiedLen || keys.mask!=0;
+        return modifiedLen || keys.mask!=0L;
     }
 }

--- a/stefc/templates/java/oneof.java.tmpl
+++ b/stefc/templates/java/oneof.java.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/splunk/stef/stefc/generator.StructTemplateModel*/ -}}
 // {{ .StructName }} Java class generated from template
 package {{ .PackageName }};
 
@@ -253,12 +254,14 @@ public class {{ .StructName }} {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random, CommonMutateRandomLimiter limiter) {
+        {{- if len .Fields }}
         int fieldCount = {{len .Fields}};
         boolean typeChanged = false;
         if (random.nextInt(10) == 0) {
             this.setType(Type.values()[random.nextInt(fieldCount + 1)]);
             typeChanged = true;
         }
+        {{- end}}
         switch (this.typ) {
         {{- range .Fields }}
         case Type{{.Name}}:

--- a/stefc/templates/java/oneofEncoder.java.tmpl
+++ b/stefc/templates/java/oneofEncoder.java.tmpl
@@ -105,7 +105,9 @@ class {{ .StructName }}Encoder {
     // collectColumns collects all buffers from all encoders into buf.
     public void collectColumns(WriteColumnSet columnSet) {
         columnSet.setBits(this.buf);
+        {{- if len .Fields }}
         int colIdx = 0;
+        {{- end}}
         {{ range $i,$e := .Fields }}
         // Collect {{.Name}} field.
         if (this.fieldCount <= {{$i}}) {

--- a/stefc/templates/java/reader.java.tmpl
+++ b/stefc/templates/java/reader.java.tmpl
@@ -99,4 +99,9 @@ public class {{.StructName}}Reader {
         decoder.decode(record);
         return ReadResult.Success;
     }
+
+    // Returns the schema of the STEF stream being read.
+    public WireSchema getSchema() {
+        return base.getSchema();
+    }
 }

--- a/stefc/templates/java/struct.java.tmpl
+++ b/stefc/templates/java/struct.java.tmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/splunk/stef/stefc/generator.StructTemplateModel*/ -}}
 // {{ .StructName }} Java class generated from template
 package {{ .PackageName }};
 
@@ -281,7 +282,9 @@ public class {{ .StructName }} {
 
     // mutateRandom mutates fields in a random, deterministic manner using random as a deterministic generator.
     void mutateRandom(Random random, CommonMutateRandomLimiter limiter) {
+        {{- if len .Fields }}
         final int fieldCount = Math.max({{len .Fields}},2); // At least 2 to ensure we don't recurse infinitely if there is only 1 field.
+        {{- end}}
         {{ range .Fields }}
         if (random.nextInt(fieldCount) == 0) {
             {{- if not .Type.IsPrimitive }}

--- a/stefc/templates/java/structEncoder.java.tmpl
+++ b/stefc/templates/java/structEncoder.java.tmpl
@@ -161,7 +161,9 @@ class {{ .StructName }}Encoder {
     // collectColumns collects all buffers from all encoders into buf.
     public void collectColumns(WriteColumnSet columnSet) {
         columnSet.setBits(this.buf);
+        {{- if len .Fields }}
         int colIdx = 0;
+        {{- end}}
         {{ range $i,$e := .Fields }}
         // Collect {{.Name}} field.
         if (this.fieldCount <= {{$i}}) {

--- a/stefc/templates/java/toolsTest.java.tmpl
+++ b/stefc/templates/java/toolsTest.java.tmpl
@@ -76,7 +76,7 @@ public class ToolsTest {
     }
 
     // copyData copies records from one STEF file to another for the specified root struct.
-    private void copyData(String rootStruct, String fname1, String fname2) throws Exception {
+    private void copyData(String rootStruct, String fname1, String fname2, boolean includeSchema) throws Exception {
         System.out.printf("Copying content from %s to %s...%n", fname1, fname2);
 
         try (FileInputStream sourceFile = new FileInputStream(fname1);
@@ -86,7 +86,11 @@ public class ToolsTest {
 {{ range $i, $StructName := .RootStructs }}
             case "{{$StructName}}": {
                 {{$StructName}}Reader reader = new {{$StructName}}Reader(sourceFile);
-                {{$StructName}}Writer writer = new {{$StructName}}Writer(new WrapChunkWriter(destFile), WriterOptions.builder().build());
+                WriterOptions.Builder optsBuilder = WriterOptions.builder();
+                if (includeSchema) {
+                    optsBuilder = optsBuilder.includeDescriptor(includeSchema).schema(reader.getSchema());
+                }
+                {{$StructName}}Writer writer = new {{$StructName}}Writer(new WrapChunkWriter(destFile), optsBuilder.build());
 
                 long recordCount = 0;
                 while (true) {
@@ -154,7 +158,9 @@ public class ToolsTest {
 
     private static final String packageFull = "{{ .PackageName }}";
     private static final String packageName = packageFull.substring(packageFull.lastIndexOf(".")+1);
-    private static String goPkgDir = "../stefc/generator/testdata/out/"+packageName+".stef/"+packageName;
+    private static String goDir = "../stefc/generator/testdata/out/"+packageName+".stef/";
+    private static String goPkgDir = goDir+packageName;
+    private static String goPkgShrunkDir = goDir+"shrunk/"+packageName;
 
     // runGoTest runs the Go test tool with the specified command line flags in the given directory.
     private int runGoTest(String inDir, String... command) throws Exception {
@@ -178,6 +184,7 @@ public class ToolsTest {
 
 {{ range $i, $StructName := .RootStructs }}
     @Test
+    // Test interoperability between Java and Go implementations for {{$StructName}}.
     void testFormatInterop{{$StructName}}() throws Exception {
         File tempDir = new File(goPkgDir+"/tempdata");
         if (!tempDir.exists()) {
@@ -192,31 +199,94 @@ public class ToolsTest {
             // Test interop: generate in Java, copy in Go, compare in Java.
 
             // Generate data using Java code
-            generateData("{{$StructName}}", goPkgDir+"/tempdata/{{$StructName}}_java_gen_for_go.stef", seed1, 1000);
+            generateData("{{$StructName}}", goPkgDir+"/tempdata/{{$StructName}}_java_gen_for_go.stef", seed1, 10000);
 
             // Run the Go test tool to create a copy of the data
-            int exitCode = runGoTest(goPkgDir,"-root={{$StructName}}", "-copy", "tempdata/{{$StructName}}_java_gen_for_go.stef", "tempdata/{{$StructName}}_go_copy_from_java.stef");
+            int exitCode = runGoTest(goPkgDir,
+                "-root={{$StructName}}",
+                "-copy",
+                "tempdata/{{$StructName}}_java_gen_for_go.stef",
+                "tempdata/{{$StructName}}_go_copy_from_java.stef");
             assertEquals(0, exitCode, "go test failed, seed " + seed1);
 
             // Verify that the generated data matches the copied data.
-            diffData("{{$StructName}}", goPkgDir+"/tempdata/{{$StructName}}_java_gen_for_go.stef", goPkgDir+"/tempdata/{{$StructName}}_go_copy_from_java.stef");
+            diffData("{{$StructName}}",
+                goPkgDir+"/tempdata/{{$StructName}}_java_gen_for_go.stef",
+                goPkgDir+"/tempdata/{{$StructName}}_go_copy_from_java.stef");
 
             // Now test the opposite direction: generate in Go, copy in Java, compare in Go.
 
             // Run the Go test tool to generate data
-            exitCode = runGoTest(goPkgDir,"-root={{$StructName}}", "-generate", "-seed="+seed1, "-out=tempdata/{{$StructName}}_go_gen_for_java.stef");
+            exitCode = runGoTest(goPkgDir,
+                "-root={{$StructName}}",
+                "-generate",
+                "-records=11000",
+                "-seed="+seed1,
+                "-out=tempdata/{{$StructName}}_go_gen_for_java.stef");
             assertEquals(0, exitCode, "go test failed, seed " + seed1);
 
             // Copy using Java code
-            copyData("{{$StructName}}", goPkgDir+"/tempdata/{{$StructName}}_go_gen_for_java.stef", goPkgDir+"/tempdata/{{$StructName}}_java_copy_from_go.stef");
+            copyData("{{$StructName}}",
+                goPkgDir+"/tempdata/{{$StructName}}_go_gen_for_java.stef",
+                goPkgDir+"/tempdata/{{$StructName}}_java_copy_from_go.stef",
+                false);
 
             // Run the Go test tool to compare data
-            exitCode = runGoTest(goPkgDir,"-root={{$StructName}}", "-diff", "tempdata/{{$StructName}}_go_gen_for_java.stef", "tempdata/{{$StructName}}_java_copy_from_go.stef");
+            exitCode = runGoTest(goPkgDir,
+                "-root={{$StructName}}",
+                "-diff",
+                "tempdata/{{$StructName}}_go_gen_for_java.stef",
+                "tempdata/{{$StructName}}_java_copy_from_go.stef");
             assertEquals(0, exitCode, "go test failed, seed " + seed1);
 
         } catch (Exception e) {
             fail("seed " + seed1 + ": " + e.getMessage());
         }
     }
+
+    @Test
+    // Test interoperability between this Java implementation and Go implementations
+    // of shrunk (older) version of schema for {{$StructName}}.
+    void testFormatInterop{{$StructName}}Compat() throws Exception {
+        File tempDir = new File(goPkgShrunkDir+"/tempdata");
+        if (!tempDir.exists()) {
+            assertTrue(tempDir.mkdir());
+        }
+
+        // Choose a seed (non-pseudo) randomly. We will print the seed
+        // on failure for easy reproduction.
+        long seed1 = System.nanoTime();
+
+        try {
+            // Generate in Go, copy in Java, compare in Go.
+
+            // Run the Go test tool to generate data
+            int exitCode = runGoTest(goPkgShrunkDir,
+                "-root={{$StructName}}",
+                "-generate",
+                "-withschema",
+                "-seed="+seed1,
+                "-out=tempdata/{{$StructName}}_go_gen_for_java.stef");
+            assertEquals(0, exitCode, "go test failed, seed " + seed1);
+
+            // Copy using Java code
+            copyData("{{$StructName}}",
+                goPkgShrunkDir+"/tempdata/{{$StructName}}_go_gen_for_java.stef",
+                goPkgShrunkDir+"/tempdata/{{$StructName}}_java_copy_from_go.stef",
+                true);
+
+            // Run the Go test tool to compare data
+            exitCode = runGoTest(goPkgShrunkDir,
+                "-root={{$StructName}}",
+                "-diff",
+                "tempdata/{{$StructName}}_go_gen_for_java.stef",
+                "tempdata/{{$StructName}}_java_copy_from_go.stef");
+            assertEquals(0, exitCode, "go test failed, seed " + seed1);
+
+        } catch (Exception e) {
+            fail("seed " + seed1 + ": " + e.getMessage());
+        }
+    }
+
 {{end}}
 }

--- a/stefc/templates/java/writerTest.java.tmpl
+++ b/stefc/templates/java/writerTest.java.tmpl
@@ -22,7 +22,7 @@ class {{.StructName}}WriterTest {
     // using the supplied Random generator. Generated records will be always
     // the same for the same input state of Random generator.
     static List<{{.StructName}}> gen{{.StructName}}Records(Random random) {
-        final int recCount = 1000;
+        final int recCount = 2000;
         List<{{.StructName}}> records = new ArrayList<>(recCount);
         {{.StructName}} record = new {{.StructName}}();
         for (int i = 0; i < recCount; i++) {


### PR DESCRIPTION
Resolves https://github.com/splunk/stef/issues/210

- Generate Go code for shrunk (old) version of all test schemas,
  place in "shrunk" subdirectory.
- Test backward compatibility of serializers by verifying interoperability
  of serializers of current and shrunk version.
- Similarly test backward compatibility interoperability test between
  Go and Java versions.
- Run Go generator tests and Java tests in parallel to speed up build.
- Fix bug in Java's ModifiedFieldsMultimap for indexes>=32