### PR TITLE
Enable test failures on TestRandomizedSchema

### DIFF
--- a/stefc/generator/generator_test.go
+++ b/stefc/generator/generator_test.go
@@ -294,7 +294,7 @@ func TestRandomizedSchema(t *testing.T) {
 	schemaContent := sch.PrettyPrint()
 
 	// Test the schema. Don't fail if generated code tests fail, just report the seed for now.
-	testSchema(t, []byte(schemaContent), "randomized.stef", false)
+	testSchema(t, []byte(schemaContent), "randomized.stef", true)
 
 	succeeded = true
 }


### PR DESCRIPTION
This was disabled previously and failures were merely showing as error messages in the output. The codebase is stable enough now that prolonged runs of TestRandomizedSchema no longer fail. We are now enabling failures so that any new random schema failure is caught immediately.