### PR TITLE
Exclude Protobuf generation from "all" target

### DIFF
--- a/examples/jsonl/makefile
+++ b/examples/jsonl/makefile
@@ -2,7 +2,7 @@
 default: build
 
 .PHONY: all
-all: generate default
+all: default
 
 .PHONY: build
 build:

--- a/go/grpc/makefile
+++ b/go/grpc/makefile
@@ -12,7 +12,7 @@ TEF_PROTO_FILES := $(wildcard ./proto/*.proto)
 default: test
 
 .PHONY: all
-all: genproto test
+all: test
 
 .PHONY: genproto
 genproto:

--- a/java/makefile
+++ b/java/makefile
@@ -23,7 +23,7 @@ PROTO_FLAGS := -I$(PROTO_DIR) --java_out=$(OUT_DIR) --grpc-java_out=$(OUT_DIR)
 
 .PHONY: all generate clean
 
-all: generate
+all:
 
 # Main code generation target
 generate: $(JAVA_FILES)


### PR DESCRIPTION
Protobuf generation does not need to happen during a regular build. This is only necessary when proto changes and that is very rare and can be run manually when needed.

Re-generation during "all" target currently causes the generated files to be updated unpredictably if the locally installed version of protoc is different. In the future we will want to fix this by using a fixed version of protoc tools.