### PR TITLE
Rename "encoders" to "codecs" in Go

### DIFF
--- a/examples/ints/internal/ints/readerstate.go
+++ b/examples/ints/internal/ints/readerstate.go
@@ -2,11 +2,11 @@
 package ints
 
 import (
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type ReaderState struct {
 	StructFieldCounts StructFieldCounts

--- a/examples/ints/internal/ints/record.go
+++ b/examples/ints/internal/ints/record.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -212,7 +212,7 @@ type RecordEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	uint64Encoder encoders.Uint64Encoder
+	uint64Encoder codecs.Uint64Encoder
 
 	allocators *Allocators
 
@@ -316,7 +316,7 @@ type RecordDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	uint64Decoder encoders.Uint64Decoder
+	uint64Decoder codecs.Uint64Decoder
 
 	allocators *Allocators
 }

--- a/examples/ints/internal/ints/writerstate.go
+++ b/examples/ints/internal/ints/writerstate.go
@@ -3,10 +3,10 @@ package ints
 
 import (
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type WriterState struct {
 	limiter pkg.SizeLimiter

--- a/examples/jsonl/internal/jsonstef/jsonobject.go
+++ b/examples/jsonl/internal/jsonstef/jsonobject.go
@@ -7,11 +7,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // JsonObject is a multimap, (aka an associative array or a list) of key value
@@ -282,7 +282,7 @@ type JsonObjectEncoder struct {
 	columns pkg.WriteColumnSet
 	limiter *pkg.SizeLimiter
 
-	keyEncoder       *encoders.StringEncoder
+	keyEncoder       *codecs.StringEncoder
 	isKeyRecursive   bool
 	valueEncoder     *JsonValueEncoder
 	isValueRecursive bool
@@ -299,7 +299,7 @@ func (e *JsonObjectEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet
 	e.limiter = &state.limiter
 
 	var err error
-	e.keyEncoder = new(encoders.StringEncoder)
+	e.keyEncoder = new(codecs.StringEncoder)
 	err = e.keyEncoder.Init(e.limiter, columns.AddSubColumn())
 	if err != nil {
 		return nil
@@ -397,7 +397,7 @@ type JsonObjectDecoder struct {
 	buf    pkg.BytesReader
 	column *pkg.ReadableColumn
 
-	keyDecoder       *encoders.StringDecoder
+	keyDecoder       *codecs.StringDecoder
 	isKeyRecursive   bool
 	valueDecoder     *JsonValueDecoder
 	isValueRecursive bool
@@ -415,7 +415,7 @@ func (d *JsonObjectDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	d.column = columns.Column()
 
 	var err error
-	d.keyDecoder = new(encoders.StringDecoder)
+	d.keyDecoder = new(codecs.StringDecoder)
 	err = d.keyDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return nil

--- a/examples/jsonl/internal/jsonstef/jsonvalue.go
+++ b/examples/jsonl/internal/jsonstef/jsonvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 
 // JsonValue is a oneof struct.
 type JsonValue struct {
@@ -418,11 +418,11 @@ type JsonValueEncoder struct {
 	arrayEncoder     *JsonValueArrayEncoder
 	isArrayRecursive bool // Indicates Array field's type is recursive.
 
-	stringEncoder encoders.StringEncoder
+	stringEncoder codecs.StringEncoder
 
-	numberEncoder encoders.Float64Encoder
+	numberEncoder codecs.Float64Encoder
 
-	boolEncoder encoders.BoolEncoder
+	boolEncoder codecs.BoolEncoder
 }
 
 func (e *JsonValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) error {
@@ -642,11 +642,11 @@ type JsonValueDecoder struct {
 	arrayDecoder     *JsonValueArrayDecoder
 	isArrayRecursive bool
 
-	stringDecoder encoders.StringDecoder
+	stringDecoder codecs.StringDecoder
 
-	numberDecoder encoders.Float64Decoder
+	numberDecoder codecs.Float64Decoder
 
-	boolDecoder encoders.BoolDecoder
+	boolDecoder codecs.BoolDecoder
 
 	allocators *Allocators
 }

--- a/examples/jsonl/internal/jsonstef/jsonvaluearray.go
+++ b/examples/jsonl/internal/jsonstef/jsonvaluearray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // JsonValueArray is a variable size array.

--- a/examples/jsonl/internal/jsonstef/readerstate.go
+++ b/examples/jsonl/internal/jsonstef/readerstate.go
@@ -2,11 +2,11 @@
 package jsonstef
 
 import (
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type ReaderState struct {
 	StructFieldCounts StructFieldCounts

--- a/examples/jsonl/internal/jsonstef/record.go
+++ b/examples/jsonl/internal/jsonstef/record.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 

--- a/examples/jsonl/internal/jsonstef/writerstate.go
+++ b/examples/jsonl/internal/jsonstef/writerstate.go
@@ -3,10 +3,10 @@ package jsonstef
 
 import (
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type WriterState struct {
 	limiter pkg.SizeLimiter

--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -399,10 +399,10 @@ type FunctionEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	nameEncoder       encoders.StringDictEncoder
-	systemNameEncoder encoders.StringDictEncoder
-	filenameEncoder   encoders.StringDictEncoder
-	startLineEncoder  encoders.Uint64Encoder
+	nameEncoder       codecs.StringDictEncoder
+	systemNameEncoder codecs.StringDictEncoder
+	filenameEncoder   codecs.StringDictEncoder
+	startLineEncoder  codecs.Uint64Encoder
 
 	allocators *Allocators
 	dict       *FunctionEncoderDict
@@ -654,13 +654,13 @@ type FunctionDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	nameDecoder encoders.StringDictDecoder
+	nameDecoder codecs.StringDictDecoder
 
-	systemNameDecoder encoders.StringDictDecoder
+	systemNameDecoder codecs.StringDictDecoder
 
-	filenameDecoder encoders.StringDictDecoder
+	filenameDecoder codecs.StringDictDecoder
 
-	startLineDecoder encoders.Uint64Decoder
+	startLineDecoder codecs.Uint64Decoder
 
 	dict       *FunctionDecoderDict
 	allocators *Allocators

--- a/examples/profile/internal/profile/labels.go
+++ b/examples/profile/internal/profile/labels.go
@@ -7,11 +7,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // Labels is a multimap, (aka an associative array or a list) of key value
@@ -282,7 +282,7 @@ type LabelsEncoder struct {
 	columns pkg.WriteColumnSet
 	limiter *pkg.SizeLimiter
 
-	keyEncoder       *encoders.StringDictEncoder
+	keyEncoder       *codecs.StringDictEncoder
 	isKeyRecursive   bool
 	valueEncoder     *LabelValueEncoder
 	isValueRecursive bool
@@ -299,7 +299,7 @@ func (e *LabelsEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) er
 	e.limiter = &state.limiter
 
 	var err error
-	e.keyEncoder = new(encoders.StringDictEncoder)
+	e.keyEncoder = new(codecs.StringDictEncoder)
 	err = e.keyEncoder.Init(&state.LabelKey, e.limiter, columns.AddSubColumn())
 	if err != nil {
 		return nil
@@ -397,7 +397,7 @@ type LabelsDecoder struct {
 	buf    pkg.BytesReader
 	column *pkg.ReadableColumn
 
-	keyDecoder       *encoders.StringDictDecoder
+	keyDecoder       *codecs.StringDictDecoder
 	isKeyRecursive   bool
 	valueDecoder     *LabelValueDecoder
 	isValueRecursive bool
@@ -415,7 +415,7 @@ func (d *LabelsDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) err
 	d.column = columns.Column()
 
 	var err error
-	d.keyDecoder = new(encoders.StringDictDecoder)
+	d.keyDecoder = new(codecs.StringDictDecoder)
 	err = d.keyDecoder.Init(&state.LabelKey, columns.AddSubColumn())
 	if err != nil {
 		return nil

--- a/examples/profile/internal/profile/labelvalue.go
+++ b/examples/profile/internal/profile/labelvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 
 // LabelValue is a oneof struct.
 type LabelValue struct {
@@ -303,7 +303,7 @@ type LabelValueEncoder struct {
 	typeBitCount uint
 
 	// Field encoders.
-	strEncoder encoders.StringDictEncoder
+	strEncoder codecs.StringDictEncoder
 
 	numEncoder     *NumValueEncoder
 	isNumRecursive bool // Indicates Num field's type is recursive.
@@ -434,7 +434,7 @@ type LabelValueDecoder struct {
 
 	// Field decoders.
 
-	strDecoder encoders.StringDictDecoder
+	strDecoder codecs.StringDictDecoder
 
 	numDecoder     *NumValueDecoder
 	isNumRecursive bool

--- a/examples/profile/internal/profile/line.go
+++ b/examples/profile/internal/profile/line.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -373,8 +373,8 @@ type LineEncoder struct {
 
 	functionEncoder     *FunctionEncoder
 	isFunctionRecursive bool // Indicates Function field's type is recursive.
-	lineEncoder         encoders.Uint64Encoder
-	columnEncoder       encoders.Uint64Encoder
+	lineEncoder         codecs.Uint64Encoder
+	columnEncoder       codecs.Uint64Encoder
 
 	allocators *Allocators
 
@@ -539,9 +539,9 @@ type LineDecoder struct {
 
 	functionDecoder     *FunctionDecoder
 	isFunctionRecursive bool
-	lineDecoder         encoders.Uint64Decoder
+	lineDecoder         codecs.Uint64Decoder
 
-	columnDecoder encoders.Uint64Decoder
+	columnDecoder codecs.Uint64Decoder
 
 	allocators *Allocators
 }

--- a/examples/profile/internal/profile/linearray.go
+++ b/examples/profile/internal/profile/linearray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // LineArray is a variable size array.

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -457,10 +457,10 @@ type LocationEncoder struct {
 
 	mappingEncoder     *MappingEncoder
 	isMappingRecursive bool // Indicates Mapping field's type is recursive.
-	addressEncoder     encoders.Uint64Encoder
+	addressEncoder     codecs.Uint64Encoder
 	linesEncoder       *LineArrayEncoder
 	isLinesRecursive   bool // Indicates Lines field's type is recursive.
-	isFoldedEncoder    encoders.BoolEncoder
+	isFoldedEncoder    codecs.BoolEncoder
 
 	allocators *Allocators
 	dict       *LocationEncoderDict
@@ -736,11 +736,11 @@ type LocationDecoder struct {
 
 	mappingDecoder     *MappingDecoder
 	isMappingRecursive bool
-	addressDecoder     encoders.Uint64Decoder
+	addressDecoder     codecs.Uint64Decoder
 
 	linesDecoder     *LineArrayDecoder
 	isLinesRecursive bool
-	isFoldedDecoder  encoders.BoolDecoder
+	isFoldedDecoder  codecs.BoolDecoder
 
 	dict       *LocationDecoderDict
 	allocators *Allocators

--- a/examples/profile/internal/profile/locationarray.go
+++ b/examples/profile/internal/profile/locationarray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // LocationArray is a variable size array.

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -654,15 +654,15 @@ type MappingEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	memoryStartEncoder     encoders.Uint64Encoder
-	memoryLimitEncoder     encoders.Uint64Encoder
-	fileOffsetEncoder      encoders.Uint64Encoder
-	filenameEncoder        encoders.StringDictEncoder
-	buildIdEncoder         encoders.StringDictEncoder
-	hasFunctionsEncoder    encoders.BoolEncoder
-	hasFilenamesEncoder    encoders.BoolEncoder
-	hasLineNumbersEncoder  encoders.BoolEncoder
-	hasInlineFramesEncoder encoders.BoolEncoder
+	memoryStartEncoder     codecs.Uint64Encoder
+	memoryLimitEncoder     codecs.Uint64Encoder
+	fileOffsetEncoder      codecs.Uint64Encoder
+	filenameEncoder        codecs.StringDictEncoder
+	buildIdEncoder         codecs.StringDictEncoder
+	hasFunctionsEncoder    codecs.BoolEncoder
+	hasFilenamesEncoder    codecs.BoolEncoder
+	hasLineNumbersEncoder  codecs.BoolEncoder
+	hasInlineFramesEncoder codecs.BoolEncoder
 
 	allocators *Allocators
 	dict       *MappingEncoderDict
@@ -1034,23 +1034,23 @@ type MappingDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	memoryStartDecoder encoders.Uint64Decoder
+	memoryStartDecoder codecs.Uint64Decoder
 
-	memoryLimitDecoder encoders.Uint64Decoder
+	memoryLimitDecoder codecs.Uint64Decoder
 
-	fileOffsetDecoder encoders.Uint64Decoder
+	fileOffsetDecoder codecs.Uint64Decoder
 
-	filenameDecoder encoders.StringDictDecoder
+	filenameDecoder codecs.StringDictDecoder
 
-	buildIdDecoder encoders.StringDictDecoder
+	buildIdDecoder codecs.StringDictDecoder
 
-	hasFunctionsDecoder encoders.BoolDecoder
+	hasFunctionsDecoder codecs.BoolDecoder
 
-	hasFilenamesDecoder encoders.BoolDecoder
+	hasFilenamesDecoder codecs.BoolDecoder
 
-	hasLineNumbersDecoder encoders.BoolDecoder
+	hasLineNumbersDecoder codecs.BoolDecoder
 
-	hasInlineFramesDecoder encoders.BoolDecoder
+	hasInlineFramesDecoder codecs.BoolDecoder
 
 	dict       *MappingDecoderDict
 	allocators *Allocators

--- a/examples/profile/internal/profile/numvalue.go
+++ b/examples/profile/internal/profile/numvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -263,8 +263,8 @@ type NumValueEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	valEncoder  encoders.Int64Encoder
-	unitEncoder encoders.StringDictEncoder
+	valEncoder  codecs.Int64Encoder
+	unitEncoder codecs.StringDictEncoder
 
 	allocators *Allocators
 
@@ -392,9 +392,9 @@ type NumValueDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	valDecoder encoders.Int64Decoder
+	valDecoder codecs.Int64Decoder
 
-	unitDecoder encoders.StringDictDecoder
+	unitDecoder codecs.StringDictDecoder
 
 	allocators *Allocators
 }

--- a/examples/profile/internal/profile/profilemetadata.go
+++ b/examples/profile/internal/profile/profilemetadata.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -682,13 +682,13 @@ type ProfileMetadataEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	dropFramesEncoder            encoders.StringDictEncoder
-	keepFramesEncoder            encoders.StringDictEncoder
-	timeNanosEncoder             encoders.Int64Encoder
-	durationNanosEncoder         encoders.Int64Encoder
+	dropFramesEncoder            codecs.StringDictEncoder
+	keepFramesEncoder            codecs.StringDictEncoder
+	timeNanosEncoder             codecs.Int64Encoder
+	durationNanosEncoder         codecs.Int64Encoder
 	periodTypeEncoder            *SampleValueTypeEncoder
 	isPeriodTypeRecursive        bool // Indicates PeriodType field's type is recursive.
-	periodEncoder                encoders.Int64Encoder
+	periodEncoder                codecs.Int64Encoder
 	commentsEncoder              *StringArrayEncoder
 	isCommentsRecursive          bool // Indicates Comments field's type is recursive.
 	defaultSampleTypeEncoder     *SampleValueTypeEncoder
@@ -997,17 +997,17 @@ type ProfileMetadataDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	dropFramesDecoder encoders.StringDictDecoder
+	dropFramesDecoder codecs.StringDictDecoder
 
-	keepFramesDecoder encoders.StringDictDecoder
+	keepFramesDecoder codecs.StringDictDecoder
 
-	timeNanosDecoder encoders.Int64Decoder
+	timeNanosDecoder codecs.Int64Decoder
 
-	durationNanosDecoder encoders.Int64Decoder
+	durationNanosDecoder codecs.Int64Decoder
 
 	periodTypeDecoder     *SampleValueTypeDecoder
 	isPeriodTypeRecursive bool
-	periodDecoder         encoders.Int64Decoder
+	periodDecoder         codecs.Int64Decoder
 
 	commentsDecoder              *StringArrayDecoder
 	isCommentsRecursive          bool

--- a/examples/profile/internal/profile/readerstate.go
+++ b/examples/profile/internal/profile/readerstate.go
@@ -2,27 +2,27 @@
 package profile
 
 import (
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type ReaderState struct {
 	StructFieldCounts StructFieldCounts
 
 	// Dictionaries
-	BuildID         encoders.StringDictDecoderDict
-	Filename        encoders.StringDictDecoderDict
+	BuildID         codecs.StringDictDecoderDict
+	Filename        codecs.StringDictDecoderDict
 	Function        FunctionDecoderDict
-	FunctionName    encoders.StringDictDecoderDict
-	LabelKey        encoders.StringDictDecoderDict
-	LabelValue      encoders.StringDictDecoderDict
+	FunctionName    codecs.StringDictDecoderDict
+	LabelKey        codecs.StringDictDecoderDict
+	LabelValue      codecs.StringDictDecoderDict
 	Location        LocationDecoderDict
 	Mapping         MappingDecoderDict
-	NumValueUnit    encoders.StringDictDecoderDict
+	NumValueUnit    codecs.StringDictDecoderDict
 	SampleValueType SampleValueTypeDecoderDict
-	SystemName      encoders.StringDictDecoderDict
+	SystemName      codecs.StringDictDecoderDict
 
 	// Decoders that are being Init-ed, to detect recursion.
 	FunctionDecoder         *FunctionDecoder

--- a/examples/profile/internal/profile/sample.go
+++ b/examples/profile/internal/profile/sample.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 

--- a/examples/profile/internal/profile/samplevalue.go
+++ b/examples/profile/internal/profile/samplevalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -320,7 +320,7 @@ type SampleValueEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	valEncoder      encoders.Int64Encoder
+	valEncoder      codecs.Int64Encoder
 	type_Encoder    *SampleValueTypeEncoder
 	isTypeRecursive bool // Indicates Type field's type is recursive.
 
@@ -461,7 +461,7 @@ type SampleValueDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	valDecoder encoders.Int64Decoder
+	valDecoder codecs.Int64Decoder
 
 	type_Decoder    *SampleValueTypeDecoder
 	isTypeRecursive bool

--- a/examples/profile/internal/profile/samplevaluearray.go
+++ b/examples/profile/internal/profile/samplevaluearray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // SampleValueArray is a variable size array.

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -297,8 +297,8 @@ type SampleValueTypeEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	type_Encoder encoders.StringEncoder
-	unitEncoder  encoders.StringEncoder
+	type_Encoder codecs.StringEncoder
+	unitEncoder  codecs.StringEncoder
 
 	allocators *Allocators
 	dict       *SampleValueTypeEncoderDict
@@ -502,9 +502,9 @@ type SampleValueTypeDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	type_Decoder encoders.StringDecoder
+	type_Decoder codecs.StringDecoder
 
-	unitDecoder encoders.StringDecoder
+	unitDecoder codecs.StringDecoder
 
 	dict       *SampleValueTypeDecoderDict
 	allocators *Allocators

--- a/examples/profile/internal/profile/stringarray.go
+++ b/examples/profile/internal/profile/stringarray.go
@@ -10,11 +10,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // StringArray is a variable size array.
@@ -243,7 +243,7 @@ func (a *StringArray) mutateRandom(random *rand.Rand, schem *schema.Schema, limi
 type StringArrayEncoder struct {
 	buf         pkg.BitsWriter
 	limiter     *pkg.SizeLimiter
-	elemEncoder *encoders.StringEncoder
+	elemEncoder *codecs.StringEncoder
 	isRecursive bool
 	state       *WriterState
 }
@@ -252,7 +252,7 @@ func (e *StringArrayEncoder) Init(state *WriterState, columns *pkg.WriteColumnSe
 	e.state = state
 	e.limiter = &state.limiter
 
-	e.elemEncoder = new(encoders.StringEncoder)
+	e.elemEncoder = new(codecs.StringEncoder)
 	if err := e.elemEncoder.Init(e.limiter, columns.AddSubColumn()); err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (e *StringArrayEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 type StringArrayDecoder struct {
 	buf         pkg.BitsReader
 	column      *pkg.ReadableColumn
-	elemDecoder *encoders.StringDecoder
+	elemDecoder *codecs.StringDecoder
 	isRecursive bool
 	allocators  *Allocators
 }
@@ -301,7 +301,7 @@ type StringArrayDecoder struct {
 // Init is called once in the lifetime of the stream.
 func (d *StringArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) error {
 	d.column = columns.Column()
-	d.elemDecoder = new(encoders.StringDecoder)
+	d.elemDecoder = new(codecs.StringDecoder)
 	err := d.elemDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err

--- a/examples/profile/internal/profile/writerstate.go
+++ b/examples/profile/internal/profile/writerstate.go
@@ -3,10 +3,10 @@ package profile
 
 import (
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type WriterState struct {
 	limiter pkg.SizeLimiter
@@ -14,17 +14,17 @@ type WriterState struct {
 	StructFieldCounts StructFieldCounts
 
 	// Dictionaries
-	BuildID         encoders.StringDictEncoderDict
-	Filename        encoders.StringDictEncoderDict
+	BuildID         codecs.StringDictEncoderDict
+	Filename        codecs.StringDictEncoderDict
 	Function        FunctionEncoderDict
-	FunctionName    encoders.StringDictEncoderDict
-	LabelKey        encoders.StringDictEncoderDict
-	LabelValue      encoders.StringDictEncoderDict
+	FunctionName    codecs.StringDictEncoderDict
+	LabelKey        codecs.StringDictEncoderDict
+	LabelValue      codecs.StringDictEncoderDict
 	Location        LocationEncoderDict
 	Mapping         MappingEncoderDict
-	NumValueUnit    encoders.StringDictEncoderDict
+	NumValueUnit    codecs.StringDictEncoderDict
 	SampleValueType SampleValueTypeEncoderDict
-	SystemName      encoders.StringDictEncoderDict
+	SystemName      codecs.StringDictEncoderDict
 
 	// Encoders that are being Init-ed, to detect recursion.
 	FunctionEncoder         *FunctionEncoder

--- a/go/otel/otelstef/anyvalue.go
+++ b/go/otel/otelstef/anyvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 
 // AnyValue is a oneof struct.
 type AnyValue struct {
@@ -484,13 +484,13 @@ type AnyValueEncoder struct {
 	typeBitCount uint
 
 	// Field encoders.
-	stringEncoder encoders.StringDictEncoder
+	stringEncoder codecs.StringDictEncoder
 
-	boolEncoder encoders.BoolEncoder
+	boolEncoder codecs.BoolEncoder
 
-	int64Encoder encoders.Int64Encoder
+	int64Encoder codecs.Int64Encoder
 
-	float64Encoder encoders.Float64Encoder
+	float64Encoder codecs.Float64Encoder
 
 	arrayEncoder     *AnyValueArrayEncoder
 	isArrayRecursive bool // Indicates Array field's type is recursive.
@@ -498,7 +498,7 @@ type AnyValueEncoder struct {
 	kVListEncoder     *KeyValueListEncoder
 	isKVListRecursive bool // Indicates KVList field's type is recursive.
 
-	bytesEncoder encoders.BytesEncoder
+	bytesEncoder codecs.BytesEncoder
 }
 
 func (e *AnyValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) error {
@@ -762,13 +762,13 @@ type AnyValueDecoder struct {
 
 	// Field decoders.
 
-	stringDecoder encoders.StringDictDecoder
+	stringDecoder codecs.StringDictDecoder
 
-	boolDecoder encoders.BoolDecoder
+	boolDecoder codecs.BoolDecoder
 
-	int64Decoder encoders.Int64Decoder
+	int64Decoder codecs.Int64Decoder
 
-	float64Decoder encoders.Float64Decoder
+	float64Decoder codecs.Float64Decoder
 
 	arrayDecoder     *AnyValueArrayDecoder
 	isArrayRecursive bool
@@ -776,7 +776,7 @@ type AnyValueDecoder struct {
 	kVListDecoder     *KeyValueListDecoder
 	isKVListRecursive bool
 
-	bytesDecoder encoders.BytesDecoder
+	bytesDecoder codecs.BytesDecoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/anyvaluearray.go
+++ b/go/otel/otelstef/anyvaluearray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // AnyValueArray is a variable size array.

--- a/go/otel/otelstef/attributes.go
+++ b/go/otel/otelstef/attributes.go
@@ -7,11 +7,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // Attributes is a multimap, (aka an associative array or a list) of key value
@@ -282,7 +282,7 @@ type AttributesEncoder struct {
 	columns pkg.WriteColumnSet
 	limiter *pkg.SizeLimiter
 
-	keyEncoder       *encoders.StringDictEncoder
+	keyEncoder       *codecs.StringDictEncoder
 	isKeyRecursive   bool
 	valueEncoder     *AnyValueEncoder
 	isValueRecursive bool
@@ -299,7 +299,7 @@ func (e *AttributesEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet
 	e.limiter = &state.limiter
 
 	var err error
-	e.keyEncoder = new(encoders.StringDictEncoder)
+	e.keyEncoder = new(codecs.StringDictEncoder)
 	err = e.keyEncoder.Init(&state.AttributeKey, e.limiter, columns.AddSubColumn())
 	if err != nil {
 		return nil
@@ -397,7 +397,7 @@ type AttributesDecoder struct {
 	buf    pkg.BytesReader
 	column *pkg.ReadableColumn
 
-	keyDecoder       *encoders.StringDictDecoder
+	keyDecoder       *codecs.StringDictDecoder
 	isKeyRecursive   bool
 	valueDecoder     *AnyValueDecoder
 	isValueRecursive bool
@@ -415,7 +415,7 @@ func (d *AttributesDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet)
 	d.column = columns.Column()
 
 	var err error
-	d.keyDecoder = new(encoders.StringDictDecoder)
+	d.keyDecoder = new(codecs.StringDictDecoder)
 	err = d.keyDecoder.Init(&state.AttributeKey, columns.AddSubColumn())
 	if err != nil {
 		return nil

--- a/go/otel/otelstef/envelope.go
+++ b/go/otel/otelstef/envelope.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 

--- a/go/otel/otelstef/envelopeattributes.go
+++ b/go/otel/otelstef/envelopeattributes.go
@@ -7,11 +7,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // EnvelopeAttributes is a multimap, (aka an associative array or a list) of key value
@@ -285,9 +285,9 @@ type EnvelopeAttributesEncoder struct {
 	columns pkg.WriteColumnSet
 	limiter *pkg.SizeLimiter
 
-	keyEncoder       *encoders.StringEncoder
+	keyEncoder       *codecs.StringEncoder
 	isKeyRecursive   bool
-	valueEncoder     *encoders.BytesEncoder
+	valueEncoder     *codecs.BytesEncoder
 	isValueRecursive bool
 }
 
@@ -302,12 +302,12 @@ func (e *EnvelopeAttributesEncoder) Init(state *WriterState, columns *pkg.WriteC
 	e.limiter = &state.limiter
 
 	var err error
-	e.keyEncoder = new(encoders.StringEncoder)
+	e.keyEncoder = new(codecs.StringEncoder)
 	err = e.keyEncoder.Init(e.limiter, columns.AddSubColumn())
 	if err != nil {
 		return nil
 	}
-	e.valueEncoder = new(encoders.BytesEncoder)
+	e.valueEncoder = new(codecs.BytesEncoder)
 	err = e.valueEncoder.Init(e.limiter, columns.AddSubColumn())
 
 	return err
@@ -394,9 +394,9 @@ type EnvelopeAttributesDecoder struct {
 	buf    pkg.BytesReader
 	column *pkg.ReadableColumn
 
-	keyDecoder       *encoders.StringDecoder
+	keyDecoder       *codecs.StringDecoder
 	isKeyRecursive   bool
-	valueDecoder     *encoders.BytesDecoder
+	valueDecoder     *codecs.BytesDecoder
 	isValueRecursive bool
 }
 
@@ -412,13 +412,13 @@ func (d *EnvelopeAttributesDecoder) Init(state *ReaderState, columns *pkg.ReadCo
 	d.column = columns.Column()
 
 	var err error
-	d.keyDecoder = new(encoders.StringDecoder)
+	d.keyDecoder = new(codecs.StringDecoder)
 	err = d.keyDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return nil
 	}
 
-	d.valueDecoder = new(encoders.BytesDecoder)
+	d.valueDecoder = new(codecs.BytesDecoder)
 	err = d.valueDecoder.Init(columns.AddSubColumn())
 
 	return err

--- a/go/otel/otelstef/event.go
+++ b/go/otel/otelstef/event.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -364,11 +364,11 @@ type EventEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	nameEncoder                   encoders.StringDictEncoder
-	timeUnixNanoEncoder           encoders.Uint64Encoder
+	nameEncoder                   codecs.StringDictEncoder
+	timeUnixNanoEncoder           codecs.Uint64Encoder
 	attributesEncoder             *AttributesEncoder
 	isAttributesRecursive         bool // Indicates Attributes field's type is recursive.
-	droppedAttributesCountEncoder encoders.Uint64Encoder
+	droppedAttributesCountEncoder codecs.Uint64Encoder
 
 	allocators *Allocators
 
@@ -555,13 +555,13 @@ type EventDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	nameDecoder encoders.StringDictDecoder
+	nameDecoder codecs.StringDictDecoder
 
-	timeUnixNanoDecoder encoders.Uint64Decoder
+	timeUnixNanoDecoder codecs.Uint64Decoder
 
 	attributesDecoder             *AttributesDecoder
 	isAttributesRecursive         bool
-	droppedAttributesCountDecoder encoders.Uint64Decoder
+	droppedAttributesCountDecoder codecs.Uint64Decoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/eventarray.go
+++ b/go/otel/otelstef/eventarray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // EventArray is a variable size array.

--- a/go/otel/otelstef/exemplar.go
+++ b/go/otel/otelstef/exemplar.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -414,11 +414,11 @@ type ExemplarEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	timestampEncoder              encoders.Uint64Encoder
+	timestampEncoder              codecs.Uint64Encoder
 	valueEncoder                  *ExemplarValueEncoder
 	isValueRecursive              bool // Indicates Value field's type is recursive.
-	spanIDEncoder                 encoders.BytesEncoder
-	traceIDEncoder                encoders.BytesEncoder
+	spanIDEncoder                 codecs.BytesEncoder
+	traceIDEncoder                codecs.BytesEncoder
 	filteredAttributesEncoder     *AttributesEncoder
 	isFilteredAttributesRecursive bool // Indicates FilteredAttributes field's type is recursive.
 
@@ -642,13 +642,13 @@ type ExemplarDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	timestampDecoder encoders.Uint64Decoder
+	timestampDecoder codecs.Uint64Decoder
 
 	valueDecoder     *ExemplarValueDecoder
 	isValueRecursive bool
-	spanIDDecoder    encoders.BytesDecoder
+	spanIDDecoder    codecs.BytesDecoder
 
-	traceIDDecoder encoders.BytesDecoder
+	traceIDDecoder codecs.BytesDecoder
 
 	filteredAttributesDecoder     *AttributesDecoder
 	isFilteredAttributesRecursive bool

--- a/go/otel/otelstef/exemplararray.go
+++ b/go/otel/otelstef/exemplararray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // ExemplarArray is a variable size array.

--- a/go/otel/otelstef/exemplarvalue.go
+++ b/go/otel/otelstef/exemplarvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 
 // ExemplarValue is a oneof struct.
 type ExemplarValue struct {
@@ -302,9 +302,9 @@ type ExemplarValueEncoder struct {
 	typeBitCount uint
 
 	// Field encoders.
-	int64Encoder encoders.Int64Encoder
+	int64Encoder codecs.Int64Encoder
 
-	float64Encoder encoders.Float64Encoder
+	float64Encoder codecs.Float64Encoder
 }
 
 func (e *ExemplarValueEncoder) Init(state *WriterState, columns *pkg.WriteColumnSet) error {
@@ -419,9 +419,9 @@ type ExemplarValueDecoder struct {
 
 	// Field decoders.
 
-	int64Decoder encoders.Int64Decoder
+	int64Decoder codecs.Int64Decoder
 
-	float64Decoder encoders.Float64Decoder
+	float64Decoder codecs.Float64Decoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/exphistogrambuckets.go
+++ b/go/otel/otelstef/exphistogrambuckets.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -262,7 +262,7 @@ type ExpHistogramBucketsEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	offsetEncoder           encoders.Int64Encoder
+	offsetEncoder           codecs.Int64Encoder
 	bucketCountsEncoder     *Uint64ArrayEncoder
 	isBucketCountsRecursive bool // Indicates BucketCounts field's type is recursive.
 
@@ -403,7 +403,7 @@ type ExpHistogramBucketsDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	offsetDecoder encoders.Int64Decoder
+	offsetDecoder codecs.Int64Decoder
 
 	bucketCountsDecoder     *Uint64ArrayDecoder
 	isBucketCountsRecursive bool

--- a/go/otel/otelstef/exphistogramvalue.go
+++ b/go/otel/otelstef/exphistogramvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -785,17 +785,17 @@ type ExpHistogramValueEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	countEncoder               encoders.Uint64Encoder
-	sumEncoder                 encoders.Float64Encoder
-	minEncoder                 encoders.Float64Encoder
-	maxEncoder                 encoders.Float64Encoder
-	scaleEncoder               encoders.Int64Encoder
-	zeroCountEncoder           encoders.Uint64Encoder
+	countEncoder               codecs.Uint64Encoder
+	sumEncoder                 codecs.Float64Encoder
+	minEncoder                 codecs.Float64Encoder
+	maxEncoder                 codecs.Float64Encoder
+	scaleEncoder               codecs.Int64Encoder
+	zeroCountEncoder           codecs.Uint64Encoder
 	positiveBucketsEncoder     *ExpHistogramBucketsEncoder
 	isPositiveBucketsRecursive bool // Indicates PositiveBuckets field's type is recursive.
 	negativeBucketsEncoder     *ExpHistogramBucketsEncoder
 	isNegativeBucketsRecursive bool // Indicates NegativeBuckets field's type is recursive.
-	zeroThresholdEncoder       encoders.Float64Encoder
+	zeroThresholdEncoder       codecs.Float64Encoder
 
 	allocators *Allocators
 
@@ -1123,23 +1123,23 @@ type ExpHistogramValueDecoder struct {
 	column             *pkg.ReadableColumn
 	fieldCount         uint
 	optionalFieldCount uint
-	countDecoder       encoders.Uint64Decoder
+	countDecoder       codecs.Uint64Decoder
 
-	sumDecoder encoders.Float64Decoder
+	sumDecoder codecs.Float64Decoder
 
-	minDecoder encoders.Float64Decoder
+	minDecoder codecs.Float64Decoder
 
-	maxDecoder encoders.Float64Decoder
+	maxDecoder codecs.Float64Decoder
 
-	scaleDecoder encoders.Int64Decoder
+	scaleDecoder codecs.Int64Decoder
 
-	zeroCountDecoder encoders.Uint64Decoder
+	zeroCountDecoder codecs.Uint64Decoder
 
 	positiveBucketsDecoder     *ExpHistogramBucketsDecoder
 	isPositiveBucketsRecursive bool
 	negativeBucketsDecoder     *ExpHistogramBucketsDecoder
 	isNegativeBucketsRecursive bool
-	zeroThresholdDecoder       encoders.Float64Decoder
+	zeroThresholdDecoder       codecs.Float64Decoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/float64array.go
+++ b/go/otel/otelstef/float64array.go
@@ -10,11 +10,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // Float64Array is a variable size array.
@@ -243,7 +243,7 @@ func (a *Float64Array) mutateRandom(random *rand.Rand, schem *schema.Schema, lim
 type Float64ArrayEncoder struct {
 	buf         pkg.BitsWriter
 	limiter     *pkg.SizeLimiter
-	elemEncoder *encoders.Float64Encoder
+	elemEncoder *codecs.Float64Encoder
 	isRecursive bool
 	state       *WriterState
 }
@@ -252,7 +252,7 @@ func (e *Float64ArrayEncoder) Init(state *WriterState, columns *pkg.WriteColumnS
 	e.state = state
 	e.limiter = &state.limiter
 
-	e.elemEncoder = new(encoders.Float64Encoder)
+	e.elemEncoder = new(codecs.Float64Encoder)
 	if err := e.elemEncoder.Init(e.limiter, columns.AddSubColumn()); err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (e *Float64ArrayEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 type Float64ArrayDecoder struct {
 	buf         pkg.BitsReader
 	column      *pkg.ReadableColumn
-	elemDecoder *encoders.Float64Decoder
+	elemDecoder *codecs.Float64Decoder
 	isRecursive bool
 	allocators  *Allocators
 }
@@ -301,7 +301,7 @@ type Float64ArrayDecoder struct {
 // Init is called once in the lifetime of the stream.
 func (d *Float64ArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) error {
 	d.column = columns.Column()
-	d.elemDecoder = new(encoders.Float64Decoder)
+	d.elemDecoder = new(codecs.Float64Decoder)
 	err := d.elemDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err

--- a/go/otel/otelstef/histogramvalue.go
+++ b/go/otel/otelstef/histogramvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -582,10 +582,10 @@ type HistogramValueEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	countEncoder            encoders.Int64Encoder
-	sumEncoder              encoders.Float64Encoder
-	minEncoder              encoders.Float64Encoder
-	maxEncoder              encoders.Float64Encoder
+	countEncoder            codecs.Int64Encoder
+	sumEncoder              codecs.Float64Encoder
+	minEncoder              codecs.Float64Encoder
+	maxEncoder              codecs.Float64Encoder
 	bucketCountsEncoder     *Uint64ArrayEncoder
 	isBucketCountsRecursive bool // Indicates BucketCounts field's type is recursive.
 
@@ -808,13 +808,13 @@ type HistogramValueDecoder struct {
 	column             *pkg.ReadableColumn
 	fieldCount         uint
 	optionalFieldCount uint
-	countDecoder       encoders.Int64Decoder
+	countDecoder       codecs.Int64Decoder
 
-	sumDecoder encoders.Float64Decoder
+	sumDecoder codecs.Float64Decoder
 
-	minDecoder encoders.Float64Decoder
+	minDecoder codecs.Float64Decoder
 
-	maxDecoder encoders.Float64Decoder
+	maxDecoder codecs.Float64Decoder
 
 	bucketCountsDecoder     *Uint64ArrayDecoder
 	isBucketCountsRecursive bool

--- a/go/otel/otelstef/keyvaluelist.go
+++ b/go/otel/otelstef/keyvaluelist.go
@@ -7,11 +7,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // KeyValueList is a multimap, (aka an associative array or a list) of key value
@@ -282,7 +282,7 @@ type KeyValueListEncoder struct {
 	columns pkg.WriteColumnSet
 	limiter *pkg.SizeLimiter
 
-	keyEncoder       *encoders.StringEncoder
+	keyEncoder       *codecs.StringEncoder
 	isKeyRecursive   bool
 	valueEncoder     *AnyValueEncoder
 	isValueRecursive bool
@@ -299,7 +299,7 @@ func (e *KeyValueListEncoder) Init(state *WriterState, columns *pkg.WriteColumnS
 	e.limiter = &state.limiter
 
 	var err error
-	e.keyEncoder = new(encoders.StringEncoder)
+	e.keyEncoder = new(codecs.StringEncoder)
 	err = e.keyEncoder.Init(e.limiter, columns.AddSubColumn())
 	if err != nil {
 		return nil
@@ -397,7 +397,7 @@ type KeyValueListDecoder struct {
 	buf    pkg.BytesReader
 	column *pkg.ReadableColumn
 
-	keyDecoder       *encoders.StringDecoder
+	keyDecoder       *codecs.StringDecoder
 	isKeyRecursive   bool
 	valueDecoder     *AnyValueDecoder
 	isValueRecursive bool
@@ -415,7 +415,7 @@ func (d *KeyValueListDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSe
 	d.column = columns.Column()
 
 	var err error
-	d.keyDecoder = new(encoders.StringDecoder)
+	d.keyDecoder = new(codecs.StringDecoder)
 	err = d.keyDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return nil

--- a/go/otel/otelstef/link.go
+++ b/go/otel/otelstef/link.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -466,13 +466,13 @@ type LinkEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	traceIDEncoder                encoders.BytesEncoder
-	spanIDEncoder                 encoders.BytesEncoder
-	traceStateEncoder             encoders.StringEncoder
-	flagsEncoder                  encoders.Uint64Encoder
+	traceIDEncoder                codecs.BytesEncoder
+	spanIDEncoder                 codecs.BytesEncoder
+	traceStateEncoder             codecs.StringEncoder
+	flagsEncoder                  codecs.Uint64Encoder
 	attributesEncoder             *AttributesEncoder
 	isAttributesRecursive         bool // Indicates Attributes field's type is recursive.
-	droppedAttributesCountEncoder encoders.Uint64Encoder
+	droppedAttributesCountEncoder codecs.Uint64Encoder
 
 	allocators *Allocators
 
@@ -707,17 +707,17 @@ type LinkDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	traceIDDecoder encoders.BytesDecoder
+	traceIDDecoder codecs.BytesDecoder
 
-	spanIDDecoder encoders.BytesDecoder
+	spanIDDecoder codecs.BytesDecoder
 
-	traceStateDecoder encoders.StringDecoder
+	traceStateDecoder codecs.StringDecoder
 
-	flagsDecoder encoders.Uint64Decoder
+	flagsDecoder codecs.Uint64Decoder
 
 	attributesDecoder             *AttributesDecoder
 	isAttributesRecursive         bool
-	droppedAttributesCountDecoder encoders.Uint64Decoder
+	droppedAttributesCountDecoder codecs.Uint64Decoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/linkarray.go
+++ b/go/otel/otelstef/linkarray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // LinkArray is a variable size array.

--- a/go/otel/otelstef/metric.go
+++ b/go/otel/otelstef/metric.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -601,16 +601,16 @@ type MetricEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	nameEncoder                   encoders.StringDictEncoder
-	descriptionEncoder            encoders.StringDictEncoder
-	unitEncoder                   encoders.StringDictEncoder
-	type_Encoder                  encoders.Uint64Encoder
+	nameEncoder                   codecs.StringDictEncoder
+	descriptionEncoder            codecs.StringDictEncoder
+	unitEncoder                   codecs.StringDictEncoder
+	type_Encoder                  codecs.Uint64Encoder
 	metadataEncoder               *AttributesEncoder
 	isMetadataRecursive           bool // Indicates Metadata field's type is recursive.
 	histogramBoundsEncoder        *Float64ArrayEncoder
 	isHistogramBoundsRecursive    bool // Indicates HistogramBounds field's type is recursive.
-	aggregationTemporalityEncoder encoders.Uint64Encoder
-	monotonicEncoder              encoders.BoolEncoder
+	aggregationTemporalityEncoder codecs.Uint64Encoder
+	monotonicEncoder              codecs.BoolEncoder
 
 	allocators *Allocators
 	dict       *MetricEncoderDict
@@ -980,21 +980,21 @@ type MetricDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	nameDecoder encoders.StringDictDecoder
+	nameDecoder codecs.StringDictDecoder
 
-	descriptionDecoder encoders.StringDictDecoder
+	descriptionDecoder codecs.StringDictDecoder
 
-	unitDecoder encoders.StringDictDecoder
+	unitDecoder codecs.StringDictDecoder
 
-	type_Decoder encoders.Uint64Decoder
+	type_Decoder codecs.Uint64Decoder
 
 	metadataDecoder               *AttributesDecoder
 	isMetadataRecursive           bool
 	histogramBoundsDecoder        *Float64ArrayDecoder
 	isHistogramBoundsRecursive    bool
-	aggregationTemporalityDecoder encoders.Uint64Decoder
+	aggregationTemporalityDecoder codecs.Uint64Decoder
 
-	monotonicDecoder encoders.BoolDecoder
+	monotonicDecoder codecs.BoolDecoder
 
 	dict       *MetricDecoderDict
 	allocators *Allocators

--- a/go/otel/otelstef/metrics.go
+++ b/go/otel/otelstef/metrics.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 

--- a/go/otel/otelstef/point.go
+++ b/go/otel/otelstef/point.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -363,8 +363,8 @@ type PointEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	startTimestampEncoder encoders.Uint64Encoder
-	timestampEncoder      encoders.Uint64Encoder
+	startTimestampEncoder codecs.Uint64Encoder
+	timestampEncoder      codecs.Uint64Encoder
 	valueEncoder          *PointValueEncoder
 	isValueRecursive      bool // Indicates Value field's type is recursive.
 	exemplarsEncoder      *ExemplarArrayEncoder
@@ -566,9 +566,9 @@ type PointDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	startTimestampDecoder encoders.Uint64Decoder
+	startTimestampDecoder codecs.Uint64Decoder
 
-	timestampDecoder encoders.Uint64Decoder
+	timestampDecoder codecs.Uint64Decoder
 
 	valueDecoder         *PointValueDecoder
 	isValueRecursive     bool

--- a/go/otel/otelstef/pointvalue.go
+++ b/go/otel/otelstef/pointvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 
 // PointValue is a oneof struct.
 type PointValue struct {
@@ -413,9 +413,9 @@ type PointValueEncoder struct {
 	typeBitCount uint
 
 	// Field encoders.
-	int64Encoder encoders.Int64Encoder
+	int64Encoder codecs.Int64Encoder
 
-	float64Encoder encoders.Float64Encoder
+	float64Encoder codecs.Float64Encoder
 
 	histogramEncoder     *HistogramValueEncoder
 	isHistogramRecursive bool // Indicates Histogram field's type is recursive.
@@ -651,9 +651,9 @@ type PointValueDecoder struct {
 
 	// Field decoders.
 
-	int64Decoder encoders.Int64Decoder
+	int64Decoder codecs.Int64Decoder
 
-	float64Decoder encoders.Float64Decoder
+	float64Decoder codecs.Float64Decoder
 
 	histogramDecoder     *HistogramValueDecoder
 	isHistogramRecursive bool

--- a/go/otel/otelstef/quantilevalue.go
+++ b/go/otel/otelstef/quantilevalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -263,8 +263,8 @@ type QuantileValueEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	quantileEncoder encoders.Float64Encoder
-	valueEncoder    encoders.Float64Encoder
+	quantileEncoder codecs.Float64Encoder
+	valueEncoder    codecs.Float64Encoder
 
 	allocators *Allocators
 
@@ -392,9 +392,9 @@ type QuantileValueDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	quantileDecoder encoders.Float64Decoder
+	quantileDecoder codecs.Float64Decoder
 
-	valueDecoder encoders.Float64Decoder
+	valueDecoder codecs.Float64Decoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/quantilevaluearray.go
+++ b/go/otel/otelstef/quantilevaluearray.go
@@ -8,11 +8,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // QuantileValueArray is a variable size array.

--- a/go/otel/otelstef/readerstate.go
+++ b/go/otel/otelstef/readerstate.go
@@ -2,29 +2,29 @@
 package otelstef
 
 import (
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type ReaderState struct {
 	StructFieldCounts StructFieldCounts
 
 	// Dictionaries
-	AnyValueString    encoders.StringDictDecoderDict
-	AttributeKey      encoders.StringDictDecoderDict
+	AnyValueString    codecs.StringDictDecoderDict
+	AttributeKey      codecs.StringDictDecoderDict
 	Metric            MetricDecoderDict
-	MetricDescription encoders.StringDictDecoderDict
-	MetricName        encoders.StringDictDecoderDict
-	MetricUnit        encoders.StringDictDecoderDict
+	MetricDescription codecs.StringDictDecoderDict
+	MetricName        codecs.StringDictDecoderDict
+	MetricUnit        codecs.StringDictDecoderDict
 	Resource          ResourceDecoderDict
-	SchemaURL         encoders.StringDictDecoderDict
+	SchemaURL         codecs.StringDictDecoderDict
 	Scope             ScopeDecoderDict
-	ScopeName         encoders.StringDictDecoderDict
-	ScopeVersion      encoders.StringDictDecoderDict
-	SpanEventName     encoders.StringDictDecoderDict
-	SpanName          encoders.StringDictDecoderDict
+	ScopeName         codecs.StringDictDecoderDict
+	ScopeVersion      codecs.StringDictDecoderDict
+	SpanEventName     codecs.StringDictDecoderDict
+	SpanName          codecs.StringDictDecoderDict
 
 	// Decoders that are being Init-ed, to detect recursion.
 	AnyValueDecoder            *AnyValueDecoder

--- a/go/otel/otelstef/resource.go
+++ b/go/otel/otelstef/resource.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -347,10 +347,10 @@ type ResourceEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	schemaURLEncoder              encoders.StringDictEncoder
+	schemaURLEncoder              codecs.StringDictEncoder
 	attributesEncoder             *AttributesEncoder
 	isAttributesRecursive         bool // Indicates Attributes field's type is recursive.
-	droppedAttributesCountEncoder encoders.Uint64Encoder
+	droppedAttributesCountEncoder codecs.Uint64Encoder
 
 	allocators *Allocators
 	dict       *ResourceEncoderDict
@@ -589,11 +589,11 @@ type ResourceDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	schemaURLDecoder encoders.StringDictDecoder
+	schemaURLDecoder codecs.StringDictDecoder
 
 	attributesDecoder             *AttributesDecoder
 	isAttributesRecursive         bool
-	droppedAttributesCountDecoder encoders.Uint64Decoder
+	droppedAttributesCountDecoder codecs.Uint64Decoder
 
 	dict       *ResourceDecoderDict
 	allocators *Allocators

--- a/go/otel/otelstef/scope.go
+++ b/go/otel/otelstef/scope.go
@@ -11,12 +11,12 @@ import (
 	"modernc.org/b/v2"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -449,12 +449,12 @@ type ScopeEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	nameEncoder                   encoders.StringDictEncoder
-	versionEncoder                encoders.StringDictEncoder
-	schemaURLEncoder              encoders.StringDictEncoder
+	nameEncoder                   codecs.StringDictEncoder
+	versionEncoder                codecs.StringDictEncoder
+	schemaURLEncoder              codecs.StringDictEncoder
 	attributesEncoder             *AttributesEncoder
 	isAttributesRecursive         bool // Indicates Attributes field's type is recursive.
-	droppedAttributesCountEncoder encoders.Uint64Encoder
+	droppedAttributesCountEncoder codecs.Uint64Encoder
 
 	allocators *Allocators
 	dict       *ScopeEncoderDict
@@ -741,15 +741,15 @@ type ScopeDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	nameDecoder encoders.StringDictDecoder
+	nameDecoder codecs.StringDictDecoder
 
-	versionDecoder encoders.StringDictDecoder
+	versionDecoder codecs.StringDictDecoder
 
-	schemaURLDecoder encoders.StringDictDecoder
+	schemaURLDecoder codecs.StringDictDecoder
 
 	attributesDecoder             *AttributesDecoder
 	isAttributesRecursive         bool
-	droppedAttributesCountDecoder encoders.Uint64Decoder
+	droppedAttributesCountDecoder codecs.Uint64Decoder
 
 	dict       *ScopeDecoderDict
 	allocators *Allocators

--- a/go/otel/otelstef/span.go
+++ b/go/otel/otelstef/span.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -871,18 +871,18 @@ type SpanEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	traceIDEncoder                encoders.BytesEncoder
-	spanIDEncoder                 encoders.BytesEncoder
-	traceStateEncoder             encoders.StringEncoder
-	parentSpanIDEncoder           encoders.BytesEncoder
-	flagsEncoder                  encoders.Uint64Encoder
-	nameEncoder                   encoders.StringDictEncoder
-	kindEncoder                   encoders.Uint64Encoder
-	startTimeUnixNanoEncoder      encoders.Uint64Encoder
-	endTimeUnixNanoEncoder        encoders.Uint64Encoder
+	traceIDEncoder                codecs.BytesEncoder
+	spanIDEncoder                 codecs.BytesEncoder
+	traceStateEncoder             codecs.StringEncoder
+	parentSpanIDEncoder           codecs.BytesEncoder
+	flagsEncoder                  codecs.Uint64Encoder
+	nameEncoder                   codecs.StringDictEncoder
+	kindEncoder                   codecs.Uint64Encoder
+	startTimeUnixNanoEncoder      codecs.Uint64Encoder
+	endTimeUnixNanoEncoder        codecs.Uint64Encoder
 	attributesEncoder             *AttributesEncoder
 	isAttributesRecursive         bool // Indicates Attributes field's type is recursive.
-	droppedAttributesCountEncoder encoders.Uint64Encoder
+	droppedAttributesCountEncoder codecs.Uint64Encoder
 	eventsEncoder                 *EventArrayEncoder
 	isEventsRecursive             bool // Indicates Events field's type is recursive.
 	linksEncoder                  *LinkArrayEncoder
@@ -1348,27 +1348,27 @@ type SpanDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	traceIDDecoder encoders.BytesDecoder
+	traceIDDecoder codecs.BytesDecoder
 
-	spanIDDecoder encoders.BytesDecoder
+	spanIDDecoder codecs.BytesDecoder
 
-	traceStateDecoder encoders.StringDecoder
+	traceStateDecoder codecs.StringDecoder
 
-	parentSpanIDDecoder encoders.BytesDecoder
+	parentSpanIDDecoder codecs.BytesDecoder
 
-	flagsDecoder encoders.Uint64Decoder
+	flagsDecoder codecs.Uint64Decoder
 
-	nameDecoder encoders.StringDictDecoder
+	nameDecoder codecs.StringDictDecoder
 
-	kindDecoder encoders.Uint64Decoder
+	kindDecoder codecs.Uint64Decoder
 
-	startTimeUnixNanoDecoder encoders.Uint64Decoder
+	startTimeUnixNanoDecoder codecs.Uint64Decoder
 
-	endTimeUnixNanoDecoder encoders.Uint64Decoder
+	endTimeUnixNanoDecoder codecs.Uint64Decoder
 
 	attributesDecoder             *AttributesDecoder
 	isAttributesRecursive         bool
-	droppedAttributesCountDecoder encoders.Uint64Decoder
+	droppedAttributesCountDecoder codecs.Uint64Decoder
 
 	eventsDecoder     *EventArrayDecoder
 	isEventsRecursive bool

--- a/go/otel/otelstef/spans.go
+++ b/go/otel/otelstef/spans.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 

--- a/go/otel/otelstef/spanstatus.go
+++ b/go/otel/otelstef/spanstatus.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -263,8 +263,8 @@ type SpanStatusEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	messageEncoder encoders.StringEncoder
-	codeEncoder    encoders.Uint64Encoder
+	messageEncoder codecs.StringEncoder
+	codeEncoder    codecs.Uint64Encoder
 
 	allocators *Allocators
 
@@ -392,9 +392,9 @@ type SpanStatusDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	messageDecoder encoders.StringDecoder
+	messageDecoder codecs.StringDecoder
 
-	codeDecoder encoders.Uint64Decoder
+	codeDecoder codecs.Uint64Decoder
 
 	allocators *Allocators
 }

--- a/go/otel/otelstef/summaryvalue.go
+++ b/go/otel/otelstef/summaryvalue.go
@@ -9,12 +9,12 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 
@@ -313,8 +313,8 @@ type SummaryValueEncoder struct {
 	// restarts so that the data can be decoded from the frame start.
 	forceModifiedFields uint64
 
-	countEncoder              encoders.Uint64Encoder
-	sumEncoder                encoders.Float64Encoder
+	countEncoder              codecs.Uint64Encoder
+	sumEncoder                codecs.Float64Encoder
 	quantileValuesEncoder     *QuantileValueArrayEncoder
 	isQuantileValuesRecursive bool // Indicates QuantileValues field's type is recursive.
 
@@ -479,9 +479,9 @@ type SummaryValueDecoder struct {
 	column     *pkg.ReadableColumn
 	fieldCount uint
 
-	countDecoder encoders.Uint64Decoder
+	countDecoder codecs.Uint64Decoder
 
-	sumDecoder encoders.Float64Decoder
+	sumDecoder codecs.Float64Decoder
 
 	quantileValuesDecoder     *QuantileValueArrayDecoder
 	isQuantileValuesRecursive bool

--- a/go/otel/otelstef/uint64array.go
+++ b/go/otel/otelstef/uint64array.go
@@ -10,11 +10,11 @@ import (
 	"unsafe"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // Uint64Array is a variable size array.
@@ -243,7 +243,7 @@ func (a *Uint64Array) mutateRandom(random *rand.Rand, schem *schema.Schema, limi
 type Uint64ArrayEncoder struct {
 	buf         pkg.BitsWriter
 	limiter     *pkg.SizeLimiter
-	elemEncoder *encoders.Uint64Encoder
+	elemEncoder *codecs.Uint64Encoder
 	isRecursive bool
 	state       *WriterState
 }
@@ -252,7 +252,7 @@ func (e *Uint64ArrayEncoder) Init(state *WriterState, columns *pkg.WriteColumnSe
 	e.state = state
 	e.limiter = &state.limiter
 
-	e.elemEncoder = new(encoders.Uint64Encoder)
+	e.elemEncoder = new(codecs.Uint64Encoder)
 	if err := e.elemEncoder.Init(e.limiter, columns.AddSubColumn()); err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (e *Uint64ArrayEncoder) CollectColumns(columnSet *pkg.WriteColumnSet) {
 type Uint64ArrayDecoder struct {
 	buf         pkg.BitsReader
 	column      *pkg.ReadableColumn
-	elemDecoder *encoders.Uint64Decoder
+	elemDecoder *codecs.Uint64Decoder
 	isRecursive bool
 	allocators  *Allocators
 }
@@ -301,7 +301,7 @@ type Uint64ArrayDecoder struct {
 // Init is called once in the lifetime of the stream.
 func (d *Uint64ArrayDecoder) Init(state *ReaderState, columns *pkg.ReadColumnSet) error {
 	d.column = columns.Column()
-	d.elemDecoder = new(encoders.Uint64Decoder)
+	d.elemDecoder = new(codecs.Uint64Decoder)
 	err := d.elemDecoder.Init(columns.AddSubColumn())
 	if err != nil {
 		return err

--- a/go/otel/otelstef/writerstate.go
+++ b/go/otel/otelstef/writerstate.go
@@ -3,10 +3,10 @@ package otelstef
 
 import (
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type WriterState struct {
 	limiter pkg.SizeLimiter
@@ -14,19 +14,19 @@ type WriterState struct {
 	StructFieldCounts StructFieldCounts
 
 	// Dictionaries
-	AnyValueString    encoders.StringDictEncoderDict
-	AttributeKey      encoders.StringDictEncoderDict
+	AnyValueString    codecs.StringDictEncoderDict
+	AttributeKey      codecs.StringDictEncoderDict
 	Metric            MetricEncoderDict
-	MetricDescription encoders.StringDictEncoderDict
-	MetricName        encoders.StringDictEncoderDict
-	MetricUnit        encoders.StringDictEncoderDict
+	MetricDescription codecs.StringDictEncoderDict
+	MetricName        codecs.StringDictEncoderDict
+	MetricUnit        codecs.StringDictEncoderDict
 	Resource          ResourceEncoderDict
-	SchemaURL         encoders.StringDictEncoderDict
+	SchemaURL         codecs.StringDictEncoderDict
 	Scope             ScopeEncoderDict
-	ScopeName         encoders.StringDictEncoderDict
-	ScopeVersion      encoders.StringDictEncoderDict
-	SpanEventName     encoders.StringDictEncoderDict
-	SpanName          encoders.StringDictEncoderDict
+	ScopeName         codecs.StringDictEncoderDict
+	ScopeVersion      codecs.StringDictEncoderDict
+	SpanEventName     codecs.StringDictEncoderDict
+	SpanName          codecs.StringDictEncoderDict
 
 	// Encoders that are being Init-ed, to detect recursion.
 	AnyValueEncoder            *AnyValueEncoder

--- a/go/pkg/codecs/bool.go
+++ b/go/pkg/codecs/bool.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import "github.com/splunk/stef/go/pkg"
 

--- a/go/pkg/codecs/bytes.go
+++ b/go/pkg/codecs/bytes.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import (
 	"github.com/splunk/stef/go/pkg"

--- a/go/pkg/codecs/bytesdict.go
+++ b/go/pkg/codecs/bytesdict.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import (
 	"github.com/splunk/stef/go/pkg"

--- a/go/pkg/codecs/float64.go
+++ b/go/pkg/codecs/float64.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import (
 	"math"

--- a/go/pkg/codecs/float64_test.go
+++ b/go/pkg/codecs/float64_test.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import (
 	"fmt"

--- a/go/pkg/codecs/int64.go
+++ b/go/pkg/codecs/int64.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 type Int64Encoder struct {
 	Uint64Encoder

--- a/go/pkg/codecs/string.go
+++ b/go/pkg/codecs/string.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import (
 	"github.com/splunk/stef/go/pkg"

--- a/go/pkg/codecs/stringdict.go
+++ b/go/pkg/codecs/stringdict.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import (
 	"errors"

--- a/go/pkg/codecs/uint64.go
+++ b/go/pkg/codecs/uint64.go
@@ -1,4 +1,4 @@
-package encoders
+package codecs
 
 import "github.com/splunk/stef/go/pkg"
 

--- a/stefc/generator/genschema.go
+++ b/stefc/generator/genschema.go
@@ -299,7 +299,7 @@ func (r *genPrimitiveTypeRef) EncoderType() string {
 	var prefix string
 	switch r.Lang {
 	case LangGo:
-		prefix = "encoders."
+		prefix = "codecs."
 	case LangJava:
 		prefix = ""
 	default:
@@ -307,7 +307,7 @@ func (r *genPrimitiveTypeRef) EncoderType() string {
 	}
 
 	if s, ok := primitiveTypeMangledNames[r.Type]; ok {
-		name := prefix + s // e.g. encoders.Uint64
+		name := prefix + s // e.g. codecs.Uint64
 		if r.Dict != "" {
 			name += "Dict"
 		}
@@ -330,7 +330,7 @@ func (r *genPrimitiveTypeRef) DictTypeNamePrefix() string {
 	var prefix string
 	switch r.Lang {
 	case LangGo:
-		prefix = "encoders."
+		prefix = "codecs."
 	case LangJava:
 		prefix = ""
 	default:

--- a/stefc/templates/go/allreaderstate.go.tmpl
+++ b/stefc/templates/go/allreaderstate.go.tmpl
@@ -1,11 +1,11 @@
 package {{ .PackageName }}
 
 import (
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
     "github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type ReaderState struct {
     StructFieldCounts StructFieldCounts

--- a/stefc/templates/go/allwriterstate.go.tmpl
+++ b/stefc/templates/go/allwriterstate.go.tmpl
@@ -2,10 +2,10 @@ package {{ .PackageName }}
 
 import (
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 
 type WriterState struct {
     limiter pkg.SizeLimiter

--- a/stefc/templates/go/array.go.tmpl
+++ b/stefc/templates/go/array.go.tmpl
@@ -9,11 +9,11 @@ import (
 	"strings"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // {{ .ArrayName }} is a variable size array.

--- a/stefc/templates/go/multimap.go.tmpl
+++ b/stefc/templates/go/multimap.go.tmpl
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
 	"github.com/splunk/stef/go/pkg/schema"
 )
 
-var _ = (*encoders.StringEncoder)(nil)
+var _ = (*codecs.StringEncoder)(nil)
 var _ = (*strings.Builder)(nil)
 
 // {{ .MultimapName }} is a multimap, (aka an associative array or a list) of key value

--- a/stefc/templates/go/oneof.go.tmpl
+++ b/stefc/templates/go/oneof.go.tmpl
@@ -12,12 +12,12 @@ import (
 	"modernc.org/b/v2"{{end}}
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
     "github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 
 // {{ .StructName }} is a oneof struct.
 type {{ .StructName }} struct {

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -12,12 +12,12 @@ import (
 	"modernc.org/b/v2"{{end}}
 
 	"github.com/splunk/stef/go/pkg"
-	"github.com/splunk/stef/go/pkg/encoders"
+	"github.com/splunk/stef/go/pkg/codecs"
     "github.com/splunk/stef/go/pkg/schema"
 )
 
 var _ = strings.Compare
-var _ = encoders.StringEncoder{}
+var _ = codecs.StringEncoder{}
 var _ = schema.WireSchema{}
 var _ = bytes.NewBuffer
 


### PR DESCRIPTION
We called them "codecs" in Java and "encoders" Go. For consistency, we now use "codecs" everywhere.