### PR TITLE
Add Test{{.StructName}}WriteReadLong

### DIFF
--- a/examples/ints/internal/ints/record.go
+++ b/examples/ints/internal/ints/record.go
@@ -166,6 +166,7 @@ func (s *Record) CopyFrom(src *Record) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Record) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/ints/internal/ints/recordwriter_test.go
+++ b/examples/ints/internal/ints/recordwriter_test.go
@@ -96,7 +96,6 @@ func testRecordWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
 					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
@@ -141,6 +140,69 @@ func TestRecordWriteRead(t *testing.T) {
 	succeeded = testRecordWriteReadSeed(t, seed)
 }
 
+func TestRecordWriteReadLong(t *testing.T) {
+	// Tests writing and reading a larger number of records
+	// in a single writer/reader session.
+
+	seed := uint64(time.Now().UnixNano())
+	random := rand.New(rand.NewPCG(seed, 0))
+
+	schem, err := idl.Parse([]byte(allSchemaContent), "")
+	require.NoError(t, err, "seed %v", seed)
+
+	schem, err = schem.PrunedForRoot("Record")
+	require.NoError(t, err, "seed %v", seed)
+
+	mem := &pkg.MemReaderWriter{}
+
+	writer, err := NewRecordWriter(mem, pkg.WriterOptions{Compression: pkg.CompressionZstd})
+	require.NoError(t, err, "seed %v", seed)
+
+	reader, err := NewRecordReader(mem)
+	require.NoError(t, err, "seed %v", seed)
+
+	iterations := 10
+	if os.Getenv("STEF_ENABLE_SLOW_TESTS") == "1" {
+		iterations = 100
+	}
+
+	var record Record
+	record.Init()
+
+	records := make([]Record, 1000)
+	for i := 0; i < iterations; i++ {
+		recCount := 1 + random.IntN(1000)
+		records = records[:recCount]
+
+		// Write some records.
+		for recIdx := range records {
+			limiter := &mutateRandomLimiter{}
+			record.mutateRandom(random, schem, limiter)
+			records[recIdx] = Record{}
+			records[recIdx].Init()
+			records[recIdx].CopyFrom(&record)
+			writer.Record.CopyFrom(&record)
+			err = writer.Write()
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+		}
+
+		// Flush to make sure the records are in the MemReaderWriter and can be
+		// read back.
+		err = writer.Flush()
+		require.NoError(t, err, "iteration %d seed %v", i, seed)
+
+		// Read the records back and compare.
+		for recIdx := range records {
+			err = reader.Read(pkg.ReadOptions{})
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+			require.True(t, reader.Record.IsEqual(&records[recIdx]), "record %d:%d seed %v", i, recIdx, seed)
+		}
+	}
+
+	err = reader.Read(pkg.ReadOptions{})
+	require.ErrorIs(t, err, io.EOF, seed)
+}
+
 func FuzzRecordReader(f *testing.F) {
 	f.Add([]byte(""))
 
@@ -155,9 +217,12 @@ func FuzzRecordReader(f *testing.F) {
 			require.NoError(f, err)
 
 			recCount := (1 << (2 * i)) - 1
+			var record Record
+			record.Init()
 			for range recCount {
 				limiter := &mutateRandomLimiter{}
-				writer.Record.mutateRandom(random, schem, limiter)
+				record.mutateRandom(random, schem, limiter)
+				writer.Record.CopyFrom(&record)
 				err = writer.Write()
 				require.NoError(f, err)
 			}

--- a/examples/jsonl/internal/jsonstef/record.go
+++ b/examples/jsonl/internal/jsonstef/record.go
@@ -195,6 +195,7 @@ func (s *Record) CopyFrom(src *Record) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Record) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/jsonl/internal/jsonstef/recordwriter_test.go
+++ b/examples/jsonl/internal/jsonstef/recordwriter_test.go
@@ -96,7 +96,6 @@ func testRecordWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
 					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
@@ -141,6 +140,69 @@ func TestRecordWriteRead(t *testing.T) {
 	succeeded = testRecordWriteReadSeed(t, seed)
 }
 
+func TestRecordWriteReadLong(t *testing.T) {
+	// Tests writing and reading a larger number of records
+	// in a single writer/reader session.
+
+	seed := uint64(time.Now().UnixNano())
+	random := rand.New(rand.NewPCG(seed, 0))
+
+	schem, err := idl.Parse([]byte(allSchemaContent), "")
+	require.NoError(t, err, "seed %v", seed)
+
+	schem, err = schem.PrunedForRoot("Record")
+	require.NoError(t, err, "seed %v", seed)
+
+	mem := &pkg.MemReaderWriter{}
+
+	writer, err := NewRecordWriter(mem, pkg.WriterOptions{Compression: pkg.CompressionZstd})
+	require.NoError(t, err, "seed %v", seed)
+
+	reader, err := NewRecordReader(mem)
+	require.NoError(t, err, "seed %v", seed)
+
+	iterations := 10
+	if os.Getenv("STEF_ENABLE_SLOW_TESTS") == "1" {
+		iterations = 100
+	}
+
+	var record Record
+	record.Init()
+
+	records := make([]Record, 1000)
+	for i := 0; i < iterations; i++ {
+		recCount := 1 + random.IntN(1000)
+		records = records[:recCount]
+
+		// Write some records.
+		for recIdx := range records {
+			limiter := &mutateRandomLimiter{}
+			record.mutateRandom(random, schem, limiter)
+			records[recIdx] = Record{}
+			records[recIdx].Init()
+			records[recIdx].CopyFrom(&record)
+			writer.Record.CopyFrom(&record)
+			err = writer.Write()
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+		}
+
+		// Flush to make sure the records are in the MemReaderWriter and can be
+		// read back.
+		err = writer.Flush()
+		require.NoError(t, err, "iteration %d seed %v", i, seed)
+
+		// Read the records back and compare.
+		for recIdx := range records {
+			err = reader.Read(pkg.ReadOptions{})
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+			require.True(t, reader.Record.IsEqual(&records[recIdx]), "record %d:%d seed %v", i, recIdx, seed)
+		}
+	}
+
+	err = reader.Read(pkg.ReadOptions{})
+	require.ErrorIs(t, err, io.EOF, seed)
+}
+
 func FuzzRecordReader(f *testing.F) {
 	f.Add([]byte(""))
 
@@ -155,9 +217,12 @@ func FuzzRecordReader(f *testing.F) {
 			require.NoError(f, err)
 
 			recCount := (1 << (2 * i)) - 1
+			var record Record
+			record.Init()
 			for range recCount {
 				limiter := &mutateRandomLimiter{}
-				writer.Record.mutateRandom(random, schem, limiter)
+				record.mutateRandom(random, schem, limiter)
+				writer.Record.CopyFrom(&record)
 				err = writer.Write()
 				require.NoError(f, err)
 			}

--- a/examples/profile/internal/profile/function.go
+++ b/examples/profile/internal/profile/function.go
@@ -299,6 +299,7 @@ func (s *Function) CopyFrom(src *Function) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Function) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/line.go
+++ b/examples/profile/internal/profile/line.go
@@ -284,6 +284,7 @@ func (s *Line) CopyFrom(src *Line) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Line) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/location.go
+++ b/examples/profile/internal/profile/location.go
@@ -345,6 +345,7 @@ func (s *Location) CopyFrom(src *Location) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Location) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/mapping.go
+++ b/examples/profile/internal/profile/mapping.go
@@ -479,6 +479,7 @@ func (s *Mapping) CopyFrom(src *Mapping) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Mapping) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/numvalue.go
+++ b/examples/profile/internal/profile/numvalue.go
@@ -202,6 +202,7 @@ func (s *NumValue) CopyFrom(src *NumValue) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *NumValue) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/profilemetadata.go
+++ b/examples/profile/internal/profile/profilemetadata.go
@@ -507,6 +507,7 @@ func (s *ProfileMetadata) CopyFrom(src *ProfileMetadata) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *ProfileMetadata) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/sample.go
+++ b/examples/profile/internal/profile/sample.go
@@ -276,6 +276,7 @@ func (s *Sample) CopyFrom(src *Sample) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Sample) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/samplevalue.go
+++ b/examples/profile/internal/profile/samplevalue.go
@@ -248,6 +248,7 @@ func (s *SampleValue) CopyFrom(src *SampleValue) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *SampleValue) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/samplevaluetype.go
+++ b/examples/profile/internal/profile/samplevaluetype.go
@@ -227,6 +227,7 @@ func (s *SampleValueType) CopyFrom(src *SampleValueType) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *SampleValueType) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/examples/profile/internal/profile/samplewriter_test.go
+++ b/examples/profile/internal/profile/samplewriter_test.go
@@ -96,7 +96,6 @@ func testSampleWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
 					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
@@ -141,6 +140,69 @@ func TestSampleWriteRead(t *testing.T) {
 	succeeded = testSampleWriteReadSeed(t, seed)
 }
 
+func TestSampleWriteReadLong(t *testing.T) {
+	// Tests writing and reading a larger number of records
+	// in a single writer/reader session.
+
+	seed := uint64(time.Now().UnixNano())
+	random := rand.New(rand.NewPCG(seed, 0))
+
+	schem, err := idl.Parse([]byte(allSchemaContent), "")
+	require.NoError(t, err, "seed %v", seed)
+
+	schem, err = schem.PrunedForRoot("Sample")
+	require.NoError(t, err, "seed %v", seed)
+
+	mem := &pkg.MemReaderWriter{}
+
+	writer, err := NewSampleWriter(mem, pkg.WriterOptions{Compression: pkg.CompressionZstd})
+	require.NoError(t, err, "seed %v", seed)
+
+	reader, err := NewSampleReader(mem)
+	require.NoError(t, err, "seed %v", seed)
+
+	iterations := 10
+	if os.Getenv("STEF_ENABLE_SLOW_TESTS") == "1" {
+		iterations = 100
+	}
+
+	var record Sample
+	record.Init()
+
+	records := make([]Sample, 1000)
+	for i := 0; i < iterations; i++ {
+		recCount := 1 + random.IntN(1000)
+		records = records[:recCount]
+
+		// Write some records.
+		for recIdx := range records {
+			limiter := &mutateRandomLimiter{}
+			record.mutateRandom(random, schem, limiter)
+			records[recIdx] = Sample{}
+			records[recIdx].Init()
+			records[recIdx].CopyFrom(&record)
+			writer.Record.CopyFrom(&record)
+			err = writer.Write()
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+		}
+
+		// Flush to make sure the records are in the MemReaderWriter and can be
+		// read back.
+		err = writer.Flush()
+		require.NoError(t, err, "iteration %d seed %v", i, seed)
+
+		// Read the records back and compare.
+		for recIdx := range records {
+			err = reader.Read(pkg.ReadOptions{})
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+			require.True(t, reader.Record.IsEqual(&records[recIdx]), "record %d:%d seed %v", i, recIdx, seed)
+		}
+	}
+
+	err = reader.Read(pkg.ReadOptions{})
+	require.ErrorIs(t, err, io.EOF, seed)
+}
+
 func FuzzSampleReader(f *testing.F) {
 	f.Add([]byte(""))
 
@@ -155,9 +217,12 @@ func FuzzSampleReader(f *testing.F) {
 			require.NoError(f, err)
 
 			recCount := (1 << (2 * i)) - 1
+			var record Sample
+			record.Init()
 			for range recCount {
 				limiter := &mutateRandomLimiter{}
-				writer.Record.mutateRandom(random, schem, limiter)
+				record.mutateRandom(random, schem, limiter)
+				writer.Record.CopyFrom(&record)
 				err = writer.Write()
 				require.NoError(f, err)
 			}

--- a/go/otel/otelstef/envelope.go
+++ b/go/otel/otelstef/envelope.go
@@ -168,6 +168,7 @@ func (s *Envelope) CopyFrom(src *Envelope) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Envelope) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/event.go
+++ b/go/otel/otelstef/event.go
@@ -277,6 +277,7 @@ func (s *Event) CopyFrom(src *Event) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Event) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/exemplar.go
+++ b/go/otel/otelstef/exemplar.go
@@ -313,6 +313,7 @@ func (s *Exemplar) CopyFrom(src *Exemplar) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Exemplar) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/exphistogrambuckets.go
+++ b/go/otel/otelstef/exphistogrambuckets.go
@@ -205,6 +205,7 @@ func (s *ExpHistogramBuckets) CopyFrom(src *ExpHistogramBuckets) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *ExpHistogramBuckets) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/exphistogramvalue.go
+++ b/go/otel/otelstef/exphistogramvalue.go
@@ -576,6 +576,7 @@ func (s *ExpHistogramValue) CopyFrom(src *ExpHistogramValue) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *ExpHistogramValue) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/histogramvalue.go
+++ b/go/otel/otelstef/histogramvalue.go
@@ -432,6 +432,7 @@ func (s *HistogramValue) CopyFrom(src *HistogramValue) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *HistogramValue) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/link.go
+++ b/go/otel/otelstef/link.go
@@ -349,6 +349,7 @@ func (s *Link) CopyFrom(src *Link) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Link) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/metric.go
+++ b/go/otel/otelstef/metric.go
@@ -446,6 +446,7 @@ func (s *Metric) CopyFrom(src *Metric) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Metric) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/metrics.go
+++ b/go/otel/otelstef/metrics.go
@@ -476,6 +476,7 @@ func (s *Metrics) CopyFrom(src *Metrics) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Metrics) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/metricswriter_test.go
+++ b/go/otel/otelstef/metricswriter_test.go
@@ -96,7 +96,6 @@ func testMetricsWriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
 					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
@@ -141,6 +140,69 @@ func TestMetricsWriteRead(t *testing.T) {
 	succeeded = testMetricsWriteReadSeed(t, seed)
 }
 
+func TestMetricsWriteReadLong(t *testing.T) {
+	// Tests writing and reading a larger number of records
+	// in a single writer/reader session.
+
+	seed := uint64(time.Now().UnixNano())
+	random := rand.New(rand.NewPCG(seed, 0))
+
+	schem, err := idl.Parse([]byte(allSchemaContent), "")
+	require.NoError(t, err, "seed %v", seed)
+
+	schem, err = schem.PrunedForRoot("Metrics")
+	require.NoError(t, err, "seed %v", seed)
+
+	mem := &pkg.MemReaderWriter{}
+
+	writer, err := NewMetricsWriter(mem, pkg.WriterOptions{Compression: pkg.CompressionZstd})
+	require.NoError(t, err, "seed %v", seed)
+
+	reader, err := NewMetricsReader(mem)
+	require.NoError(t, err, "seed %v", seed)
+
+	iterations := 10
+	if os.Getenv("STEF_ENABLE_SLOW_TESTS") == "1" {
+		iterations = 100
+	}
+
+	var record Metrics
+	record.Init()
+
+	records := make([]Metrics, 1000)
+	for i := 0; i < iterations; i++ {
+		recCount := 1 + random.IntN(1000)
+		records = records[:recCount]
+
+		// Write some records.
+		for recIdx := range records {
+			limiter := &mutateRandomLimiter{}
+			record.mutateRandom(random, schem, limiter)
+			records[recIdx] = Metrics{}
+			records[recIdx].Init()
+			records[recIdx].CopyFrom(&record)
+			writer.Record.CopyFrom(&record)
+			err = writer.Write()
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+		}
+
+		// Flush to make sure the records are in the MemReaderWriter and can be
+		// read back.
+		err = writer.Flush()
+		require.NoError(t, err, "iteration %d seed %v", i, seed)
+
+		// Read the records back and compare.
+		for recIdx := range records {
+			err = reader.Read(pkg.ReadOptions{})
+			require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+			require.True(t, reader.Record.IsEqual(&records[recIdx]), "record %d:%d seed %v", i, recIdx, seed)
+		}
+	}
+
+	err = reader.Read(pkg.ReadOptions{})
+	require.ErrorIs(t, err, io.EOF, seed)
+}
+
 func FuzzMetricsReader(f *testing.F) {
 	f.Add([]byte(""))
 
@@ -155,9 +217,12 @@ func FuzzMetricsReader(f *testing.F) {
 			require.NoError(f, err)
 
 			recCount := (1 << (2 * i)) - 1
+			var record Metrics
+			record.Init()
 			for range recCount {
 				limiter := &mutateRandomLimiter{}
-				writer.Record.mutateRandom(random, schem, limiter)
+				record.mutateRandom(random, schem, limiter)
+				writer.Record.CopyFrom(&record)
 				err = writer.Write()
 				require.NoError(f, err)
 			}

--- a/go/otel/otelstef/point.go
+++ b/go/otel/otelstef/point.go
@@ -277,6 +277,7 @@ func (s *Point) CopyFrom(src *Point) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Point) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/quantilevalue.go
+++ b/go/otel/otelstef/quantilevalue.go
@@ -202,6 +202,7 @@ func (s *QuantileValue) CopyFrom(src *QuantileValue) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *QuantileValue) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/resource.go
+++ b/go/otel/otelstef/resource.go
@@ -266,6 +266,7 @@ func (s *Resource) CopyFrom(src *Resource) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Resource) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/scope.go
+++ b/go/otel/otelstef/scope.go
@@ -338,6 +338,7 @@ func (s *Scope) CopyFrom(src *Scope) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Scope) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/span.go
+++ b/go/otel/otelstef/span.go
@@ -637,6 +637,7 @@ func (s *Span) CopyFrom(src *Span) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Span) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/spans.go
+++ b/go/otel/otelstef/spans.go
@@ -362,6 +362,7 @@ func (s *Spans) CopyFrom(src *Spans) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *Spans) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/spanstatus.go
+++ b/go/otel/otelstef/spanstatus.go
@@ -202,6 +202,7 @@ func (s *SpanStatus) CopyFrom(src *SpanStatus) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *SpanStatus) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/otel/otelstef/summaryvalue.go
+++ b/go/otel/otelstef/summaryvalue.go
@@ -241,6 +241,7 @@ func (s *SummaryValue) CopyFrom(src *SummaryValue) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *SummaryValue) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
 	// Get the field count for this struct from the schema. If the schema specifies
 	// fewer field count than the one we have in this code then we will not mutate

--- a/go/pkg/memreaderwriter.go
+++ b/go/pkg/memreaderwriter.go
@@ -1,0 +1,30 @@
+package pkg
+
+import "bytes"
+
+// MemReaderWriter is an in-memory implementation of ChunkWriter and ByteAndBlockReader interfaces
+// that allows to first write to the buffer and then read from it.
+// Typically used in tests.
+type MemReaderWriter struct {
+	buf bytes.Buffer
+}
+
+func (m *MemReaderWriter) ReadByte() (byte, error) {
+	return m.buf.ReadByte()
+}
+
+func (m *MemReaderWriter) Read(p []byte) (n int, err error) {
+	return m.buf.Read(p)
+}
+
+func (m *MemReaderWriter) WriteChunk(header []byte, content []byte) error {
+	if _, err := m.buf.Write(header); err != nil {
+		return err
+	}
+	_, err := m.buf.Write(content)
+	return err
+}
+
+func (m *MemReaderWriter) Bytes() []byte {
+	return m.buf.Bytes()
+}

--- a/stefc/templates/go/struct.go.tmpl
+++ b/stefc/templates/go/struct.go.tmpl
@@ -525,6 +525,7 @@ func (s* {{.StructName}}) CopyFrom(src *{{.StructName}}) {
 // mutateRandom mutates fields in a random, deterministic manner using
 // random parameter as a deterministic generator. Only fields that exist
 // in the schem are mutated, allowing to generate data for specified schema.
+// The state of "modified" flags is undefined after this operation.
 func (s *{{ .StructName }}) mutateRandom(random *rand.Rand, schem *schema.Schema, limiter *mutateRandomLimiter) {
     {{- if len .Fields }}
     // Get the field count for this struct from the schema. If the schema specifies

--- a/stefc/templates/go/writer_test.go.tmpl
+++ b/stefc/templates/go/writer_test.go.tmpl
@@ -95,7 +95,6 @@ func test{{.StructName}}WriteReadSeed(t *testing.T, seed uint64) (retVal bool) {
 				for i := 0; i < len(records); i++ {
 					err := reader.Read(pkg.ReadOptions{})
 					require.NoError(t, err, "record %d seed %v", i, seed)
-					require.NotNil(t, reader.Record, "record %d seed %v", i, seed)
 					require.True(t, reader.Record.IsEqual(&records[i]), "record %d seed %v", i, seed)
 				}
 				err = reader.Read(pkg.ReadOptions{})
@@ -140,6 +139,69 @@ func Test{{.StructName}}WriteRead(t *testing.T) {
     succeeded = test{{.StructName}}WriteReadSeed(t, seed)
 }
 
+func Test{{.StructName}}WriteReadLong(t *testing.T) {
+    // Tests writing and reading a larger number of records
+    // in a single writer/reader session.
+
+    seed := uint64(time.Now().UnixNano())
+    random := rand.New(rand.NewPCG(seed, 0))
+
+    schem, err := idl.Parse([]byte(allSchemaContent), "")
+    require.NoError(t, err, "seed %v", seed)
+
+    schem, err = schem.PrunedForRoot("{{.StructName}}")
+    require.NoError(t, err, "seed %v", seed)
+
+    mem := &pkg.MemReaderWriter{}
+
+    writer, err := New{{.StructName}}Writer(mem, pkg.WriterOptions{Compression: pkg.CompressionZstd})
+    require.NoError(t, err, "seed %v", seed)
+
+    reader, err := New{{.StructName}}Reader(mem)
+    require.NoError(t, err, "seed %v", seed)
+
+    iterations := 10
+    if os.Getenv("STEF_ENABLE_SLOW_TESTS") == "1" {
+        iterations = 100
+    }
+
+    var record {{.StructName}}
+    record.Init()
+
+    records := make([]{{.StructName}}, 1000)
+    for i := 0; i < iterations; i++ {
+        recCount := 1+random.IntN(1000)
+        records = records[:recCount]
+
+        // Write some records.
+        for recIdx := range records {
+            limiter := &mutateRandomLimiter{}
+            record.mutateRandom(random, schem, limiter)
+            records[recIdx] = {{.StructName}}{}
+            records[recIdx].Init()
+            records[recIdx].CopyFrom(&record)
+            writer.Record.CopyFrom(&record)
+            err = writer.Write()
+            require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+        }
+
+        // Flush to make sure the records are in the MemReaderWriter and can be
+        // read back.
+        err = writer.Flush()
+        require.NoError(t, err, "iteration %d seed %v", i, seed)
+
+        // Read the records back and compare.
+        for recIdx := range records {
+            err = reader.Read(pkg.ReadOptions{})
+            require.NoError(t, err, "record %d:%d seed %v", i, recIdx, seed)
+            require.True(t, reader.Record.IsEqual(&records[recIdx]), "record %d:%d seed %v", i, recIdx, seed)
+        }
+    }
+
+    err = reader.Read(pkg.ReadOptions{})
+    require.ErrorIs(t, err, io.EOF, seed)
+}
+
 func Fuzz{{.StructName}}Reader(f *testing.F) {
 	f.Add([]byte(""))
 
@@ -154,9 +216,12 @@ func Fuzz{{.StructName}}Reader(f *testing.F) {
             require.NoError(f, err)
 
             recCount := (1 << (2*i)) - 1
+            var record {{.StructName}}
+            record.Init()
             for range recCount {
                 limiter := &mutateRandomLimiter{}
-                writer.Record.mutateRandom(random, schem, limiter)
+                record.mutateRandom(random, schem, limiter)
+                writer.Record.CopyFrom(&record)
                 err = writer.Write()
                 require.NoError(f, err)
             }


### PR DESCRIPTION
The new test uses longer test sequences. The existing Test{{.StructName}}WriteRead uses short sequences and does not mutate the records enough to test all interesting codepaths. In the past we had bugs that were only visible when large number of record varieties were generated. The new test generates approximately 500000 records in the slow mode, compared to only 1000 records generated by existing Test{{.StructName}}WriteRead.