### PR TITLE
Fix mutateRandom bug for optionals

### DIFF
--- a/go/otel/otelstef/exphistogramvalue.go
+++ b/go/otel/otelstef/exphistogramvalue.go
@@ -158,9 +158,9 @@ func (s *ExpHistogramValue) markSumModified() {
 	s.modifiedFields.markModified(fieldModifiedExpHistogramValueSum)
 }
 
-// UnsetSum unsets the precense flag of Sum field. A subsequent HasSum() will return false.
+// UnsetSum unsets the presence flag of Sum field. A subsequent HasSum() will return false.
 func (s *ExpHistogramValue) UnsetSum() {
-	if s.optionalFieldsPresent&fieldPresentExpHistogramValueSum != 0 {
+	if s.HasSum() {
 		s.optionalFieldsPresent &= ^fieldPresentExpHistogramValueSum
 		s.markSumModified()
 	}
@@ -196,9 +196,9 @@ func (s *ExpHistogramValue) markMinModified() {
 	s.modifiedFields.markModified(fieldModifiedExpHistogramValueMin)
 }
 
-// UnsetMin unsets the precense flag of Min field. A subsequent HasMin() will return false.
+// UnsetMin unsets the presence flag of Min field. A subsequent HasMin() will return false.
 func (s *ExpHistogramValue) UnsetMin() {
-	if s.optionalFieldsPresent&fieldPresentExpHistogramValueMin != 0 {
+	if s.HasMin() {
 		s.optionalFieldsPresent &= ^fieldPresentExpHistogramValueMin
 		s.markMinModified()
 	}
@@ -234,9 +234,9 @@ func (s *ExpHistogramValue) markMaxModified() {
 	s.modifiedFields.markModified(fieldModifiedExpHistogramValueMax)
 }
 
-// UnsetMax unsets the precense flag of Max field. A subsequent HasMax() will return false.
+// UnsetMax unsets the presence flag of Max field. A subsequent HasMax() will return false.
 func (s *ExpHistogramValue) UnsetMax() {
-	if s.optionalFieldsPresent&fieldPresentExpHistogramValueMax != 0 {
+	if s.HasMax() {
 		s.optionalFieldsPresent &= ^fieldPresentExpHistogramValueMax
 		s.markMaxModified()
 	}

--- a/go/otel/otelstef/histogramvalue.go
+++ b/go/otel/otelstef/histogramvalue.go
@@ -143,9 +143,9 @@ func (s *HistogramValue) markSumModified() {
 	s.modifiedFields.markModified(fieldModifiedHistogramValueSum)
 }
 
-// UnsetSum unsets the precense flag of Sum field. A subsequent HasSum() will return false.
+// UnsetSum unsets the presence flag of Sum field. A subsequent HasSum() will return false.
 func (s *HistogramValue) UnsetSum() {
-	if s.optionalFieldsPresent&fieldPresentHistogramValueSum != 0 {
+	if s.HasSum() {
 		s.optionalFieldsPresent &= ^fieldPresentHistogramValueSum
 		s.markSumModified()
 	}
@@ -181,9 +181,9 @@ func (s *HistogramValue) markMinModified() {
 	s.modifiedFields.markModified(fieldModifiedHistogramValueMin)
 }
 
-// UnsetMin unsets the precense flag of Min field. A subsequent HasMin() will return false.
+// UnsetMin unsets the presence flag of Min field. A subsequent HasMin() will return false.
 func (s *HistogramValue) UnsetMin() {
-	if s.optionalFieldsPresent&fieldPresentHistogramValueMin != 0 {
+	if s.HasMin() {
 		s.optionalFieldsPresent &= ^fieldPresentHistogramValueMin
 		s.markMinModified()
 	}
@@ -219,9 +219,9 @@ func (s *HistogramValue) markMaxModified() {
 	s.modifiedFields.markModified(fieldModifiedHistogramValueMax)
 }
 
-// UnsetMax unsets the precense flag of Max field. A subsequent HasMax() will return false.
+// UnsetMax unsets the presence flag of Max field. A subsequent HasMax() will return false.
 func (s *HistogramValue) UnsetMax() {
-	if s.optionalFieldsPresent&fieldPresentHistogramValueMax != 0 {
+	if s.HasMax() {
 		s.optionalFieldsPresent &= ^fieldPresentHistogramValueMax
 		s.markMaxModified()
 	}

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -222,6 +222,24 @@ func (s *{{ $.StructName }}) Set{{.Name}}(v {{if .Type.Flags.PassByPtr}}*{{end}}
         {{- end}}
     }
 }
+{{else if .Optional}}
+// Set{{.Name}} sets the presence flag of {{.Name}} field. A subsequent Has{{.Name}}() will return true.
+// The value of the field will be set to initial state for the field type.
+func (s *{{ $.StructName }}) Set{{.Name}}() {
+    if !s.Has{{.Name}}() {
+        {{if .Type.Flags.StoreByPtr}}
+        if s.{{.name}} == nil {
+            s.{{.name}} = new({{ .Type.Storage }})
+            s.{{.name}}.init(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
+        }
+        {{end -}}
+        s.optionalFieldsPresent |= fieldPresent{{ $.StructName }}{{.Name}}
+        {{- if not .Type.IsPrimitive}}
+        s.{{.name}}.reset()
+        {{- end}}
+        s.mark{{.Name}}Modified()
+    }
+}
 {{end}}
 
 func (s *{{ $.StructName }}) mark{{.Name}}Modified() {
@@ -229,9 +247,9 @@ func (s *{{ $.StructName }}) mark{{.Name}}Modified() {
 }
 
 {{ if .Optional}}
-// Unset{{.Name}} unsets the precense flag of {{.Name}} field. A subsequent Has{{.Name}}() will return false.
+// Unset{{.Name}} unsets the presence flag of {{.Name}} field. A subsequent Has{{.Name}}() will return false.
 func (s *{{ $.StructName }}) Unset{{.Name}}() {
-    if s.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} != 0 {
+    if s.Has{{.Name}}() {
         s.optionalFieldsPresent &= ^fieldPresent{{ $.StructName }}{{.Name}}
         s.mark{{.Name}}Modified()
     }
@@ -513,16 +531,10 @@ func (s *{{ .StructName }}) mutateRandom(random *rand.Rand, schem *schema.Schema
         }
 
         if flipOptional {
-            // Flip the optional field presence bit.
-            s.optionalFieldsPresent ^= fieldPresent{{ $.StructName }}{{.Name}}
-            s.mark{{.Name}}Modified()
-            if s.optionalFieldsPresent & fieldPresent{{ $.StructName }}{{.Name}} !=0 {
-                {{if .Type.Flags.StoreByPtr}}
-                if s.{{.name}} == nil {
-                    s.{{.name}} = new({{ .Type.Storage }})
-                    s.{{.name}}.init(&s.modifiedFields, fieldModified{{ $.StructName }}{{.Name}})
-                }
-                {{end -}}
+            if s.Has{{.Name}}() {
+                s.Unset{{.Name}}()
+            } else {
+                s.Set{{.Name}}() // Mark as present.
                 s.{{.name}}.mutateRandom(random, schem, limiter)
             }
         }

--- a/stefc/templates/java/struct.java.tmpl
+++ b/stefc/templates/java/struct.java.tmpl
@@ -305,6 +305,8 @@ public class {{ .StructName }} {
                 if ((this.optionalFieldsPresent & fieldPresent{{.Name}}) !=0) {
                     if (this.{{.name}} == null) {
                         this.{{.name}} = new {{ .Type.Storage }}(this.modifiedFields, fieldModified{{.Name}});
+                    } else {
+                        this.{{.name}}.reset();
                     }
                     this.{{.name}}.mutateRandom(random, limiter);
                 } else {


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/327

Optionals fields were not correctly reset when they were flipped from unset to set state. This fixes it.