### PR TITLE
fix(pdata): return errors instead of panicking in OTLP-to-STEF conversion

### DIFF
--- a/go/pdata/metrics/internal/baseotlptostef_test.go
+++ b/go/pdata/metrics/internal/baseotlptostef_test.go
@@ -1,0 +1,87 @@
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/splunk/stef/go/otel/otelstef"
+)
+
+func TestConvertNumDatapoint_EmptyValueType(t *testing.T) {
+	c := &BaseOtlpToStef{}
+	dst := otelstef.NewPoint()
+	src := pmetric.NewNumberDataPoint()
+	src.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	// Don't set any value — ValueType will be NumberDataPointValueTypeEmpty
+
+	err := c.ConvertNumDatapoint(dst, src)
+	require.NoError(t, err)
+	assert.Equal(t, otelstef.PointValueTypeNone, dst.Value().Type())
+}
+
+func TestConvertNumDatapoint_IntValue(t *testing.T) {
+	c := &BaseOtlpToStef{}
+	dst := otelstef.NewPoint()
+	src := pmetric.NewNumberDataPoint()
+	src.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	src.SetIntValue(42)
+
+	err := c.ConvertNumDatapoint(dst, src)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), dst.Value().Int64())
+}
+
+func TestConvertNumDatapoint_DoubleValue(t *testing.T) {
+	c := &BaseOtlpToStef{}
+	dst := otelstef.NewPoint()
+	src := pmetric.NewNumberDataPoint()
+	src.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	src.SetDoubleValue(3.14)
+
+	err := c.ConvertNumDatapoint(dst, src)
+	require.NoError(t, err)
+	assert.InDelta(t, 3.14, dst.Value().Float64(), 0.001)
+}
+
+func TestConvertNumDatapoint_NoRecordedValue(t *testing.T) {
+	c := &BaseOtlpToStef{}
+	dst := otelstef.NewPoint()
+	src := pmetric.NewNumberDataPoint()
+	src.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	src.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+
+	err := c.ConvertNumDatapoint(dst, src)
+	require.NoError(t, err)
+	assert.Equal(t, otelstef.PointValueTypeNone, dst.Value().Type())
+}
+
+func TestAggregationTemporalityToStef_AllValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    pmetric.AggregationTemporality
+		expected otelstef.AggregationTemporality
+		wantErr  bool
+	}{
+		{name: "delta", input: pmetric.AggregationTemporalityDelta, expected: otelstef.AggregationTemporalityDelta},
+		{name: "cumulative", input: pmetric.AggregationTemporalityCumulative, expected: otelstef.AggregationTemporalityCumulative},
+		{name: "unspecified", input: pmetric.AggregationTemporalityUnspecified, expected: otelstef.AggregationTemporalityUnspecified},
+		{name: "unknown", input: pmetric.AggregationTemporality(99), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := AggregationTemporalityToStef(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/go/pdata/metrics/otlp2stef_unsorted_test.go
+++ b/go/pdata/metrics/otlp2stef_unsorted_test.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/splunk/stef/go/otel/otelstef"
+	"github.com/splunk/stef/go/pkg"
+)
+
+func TestConvertUnsorted_EmptyNumberDataPointValueType(t *testing.T) {
+	// Build metrics with a Gauge that has an empty value type data point.
+	// This previously caused a panic in ConvertNumDatapoint.
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("test_gauge")
+	m.SetEmptyGauge()
+	dp := m.Gauge().DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	// Don't set any value — ValueType will be NumberDataPointValueTypeEmpty
+
+	buf := &pkg.MemChunkWriter{}
+	writer, err := otelstef.NewMetricsWriter(buf, pkg.WriterOptions{})
+	require.NoError(t, err)
+
+	converter := OtlpToStefUnsorted{}
+	err = converter.Convert(metrics, writer)
+	require.NoError(t, err, "Convert should not panic or error on empty value type")
+
+	err = writer.Flush()
+	require.NoError(t, err)
+}
+
+func TestConvertUnsorted_MixedValueTypes(t *testing.T) {
+	// Build metrics with a mix of int, double, and empty value types.
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("test_gauge")
+	m.SetEmptyGauge()
+
+	// Data point with int value
+	dp1 := m.Gauge().DataPoints().AppendEmpty()
+	dp1.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	dp1.SetIntValue(42)
+
+	// Data point with empty value (previously caused panic)
+	dp2 := m.Gauge().DataPoints().AppendEmpty()
+	dp2.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	// Data point with double value
+	dp3 := m.Gauge().DataPoints().AppendEmpty()
+	dp3.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	dp3.SetDoubleValue(3.14)
+
+	buf := &pkg.MemChunkWriter{}
+	writer, err := otelstef.NewMetricsWriter(buf, pkg.WriterOptions{})
+	require.NoError(t, err)
+
+	converter := OtlpToStefUnsorted{}
+	err = converter.Convert(metrics, writer)
+	require.NoError(t, err)
+
+	err = writer.Flush()
+	require.NoError(t, err)
+
+	// All 3 data points should have been written
+	require.EqualValues(t, 3, writer.RecordCount())
+}
+
+func TestConvertSorted_EmptyNumberDataPointValueType(t *testing.T) {
+	// Same test for the sorted converter path.
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("test_gauge")
+	m.SetEmptyGauge()
+	dp := m.Gauge().DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	// Don't set any value — ValueType will be NumberDataPointValueTypeEmpty
+
+	buf := &pkg.MemChunkWriter{}
+	writer, err := otelstef.NewMetricsWriter(buf, pkg.WriterOptions{})
+	require.NoError(t, err)
+
+	converter := OtlpToStefSorted{}
+	err = converter.Convert(metrics, writer)
+	require.NoError(t, err, "Convert should not panic or error on empty value type")
+
+	err = writer.Flush()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Replace `panic()` calls with error returns in the OTLP-to-STEF metric conversion paths (both sorted and unsorted)
- Handle `NumberDataPointValueTypeEmpty` by mapping to `PointValueTypeNone` (matching the existing `ExemplarValueTypeEmpty` handling)
- Add unit tests for empty value type, int/double values, NoRecordedValue flag, and aggregation temporality

## Context

When processing real-world OTLP metrics, some data points may have `NumberDataPointValueTypeEmpty` (the zero value of the enum). The current code panics on this, which crashes the calling process with no way to recover through normal error handling.

This is the same pattern already used for `ExemplarValueTypeEmpty` at `baseotlptostef.go:73-74`, which correctly maps to `ExemplarValueTypeNone`.

## Changes

| File | Change |
|------|--------|
| `baseotlptostef.go` | `ConvertNumDatapoint` returns error, handles `Empty`; `AggregationTemporalityToStef` returns `(value, error)`; `ConvertExemplars` returns error |
| `baseotlptostef_test.go` | **New** — unit tests for empty value type, int, double, NoRecordedValue, aggregation temporality |
| `otlp2stef_unsorted.go` | `metricType`/`metric2metric` return error; `Convert` and `writeNumeric` propagate errors |
| `otlp2stef_unsorted_test.go` | **New** — integration tests: empty value type, mixed value types, sorted path |
| `sortedbymetric/converter.go` | `calcMetricFlags`/`calcNumericMetricType` return error; all conversion functions propagate errors |

## Testing

All existing tests pass. New tests verify:
- Empty value type doesn't panic (the production crash case)
- Int and double values still convert correctly
- NoRecordedValue flag still maps to `PointValueTypeNone`
- Unknown aggregation temporality returns error
- Mixed value types (int + empty + double) all convert
- Both sorted and unsorted paths handle empty value type

Fixes #370