### PR TITLE
Fix TestSchemaShrink

### DIFF
--- a/go/pkg/schema/schema_test.go
+++ b/go/pkg/schema/schema_test.go
@@ -601,14 +601,17 @@ func TestSchemaShrink(t *testing.T) {
 		require.NoError(t, err)
 
 		// Srhink it
-		ShrinkRandomly(r, shrinked)
+		if !ShrinkRandomly(r, shrinked) {
+			// Nothing to shrink anymore, schema is empty for the particular root
+			break
+		}
 		shrinkedWire := NewWireSchema(shrinked, "Metrics")
 		require.NoError(t, err)
 
 		// Shrinking is incompatible
 		origWire := NewWireSchema(orig, "Metrics")
 		compat, err := shrinkedWire.Compatible(&origWire)
-		require.Error(t, err)
+		require.Error(t, err, i)
 		require.EqualValues(t, CompatibilityIncompatible, compat)
 
 		// Opposite direction is compatible/superset

--- a/go/pkg/schema/utils.go
+++ b/go/pkg/schema/utils.go
@@ -8,7 +8,9 @@ import (
 // ShrinkRandomly will deterministically, pseudo-randomly shrink the provided
 // schema by removing the last field from one of the structs or oneofs.
 // This function is used for testing schema changes.
-func ShrinkRandomly(r *rand.Rand, schem *Schema) {
+// Returns true if the schema was changed, false if there was nothing to shrink,
+// i.e. the schema has no fields.
+func ShrinkRandomly(r *rand.Rand, schem *Schema) bool {
 	totalFieldCount := 0
 	var structNames []string
 	for structName := range schem.Structs {
@@ -17,7 +19,7 @@ func ShrinkRandomly(r *rand.Rand, schem *Schema) {
 	}
 	if totalFieldCount == 0 {
 		// Nothing to shrink
-		return
+		return false
 	}
 
 	sort.Strings(structNames)
@@ -26,7 +28,7 @@ func ShrinkRandomly(r *rand.Rand, schem *Schema) {
 		structName := structNames[r.IntN(len(structNames))]
 		str := schem.Structs[structName]
 		if shrinkStruct(r, schem, str) {
-			return
+			return true
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/splunk/stef/issues/338

The test was trying to shrink an empty schema and expecting to see it as a subset, which is impossible.

The test now stops if it reaches an empty schema, which is a valid situation and does not require further testing.

The bug was visible for seed 1769365654315626856.