### PR TITLE
Update benchmark charts to use unit sizes

### DIFF
--- a/benchmarks/benchmarks_test.go
+++ b/benchmarks/benchmarks_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"testing"
 
 	"github.com/go-echarts/go-echarts/v2/charts"
@@ -215,6 +216,14 @@ func BenchmarkDeserializeNative(b *testing.B) {
 	b.ReportAllocs()
 }
 
+func nsPerPoint(b *testing.B, dataPointCount int) float64 {
+	totalDpCount := b.N * dataPointCount
+	if totalDpCount == 0 {
+		return 0
+	}
+	return math.Round(float64(b.Elapsed().Nanoseconds()) / float64(totalDpCount))
+}
+
 func BenchmarkSerializeFromPdata(b *testing.B) {
 	chart.BeginChart("Serialization From pdata Speed", b)
 	defer chart.EndChart(
@@ -245,7 +254,7 @@ func BenchmarkSerializeFromPdata(b *testing.B) {
 						b,
 						encoding.LongName(),
 						"CPU time to serialize one data point",
-						float64(b.Elapsed().Nanoseconds())/float64(b.N*batch.DataPointCount()),
+						nsPerPoint(b, batch.DataPointCount()),
 					)
 				},
 			)
@@ -297,7 +306,7 @@ func BenchmarkDeserializeToPdata(b *testing.B) {
 						b,
 						encoding.LongName(),
 						"CPU time to deserialize one data point",
-						float64(b.Elapsed().Nanoseconds())/float64(b.N*batch.DataPointCount()),
+						nsPerPoint(b, batch.DataPointCount()),
 					)
 				},
 			)

--- a/benchmarks/charts.go
+++ b/benchmarks/charts.go
@@ -110,11 +110,16 @@ func (c *BarOutput) EndChart(unit string, globalopts ...charts.GlobalOpts) {
 	require.NoError(c.t, err)
 }
 
+func roundFloat(val float64, decimals int) float64 {
+	pow := math.Pow(10, float64(decimals))
+	return math.Round(val*pow) / pow
+}
+
 func (c *BarOutput) Record(b *testing.B, encoding string, series string, val float64) {
 	if b != nil {
 		b.ReportMetric(val, "ns/point")
 	}
-	c.results[encoding] = map[string]float64{series: math.Round(val)}
+	c.results[encoding] = map[string]float64{series: val}
 }
 
 func (c *BarOutput) RecordStacked(b *testing.B, encoding string, series string, val float64) {

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -9,186 +9,186 @@
 <body>
 <div/><h2>Size Benchmarks - One Large Batch</h2>
 <div class="container">
-    <div class="item" id="TAVUoEdzRpWo" style="width:900px;height:500px;"></div>
+    <div class="item" id="mhNYXQzBTgmQ" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_TAVUoEdzRpWo = echarts.init(document.getElementById('TAVUoEdzRpWo'), "white", { renderer: "canvas" });
-    let option_TAVUoEdzRpWo = {"animation":false,"color":["#92C5F9"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","stack":"stack","data":[{"value":1616100,"label":{"show":true}},{"value":5987068,"label":{"show":true}},{"value":1641063,"label":{"show":true}},{"value":3726272,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_mhNYXQzBTgmQ = echarts.init(document.getElementById('mhNYXQzBTgmQ'), "white", { renderer: "canvas" });
+    let option_mhNYXQzBTgmQ = {"animation":false,"color":["#92C5F9"],"legend":{},"series":[{"name":"Bytes/point (zstd)","type":"bar","stack":"stack","data":[{"value":2.1,"label":{"show":true}},{"value":7.6,"label":{"show":true}},{"value":2.1,"label":{"show":true}},{"value":4.7,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_TAVUoEdzRpWo.setOption(option_TAVUoEdzRpWo);
+    goecharts_mhNYXQzBTgmQ.setOption(option_mhNYXQzBTgmQ);
 </script>
 <div class="container">
-    <div class="item" id="CIGRGRTVJTFk" style="width:900px;height:500px;"></div>
+    <div class="item" id="duXTyxFhaUbc" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_CIGRGRTVJTFk = echarts.init(document.getElementById('CIGRGRTVJTFk'), "white", { renderer: "canvas" });
-    let option_CIGRGRTVJTFk = {"animation":false,"color":["#92C5F9"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","stack":"stack","data":[{"value":236899,"label":{"show":true}},{"value":210835,"label":{"show":true}},{"value":469789,"label":{"show":true}},{"value":95090,"label":{"show":true}},{"value":266394,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_duXTyxFhaUbc = echarts.init(document.getElementById('duXTyxFhaUbc'), "white", { renderer: "canvas" });
+    let option_duXTyxFhaUbc = {"animation":false,"color":["#92C5F9"],"legend":{},"series":[{"name":"Bytes/point (zstd)","type":"bar","stack":"stack","data":[{"value":3.5,"label":{"show":true}},{"value":3.1,"label":{"show":true}},{"value":7,"label":{"show":true}},{"value":1.4,"label":{"show":true}},{"value":4,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_CIGRGRTVJTFk.setOption(option_CIGRGRTVJTFk);
+    goecharts_duXTyxFhaUbc.setOption(option_duXTyxFhaUbc);
 </script>
 <div class="container">
-    <div class="item" id="yBhKHMaXfjbF" style="width:900px;height:500px;"></div>
+    <div class="item" id="zQAdWAuOvuVL" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_yBhKHMaXfjbF = echarts.init(document.getElementById('yBhKHMaXfjbF'), "white", { renderer: "canvas" });
-    let option_yBhKHMaXfjbF = {"animation":false,"color":["#92C5F9"],"legend":{},"series":[{"name":"Compressed size in bytes (zstd)","type":"bar","stack":"stack","data":[{"value":205525,"label":{"show":true}},{"value":133950,"label":{"show":true}},{"value":773929,"label":{"show":true}},{"value":79844,"label":{"show":true}},{"value":289397,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_zQAdWAuOvuVL = echarts.init(document.getElementById('zQAdWAuOvuVL'), "white", { renderer: "canvas" });
+    let option_zQAdWAuOvuVL = {"animation":false,"color":["#92C5F9"],"legend":{},"series":[{"name":"Bytes/point (zstd)","type":"bar","stack":"stack","data":[{"value":1,"label":{"show":true}},{"value":0.6,"label":{"show":true}},{"value":3.7,"label":{"show":true}},{"value":0.4,"label":{"show":true}},{"value":1.4,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics.zst"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_yBhKHMaXfjbF.setOption(option_yBhKHMaXfjbF);
+    goecharts_zQAdWAuOvuVL.setOption(option_zQAdWAuOvuVL);
 </script>
 <div/><h2>Size - Many Batches, Multipart Metrics</h2>
 <div class="container">
-    <div class="item" id="MtFUkkdJIjkU" style="width:900px;height:500px;"></div>
+    <div class="item" id="eZqTIwdXPLOE" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_MtFUkkdJIjkU = echarts.init(document.getElementById('MtFUkkdJIjkU'), "white", { renderer: "canvas" });
-    let option_MtFUkkdJIjkU = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","stack":"stack","data":[{"value":13571951,"label":{"show":true}},{"value":22219873,"label":{"show":true}},{"value":1493558,"label":{"show":true}},{"value":1559921,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_eZqTIwdXPLOE = echarts.init(document.getElementById('eZqTIwdXPLOE'), "white", { renderer: "canvas" });
+    let option_eZqTIwdXPLOE = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/point, compression=none","type":"bar","stack":"stack","data":[{"value":65.1,"label":{"show":true}},{"value":106.6,"label":{"show":true}},{"value":7.2,"label":{"show":true}},{"value":7.5,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_MtFUkkdJIjkU.setOption(option_MtFUkkdJIjkU);
+    goecharts_eZqTIwdXPLOE.setOption(option_eZqTIwdXPLOE);
 </script>
 <div class="container">
-    <div class="item" id="EHkISBtNtTlQ" style="width:900px;height:500px;"></div>
+    <div class="item" id="LMKXzmEckWXM" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_EHkISBtNtTlQ = echarts.init(document.getElementById('EHkISBtNtTlQ'), "white", { renderer: "canvas" });
-    let option_EHkISBtNtTlQ = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","stack":"stack","data":[{"value":92128187,"label":{"show":true}},{"value":145844039,"label":{"show":true}},{"value":10343709,"label":{"show":true}},{"value":10793486,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_LMKXzmEckWXM = echarts.init(document.getElementById('LMKXzmEckWXM'), "white", { renderer: "canvas" });
+    let option_LMKXzmEckWXM = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/point, compression=none","type":"bar","stack":"stack","data":[{"value":117.1,"label":{"show":true}},{"value":185.4,"label":{"show":true}},{"value":13.1,"label":{"show":true}},{"value":13.7,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_EHkISBtNtTlQ.setOption(option_EHkISBtNtTlQ);
+    goecharts_LMKXzmEckWXM.setOption(option_LMKXzmEckWXM);
 </script>
 <div class="container">
-    <div class="item" id="jtBLZhIHuZdq" style="width:900px;height:500px;"></div>
+    <div class="item" id="kgzywYCZSmMX" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_jtBLZhIHuZdq = echarts.init(document.getElementById('jtBLZhIHuZdq'), "white", { renderer: "canvas" });
-    let option_jtBLZhIHuZdq = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","stack":"stack","data":[{"value":1316311,"label":{"show":true}},{"value":2675305,"label":{"show":true}},{"value":246609,"label":{"show":true}},{"value":371536,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_kgzywYCZSmMX = echarts.init(document.getElementById('kgzywYCZSmMX'), "white", { renderer: "canvas" });
+    let option_kgzywYCZSmMX = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/point, compression=zstd","type":"bar","stack":"stack","data":[{"value":6.3,"label":{"show":true}},{"value":12.8,"label":{"show":true}},{"value":1.2,"label":{"show":true}},{"value":1.8,"label":{"show":true}}]}],"title":{"text":"Dataset: hostandcollector-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_jtBLZhIHuZdq.setOption(option_jtBLZhIHuZdq);
+    goecharts_kgzywYCZSmMX.setOption(option_kgzywYCZSmMX);
 </script>
 <div class="container">
-    <div class="item" id="GiZfhybJuPVM" style="width:900px;height:500px;"></div>
+    <div class="item" id="toJeCReVrfmk" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_GiZfhybJuPVM = echarts.init(document.getElementById('GiZfhybJuPVM'), "white", { renderer: "canvas" });
-    let option_GiZfhybJuPVM = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","stack":"stack","data":[{"value":11690516,"label":{"show":true}},{"value":19596366,"label":{"show":true}},{"value":3381914,"label":{"show":true}},{"value":4171492,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_toJeCReVrfmk = echarts.init(document.getElementById('toJeCReVrfmk'), "white", { renderer: "canvas" });
+    let option_toJeCReVrfmk = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/point, compression=zstd","type":"bar","stack":"stack","data":[{"value":14.9,"label":{"show":true}},{"value":24.9,"label":{"show":true}},{"value":4.3,"label":{"show":true}},{"value":5.3,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-otelmetrics"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/point"}]}
 
-    goecharts_GiZfhybJuPVM.setOption(option_GiZfhybJuPVM);
+    goecharts_toJeCReVrfmk.setOption(option_toJeCReVrfmk);
 </script>
 <div/><h2>Size - Many Batches, Multipart Traces</h2>
 <div class="container">
-    <div class="item" id="UICCTeGruDma" style="width:900px;height:500px;"></div>
+    <div class="item" id="bMndIWiJnJsm" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_UICCTeGruDma = echarts.init(document.getElementById('UICCTeGruDma'), "white", { renderer: "canvas" });
-    let option_UICCTeGruDma = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","stack":"stack","data":[{"value":39305351,"label":{"show":true}},{"value":6966007,"label":{"show":true}},{"value":6954788,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_bMndIWiJnJsm = echarts.init(document.getElementById('bMndIWiJnJsm'), "white", { renderer: "canvas" });
+    let option_bMndIWiJnJsm = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/span, compression=none","type":"bar","stack":"stack","data":[{"value":612.7,"label":{"show":true}},{"value":108.6,"label":{"show":true}},{"value":108.4,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/span"}]}
 
-    goecharts_UICCTeGruDma.setOption(option_UICCTeGruDma);
+    goecharts_bMndIWiJnJsm.setOption(option_bMndIWiJnJsm);
 </script>
 <div class="container">
-    <div class="item" id="OrSFcSAlAzPI" style="width:900px;height:500px;"></div>
+    <div class="item" id="RrVFABHLaCsX" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_OrSFcSAlAzPI = echarts.init(document.getElementById('OrSFcSAlAzPI'), "white", { renderer: "canvas" });
-    let option_OrSFcSAlAzPI = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","stack":"stack","data":[{"value":4238964,"label":{"show":true}},{"value":2660847,"label":{"show":true}},{"value":2664344,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_RrVFABHLaCsX = echarts.init(document.getElementById('RrVFABHLaCsX'), "white", { renderer: "canvas" });
+    let option_RrVFABHLaCsX = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/span, compression=zstd","type":"bar","stack":"stack","data":[{"value":66.1,"label":{"show":true}},{"value":41.5,"label":{"show":true}},{"value":41.5,"label":{"show":true}}]}],"title":{"text":"Dataset: astronomy-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/span"}]}
 
-    goecharts_OrSFcSAlAzPI.setOption(option_OrSFcSAlAzPI);
+    goecharts_RrVFABHLaCsX.setOption(option_RrVFABHLaCsX);
 </script>
 <div class="container">
-    <div class="item" id="IPSbyXcVzsPE" style="width:900px;height:500px;"></div>
+    <div class="item" id="xDMAyEwWYijf" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_IPSbyXcVzsPE = echarts.init(document.getElementById('IPSbyXcVzsPE'), "white", { renderer: "canvas" });
-    let option_IPSbyXcVzsPE = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=none","type":"bar","stack":"stack","data":[{"value":23778900,"label":{"show":true}},{"value":4865269,"label":{"show":true}},{"value":8083295,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_xDMAyEwWYijf = echarts.init(document.getElementById('xDMAyEwWYijf'), "white", { renderer: "canvas" });
+    let option_xDMAyEwWYijf = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/span, compression=none","type":"bar","stack":"stack","data":[{"value":274.6,"label":{"show":true}},{"value":56.2,"label":{"show":true}},{"value":93.4,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/span"}]}
 
-    goecharts_IPSbyXcVzsPE.setOption(option_IPSbyXcVzsPE);
+    goecharts_xDMAyEwWYijf.setOption(option_xDMAyEwWYijf);
 </script>
 <div class="container">
-    <div class="item" id="nNeWwbYZHiuS" style="width:900px;height:500px;"></div>
+    <div class="item" id="POVJLgRaxGIv" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_nNeWwbYZHiuS = echarts.init(document.getElementById('nNeWwbYZHiuS'), "white", { renderer: "canvas" });
-    let option_nNeWwbYZHiuS = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Size in bytes, compression=zstd","type":"bar","stack":"stack","data":[{"value":3267241,"label":{"show":true}},{"value":2195211,"label":{"show":true}},{"value":2415872,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes"}]}
+    let goecharts_POVJLgRaxGIv = echarts.init(document.getElementById('POVJLgRaxGIv'), "white", { renderer: "canvas" });
+    let option_POVJLgRaxGIv = {"animation":false,"color":["#87BB62"],"legend":{},"series":[{"name":"Bytes/span, compression=zstd","type":"bar","stack":"stack","data":[{"value":37.7,"label":{"show":true}},{"value":25.4,"label":{"show":true}},{"value":27.9,"label":{"show":true}}]}],"title":{"text":"Dataset: hipstershop-oteltraces"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"Bytes/span"}]}
 
-    goecharts_nNeWwbYZHiuS.setOption(option_nNeWwbYZHiuS);
+    goecharts_POVJLgRaxGIv.setOption(option_POVJLgRaxGIv);
 </script>
 <div/><h2>Speed Benchmarks</h2>
 <div class="container">
-    <div class="item" id="BsKOGfabDIAK" style="width:900px;height:500px;"></div>
+    <div class="item" id="HwTuqVLVNKbt" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_BsKOGfabDIAK = echarts.init(document.getElementById('BsKOGfabDIAK'), "white", { renderer: "canvas" });
-    let option_BsKOGfabDIAK = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"Serialize","type":"bar","stack":"stack","data":[{"value":1066,"label":{"show":true}},{"value":175,"label":{"show":true}},{"value":63,"label":{"show":true}},{"value":243,"label":{"show":true}}]},{"name":"Zstd Compress","type":"bar","stack":"stack","data":[{"value":186,"label":{"show":true}},{"value":178,"label":{"show":true}},{"value":13,"label":{"show":true}},{"value":50,"label":{"show":true}}]}],"title":{"text":"Serialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_HwTuqVLVNKbt = echarts.init(document.getElementById('HwTuqVLVNKbt'), "white", { renderer: "canvas" });
+    let option_HwTuqVLVNKbt = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"Serialize","type":"bar","stack":"stack","data":[{"value":1727,"label":{"show":true}},{"value":183,"label":{"show":true}},{"value":74,"label":{"show":true}},{"value":259,"label":{"show":true}}]},{"name":"Zstd Compress","type":"bar","stack":"stack","data":[{"value":187,"label":{"show":true}},{"value":180,"label":{"show":true}},{"value":9,"label":{"show":true}},{"value":51,"label":{"show":true}}]}],"title":{"text":"Serialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_BsKOGfabDIAK.setOption(option_BsKOGfabDIAK);
+    goecharts_HwTuqVLVNKbt.setOption(option_HwTuqVLVNKbt);
 </script>
 <div class="container">
-    <div class="item" id="czZmJECLrnyV" style="width:900px;height:500px;"></div>
+    <div class="item" id="vpRtwiczROmD" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_czZmJECLrnyV = echarts.init(document.getElementById('czZmJECLrnyV'), "white", { renderer: "canvas" });
-    let option_czZmJECLrnyV = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"Deserialize","type":"bar","stack":"stack","data":[{"value":2324,"label":{"show":true}},{"value":734,"label":{"show":true}},{"value":23,"label":{"show":true}},{"value":64,"label":{"show":true}}]},{"name":"Zstd Decompress","type":"bar","stack":"stack","data":[{"value":180,"label":{"show":true}},{"value":87,"label":{"show":true}},{"value":5,"label":{"show":true}},{"value":15,"label":{"show":true}}]}],"title":{"text":"Deserialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_vpRtwiczROmD = echarts.init(document.getElementById('vpRtwiczROmD'), "white", { renderer: "canvas" });
+    let option_vpRtwiczROmD = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"Deserialize","type":"bar","stack":"stack","data":[{"value":2292,"label":{"show":true}},{"value":751,"label":{"show":true}},{"value":21,"label":{"show":true}},{"value":64,"label":{"show":true}}]},{"name":"Zstd Decompress","type":"bar","stack":"stack","data":[{"value":180,"label":{"show":true}},{"value":88,"label":{"show":true}},{"value":4,"label":{"show":true}},{"value":15,"label":{"show":true}}]}],"title":{"text":"Deserialization Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_czZmJECLrnyV.setOption(option_czZmJECLrnyV);
+    goecharts_vpRtwiczROmD.setOption(option_vpRtwiczROmD);
 </script>
 <div class="container">
-    <div class="item" id="DuNXyIYTDSKS" style="width:900px;height:500px;"></div>
+    <div class="item" id="gMqQaTSlcxxK" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_DuNXyIYTDSKS = echarts.init(document.getElementById('DuNXyIYTDSKS'), "white", { renderer: "canvas" });
-    let option_DuNXyIYTDSKS = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","stack":"stack","data":[{"value":7596,"label":{"show":true}},{"value":2309,"label":{"show":true}},{"value":173,"label":{"show":true}},{"value":973,"label":{"show":true}},{"value":243,"label":{"show":true}}]},{"name":"Zstd Compress","type":"bar","stack":"stack","data":[{"value":74,"label":{"show":true}},{"value":188,"label":{"show":true}},{"value":182,"label":{"show":true}},{"value":9,"label":{"show":true}},{"value":51,"label":{"show":true}}]}],"title":{"text":"Serialization From pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_gMqQaTSlcxxK = echarts.init(document.getElementById('gMqQaTSlcxxK'), "white", { renderer: "canvas" });
+    let option_gMqQaTSlcxxK = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"CPU time to serialize one data point","type":"bar","stack":"stack","data":[{"value":8012,"label":{"show":true}},{"value":3033,"label":{"show":true}},{"value":173,"label":{"show":true}},{"value":1066,"label":{"show":true}},{"value":261,"label":{"show":true}}]},{"name":"Zstd Compress","type":"bar","stack":"stack","data":[{"value":75,"label":{"show":true}},{"value":186,"label":{"show":true}},{"value":179,"label":{"show":true}},{"value":9,"label":{"show":true}},{"value":51,"label":{"show":true}}]}],"title":{"text":"Serialization From pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_DuNXyIYTDSKS.setOption(option_DuNXyIYTDSKS);
+    goecharts_gMqQaTSlcxxK.setOption(option_gMqQaTSlcxxK);
 </script>
 <div class="container">
-    <div class="item" id="SJJJVJTwNrkS" style="width:900px;height:500px;"></div>
+    <div class="item" id="MJVGMZbHXfmT" style="width:900px;height:500px;"></div>
 </div>
 
     
  <script type="text/javascript">
     "use strict";
-    let goecharts_SJJJVJTwNrkS = echarts.init(document.getElementById('SJJJVJTwNrkS'), "white", { renderer: "canvas" });
-    let option_SJJJVJTwNrkS = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"CPU time to deserialize one data point","type":"bar","stack":"stack","data":[{"value":1493,"label":{"show":true}},{"value":2855,"label":{"show":true}},{"value":710,"label":{"show":true}},{"value":302,"label":{"show":true}},{"value":424,"label":{"show":true}}]},{"name":"Zstd Decompress","type":"bar","stack":"stack","data":[{"value":79,"label":{"show":true}},{"value":184,"label":{"show":true}},{"value":87,"label":{"show":true}},{"value":4,"label":{"show":true}},{"value":15,"label":{"show":true}}]}],"title":{"text":"Deserialization To pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
+    let goecharts_MJVGMZbHXfmT = echarts.init(document.getElementById('MJVGMZbHXfmT'), "white", { renderer: "canvas" });
+    let option_MJVGMZbHXfmT = {"animation":false,"color":["#92C5F9","#12C5F9"],"legend":{},"series":[{"name":"CPU time to deserialize one data point","type":"bar","stack":"stack","data":[{"value":1504,"label":{"show":true}},{"value":2959,"label":{"show":true}},{"value":726,"label":{"show":true}},{"value":306,"label":{"show":true}},{"value":427,"label":{"show":true}}]},{"name":"Zstd Decompress","type":"bar","stack":"stack","data":[{"value":79,"label":{"show":true}},{"value":180,"label":{"show":true}},{"value":88,"label":{"show":true}},{"value":4,"label":{"show":true}},{"value":15,"label":{"show":true}}]}],"title":{"text":"Deserialization To pdata Speed"},"toolbox":{},"tooltip":{},"xAxis":[{"data":["Otel Arrow","Parquet","Protobuf OTLP","STEF Sorted","STEF Unsorted"]}],"yAxis":[{"name":"ns/point"}]}
 
-    goecharts_SJJJVJTwNrkS.setOption(option_SJJJVJTwNrkS);
+    goecharts_MJVGMZbHXfmT.setOption(option_MJVGMZbHXfmT);
 </script>
 </body></html>


### PR DESCRIPTION
Instead of showing total byte sizes charts now show bytes per datapoint or per span, which is easier to compare for different datasets.